### PR TITLE
Persist rate limit counters

### DIFF
--- a/community/rate_limit.php
+++ b/community/rate_limit.php
@@ -3,20 +3,20 @@
 $RATE_LIMITS = [
     'post' => [
         'short' => ['count' => 1, 'minutes' => 5],    // 1 post per 5 minutes
-        'long' => ['count' => 5, 'hours' => 1]        // 5 posts per hour
+        'long'  => ['count' => 5, 'hours' => 1]       // 5 posts per hour
     ],
     'comment' => [
         'short' => ['count' => 3, 'minutes' => 5],    // 3 comments per 5 minutes
-        'long' => ['count' => 20, 'hours' => 1]       // 20 comments per hour
+        'long'  => ['count' => 20, 'hours' => 1]      // 20 comments per hour
     ]
 ];
 
 /**
  * Check if a user has exceeded rate limits
- * 
- * @param int $user_id User ID
+ *
+ * @param int    $user_id     User ID
  * @param string $action_type Action type ('post' or 'comment')
- * @return bool|string False if within limits, HTML string if limit exceeded
+ * @return bool|string        False if within limits, HTML string if limit exceeded
  */
 function check_rate_limit($user_id, $action_type)
 {
@@ -24,7 +24,7 @@ function check_rate_limit($user_id, $action_type)
 
     // Skip checks for admin users
     $is_logged_in = isset($_SESSION['user_id']);
-    $role = $is_logged_in ? ($_SESSION['role'] ?? 'user') : '';
+    $role         = $is_logged_in ? ($_SESSION['role'] ?? 'user') : '';
     if ($role === 'admin') {
         return false;
     }
@@ -36,38 +36,49 @@ function check_rate_limit($user_id, $action_type)
         return false;
     }
 
-    // Delete existing rate limit records for a fresh start
-    $stmt = $db->prepare('DELETE FROM rate_limits WHERE user_id = ? AND action_type = ?');
+    $now         = time();
+    $short_limit = $RATE_LIMITS[$action_type]['short'];
+    $long_limit  = $RATE_LIMITS[$action_type]['long'];
+
+    // Retrieve existing rate limit row
+    $stmt = $db->prepare('SELECT count, period_start, last_action_at FROM rate_limits WHERE user_id = ? AND action_type = ?');
     $stmt->bind_param('is', $user_id, $action_type);
     $stmt->execute();
+    $result = $stmt->get_result();
+    $row    = $result->fetch_assoc();
     $stmt->close();
 
