### PR TITLE
Fix JSON validation in upload handler

### DIFF
--- a/upload_data.php
+++ b/upload_data.php
@@ -76,9 +76,12 @@ function checkRateLimit()
 // Validate JSON content
 function validateJsonContent($content)
 {
-    // Check for basic JSON structure
+    // Attempt to decode the content to ensure it's valid JSON
+    json_decode($content);
+
+    // Check if JSON decoding resulted in an error
     if (json_last_error() !== JSON_ERROR_NONE) {
-        error_log("Uploaded content not in correct format");
+        error_log("Uploaded content not in correct JSON format: " . json_last_error_msg());
         return false;
     }
 


### PR DESCRIPTION
## Summary
- Ensure `validateJsonContent` decodes uploaded content before checking for errors
- Log detailed message when uploaded data is not valid JSON

## Testing
- `php -l upload_data.php`


------
https://chatgpt.com/codex/tasks/task_e_68acc0f775b08325be810edde3b4cd36