### PR TITLE
Fix spacing in feedback heading

### DIFF
--- a/contact-us/index.php
+++ b/contact-us/index.php
@@ -91,7 +91,7 @@ if (isset($_SESSION['contact_error'])) {
 
           <!-- Feedback containers -->
           <div class="support-container">
-            <h2 class="sub-title"> Leave feedback</h2>
+            <h2 class="sub-title">Leave feedback</h2>
             <p class="description">Provide feedback at <a
                 href="mailto:feedback@argorobots.com">feedback@argorobots.com</a>.
               We're always striving to better serve our customers. You can influence our business and help us improve.


### PR DESCRIPTION
## Summary
- remove leading space in feedback heading on contact page

## Testing
- `php -l contact-us/index.php`
- `curl -s http://127.0.0.1:8000/contact-us/index.php | grep -n "sub-title"`

------
https://chatgpt.com/codex/tasks/task_e_68acc4cf09148325ac20a2451bbc4dc0