-    // Check short-term limit (minutes)
-    $table = $action_type === 'post' ? 'community_posts' : 'community_comments';
-    $time_limit = $RATE_LIMITS[$action_type]['short']['minutes'];
-    $count_limit = $RATE_LIMITS[$action_type]['short']['count'];
+    if ($row) {
+        // Reset count if the long-term window has passed
+        if (strtotime($row['period_start']) <= $now - ($long_limit['hours'] * 3600)) {
+            $stmt = $db->prepare('UPDATE rate_limits SET count = 0, period_start = CURRENT_TIMESTAMP WHERE user_id = ? AND action_type = ?');
+            $stmt->bind_param('is', $user_id, $action_type);
+            $stmt->execute();
+            $stmt->close();
 
-    $result = check_period_limit($db, $table, $user_id, $time_limit, 'minutes');
+            $row['count']        = 0;
+            $row['period_start'] = date('Y-m-d H:i:s', $now);
+        }
 
-    if ($result >= $count_limit) {
-        // Short-term limit exceeded
-        return build_rate_limit_message($action_type, 300); // 5 minutes in seconds
+        // Short-term limit check
+        if (strtotime($row['last_action_at']) > $now - ($short_limit['minutes'] * 60) &&
+            $row['count'] >= $short_limit['count']) {
+            return build_rate_limit_message($action_type, $short_limit['minutes'] * 60);
+        }
+
+        // Long-term limit check
+        if ($row['count'] >= $long_limit['count']) {
+            $remaining = ($long_limit['hours'] * 3600) - ($now - strtotime($row['period_start']));
+            return build_rate_limit_message($action_type, $remaining);
+        }
     }
 
-    // Check long-term limit (hours)
-    $time_limit = $RATE_LIMITS[$action_type]['long']['hours'];
-    $count_limit = $RATE_LIMITS[$action_type]['long']['count'];
-
-    $result = check_period_limit($db, $table, $user_id, $time_limit, 'hours');
-
-    if ($result >= $count_limit) {
-        // Long-term limit exceeded
-        return build_rate_limit_message($action_type, 3600); // 1 hour in seconds
-    }
-
-    // User is within limits, insert a fresh record
-    $stmt = $db->prepare('INSERT INTO rate_limits (user_id, action_type, count, period_start, last_action_at) 
-                         VALUES (?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)');
+    // Record this action
+    $stmt = $db->prepare(
+        'INSERT INTO rate_limits (user_id, action_type, count, period_start, last_action_at) ' .
+        'VALUES (?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) ' .
+        'ON DUPLICATE KEY UPDATE count = count + 1, last_action_at = CURRENT_TIMESTAMP'
+    );
     $stmt->bind_param('is', $user_id, $action_type);
     $stmt->execute();
     $stmt->close();
@@ -76,44 +87,10 @@ function check_rate_limit($user_id, $action_type)
 }
 
 /**
- * Check how many actions the user has performed in a time period
- * 
- * @param mysqli $db Database connection
- * @param string $table Table to check ('community_posts' or 'community_comments')
- * @param int $user_id User ID
- * @param int $time_value Time value (e.g., 5)
- * @param string $time_unit Time unit ('minutes' or 'hours')
- * @return int Count of actions in the specified period
- */
-function check_period_limit($db, $table, $user_id, $time_value, $time_unit)
-{
-    // Convert 'minutes' to 'MINUTE' and 'hours' to 'HOUR' for MySQL syntax
-    $mysql_time_unit = strtoupper(rtrim($time_unit, "s"));
-
-    $sql = "SELECT COUNT(*) as count FROM {$table} 
-            WHERE user_id = ? 
-            AND created_at > DATE_SUB(NOW(), INTERVAL {$time_value} {$mysql_time_unit})";
-
-    $stmt = $db->prepare($sql);
-    if (!$stmt) {
-        error_log("SQL Error in check_period_limit: " . $db->error);
-        return 0;
-    }
-
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
-    $stmt->close();
-
-    return $row['count'];
-}
-
-/**
  * Build an HTML rate limit message
  *
  * @param string $action_type Action type ('post' or 'comment')
- * @param int $wait_seconds Wait time in seconds
+ * @param int    $wait_seconds Wait time in seconds
  * @return string HTML message
  */
 function build_rate_limit_message($action_type, $wait_seconds)
@@ -123,8 +100,9 @@ function build_rate_limit_message($action_type, $wait_seconds)
     $time_str = sprintf('%dm %02ds', $minutes, $seconds);
     $reset_timestamp = time() + $wait_seconds;
 
-    return '<div class="rate-limit-message">' .
-        'You are ' . ($action_type === 'post' ? 'posting' : 'commenting') . ' too frequently. ' .
-        'Please wait <span class="countdown-timer" data-reset-timestamp="' . $reset_timestamp . '">' . $time_str . '</span> before ' .
-        ($action_type === 'post' ? 'posting' : 'commenting') . ' again.</div>';
+    return '<div class="rate-limit-message">'
+        . 'You are ' . ($action_type === 'post' ? 'posting' : 'commenting') . ' too frequently. '
+        . 'Please wait <span class="countdown-timer" data-reset-timestamp="' . $reset_timestamp . '">' . $time_str . '</span> before '
+        . ($action_type === 'post' ? 'posting' : 'commenting') . ' again.</div>';
 }
+?>


### PR DESCRIPTION
## Summary
- Remove unconditional rate limit resets
- Persist and increment rate limit counts using `INSERT ... ON DUPLICATE KEY UPDATE`
- Compare configured limits against stored counts before accepting actions

## Testing
- `php -l community/rate_limit.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acc54d56d483259eb15f16bbd24ab5