### PR TITLE
Rename helper to get_current_user and update references

### DIFF
--- a/community/add_comment.php
+++ b/community/add_comment.php
@@ -21,7 +21,7 @@ if (!is_user_logged_in()) {
 }
 
 $user_id = $_SESSION['user_id'] ?? 0;
-$current_user = get_current_user_ID();
+$current_user = \CommunityUsers\get_current_user();
 
 // Only accept POST requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/community/create_post.php
+++ b/community/create_post.php
@@ -7,7 +7,7 @@ include_once 'rate_limit.php';
 require_once 'formatting/formatting_functions.php';
 
 require_login('', true);
-$current_user = get_current_user_ID();
+$current_user = \CommunityUsers\get_current_user();
 
 $html_message = '';
 $error_message = '';

--- a/community/index.php
+++ b/community/index.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
 
 $posts = get_all_posts();
 $is_logged_in = is_user_logged_in();
-$current_user = $is_logged_in ? get_current_user_ID() : null;
+$current_user = $is_logged_in ? \CommunityUsers\get_current_user() : null;
 
 ?>
 <!DOCTYPE html>

--- a/community/users/user_functions.php
+++ b/community/users/user_functions.php
@@ -1,4 +1,5 @@
 <?php
+namespace {
 require_once __DIR__ . '/../../email_sender.php';
 
 /**
@@ -570,12 +571,14 @@ function require_login($redirect_url = '', $force_redirect = false)
     }
 }
 
+}
+namespace CommunityUsers {
 /**
- * Get current logged in user data
- * 
+ * Get the current logged-in user's data
+ *
  * @return array|null User data or null if not logged in
  */
-function get_current_user_ID()
+function get_current_user()
 {
     if (!isset($_SESSION['user_id'])) {
         return null;
@@ -607,13 +610,16 @@ function get_current_user_ID()
 
     return $user;
 }
+}
 
+namespace {
 /**
  * Generate a 6-digit verification code
- * 
+ *
  * @return string 6-digit code
  */
 function generate_verification_code()
 {
     return sprintf('%06d', mt_rand(100000, 999999));
+}
 }


### PR DESCRIPTION
## Summary
- Replace `get_current_user_ID` helper with namespaced `get_current_user` for fetching session user data.
- Update community pages to call the new helper.

## Testing
- `php -l community/users/user_functions.php`
- `php -l community/add_comment.php`
- `php -l community/index.php`
- `php -l community/create_post.php`
- `php <<'PHP' ... \CommunityUsers\get_current_user(); ... PHP`

------
https://chatgpt.com/codex/tasks/task_e_68acc53f01588325bc5cfc4de9e7493a