### PR TITLE
refactor: centralize common colors

### DIFF
--- a/admin/unified-admin.css
+++ b/admin/unified-admin.css
@@ -86,7 +86,7 @@ body.menu-open::after {
 }
 
 .menu-icon .nav-icon {
-  background: #333;
+  background: var(--dark-gray);
   display: block;
   height: 1px;
   position: relative;
@@ -96,7 +96,7 @@ body.menu-open::after {
 
 .menu-icon .nav-icon:before,
 .menu-icon .nav-icon:after {
-  background: #333;
+  background: var(--dark-gray);
   content: "";
   display: block;
   height: 100%;
@@ -195,7 +195,7 @@ body.menu-open::after {
 }
 
 .hamburger-nav-menu ul li a.logout-link {
-  color: #dc2626;
+  color: var(--redHover);
   font-weight: 500;
 }
 
@@ -226,7 +226,7 @@ body.menu-open::after {
 .header-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: #333;
+  color: var(--dark-gray);
 }
 
 /* Desktop Navigation */
@@ -250,7 +250,7 @@ body.menu-open::after {
 }
 
 .header-link:hover {
-  color: #333;
+  color: var(--dark-gray);
   background: #f0f0f0;
 }
 
@@ -325,7 +325,7 @@ body.menu-open::after {
 .page-title {
   font-size: 1.75rem;
   font-weight: 600;
-  color: #333;
+  color: var(--dark-gray);
   margin: 0 0 0.5rem 0;
 }
 
@@ -362,7 +362,7 @@ h3 {
 }
 
 .btn-green:hover {
-  background: #059669;
+  background: var(--success-green-dark);
 }
 
 .btn-deactivate {
@@ -513,7 +513,7 @@ tbody tr:hover {
 }
 
 .badge-pending {
-  background-color: #fef3c7;
+  background-color: var(--yellow-50);
   color: #92400e;
 }
 

--- a/community/create-post.css
+++ b/community/create-post.css
@@ -211,8 +211,8 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .preview-type-badge.bug {
-  background-color: #fef2f2;
-  color: #dc2626;
+  background-color: var(--red-50);
+  color: var(--redHover);
   border: 1px solid #fecaca;
 }
 

--- a/community/formatting/formatted-text.css
+++ b/community/formatting/formatted-text.css
@@ -66,7 +66,7 @@
 }
 
 .formatting-toolbar .help-btn:hover {
-  background-color: #2563eb;
+  background-color: var(--blue-600);
   transform: scale(1.1);
 }
 
@@ -114,7 +114,7 @@
 }
 
 .invalid-link-warning {
-  color: #dc2626;
+  color: var(--redHover);
   font-size: 0.9em;
   font-style: italic;
 }

--- a/community/index.css
+++ b/community/index.css
@@ -181,15 +181,15 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .vote-btn:hover {
-  color: #1e40af;
+  color: var(--primary-blue-dark);
 }
 
 .vote-btn.voted.upvote {
-  color: #2563eb;
+  color: var(--blue-600);
 }
 
 .vote-btn.voted.downvote {
-  color: #dc2626;
+  color: var(--redHover);
 }
 
 .vote-count {
@@ -264,12 +264,12 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .post-status.open {
-  background-color: #f0fdf4;
+  background-color: var(--green-50);
   color: #16a34a;
 }
 
 .post-status.in_progress {
-  background-color: #fef3c7;
+  background-color: var(--yellow-50);
   color: #d97706;
 }
 
@@ -279,8 +279,8 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .post-status.declined {
-  background-color: #fef2f2;
-  color: #dc2626;
+  background-color: var(--red-50);
+  color: var(--redHover);
 }
 
 .post-footer {
@@ -335,12 +335,12 @@ header .header-inner .menu-container .menu .community:after {
   padding: 5px 8px;
   border: 1px solid #d1d5db;
   border-radius: 4px;
-  background-color: white;
+  background-color: var(--white);
 }
 
 .delete-post-btn {
   background-color: #fee2e2;
-  color: #dc2626;
+  color: var(--redHover);
   border: none;
   padding: 5px 10px;
   border-radius: 4px;

--- a/community/post-history.css
+++ b/community/post-history.css
@@ -121,7 +121,7 @@ header .header-inner .menu-container .menu .community:after {
 /* Added content */
 .diff-add {
   background-color: #dcfce7;
-  color: #166534;
+  color: var(--green-800);
   border-radius: 2px;
   text-decoration: none !important;
 }
@@ -129,7 +129,7 @@ header .header-inner .menu-container .menu .community:after {
 /* Removed content */
 .diff-del {
   background-color: #fee2e2;
-  color: #991b1b;
+  color: var(--red-800);
   border-radius: 2px;
   text-decoration: line-through;
 }

--- a/community/users/profile.css
+++ b/community/users/profile.css
@@ -503,7 +503,7 @@
 
 .reputation-value.negative {
   background-color: #fee2e2;
-  color: #dc2626;
+  color: var(--redHover);
 }
 
 .reputation-details {

--- a/community/users/reputation-help.css
+++ b/community/users/reputation-help.css
@@ -77,7 +77,7 @@
 }
 
 .rep-negative {
-  color: #dc2626;
+  color: var(--redHover);
 }
 
 .rep-example {

--- a/community/view-post.css
+++ b/community/view-post.css
@@ -174,12 +174,12 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .post-status.open {
-  background-color: #f0fdf4;
+  background-color: var(--green-50);
   color: #16a34a;
 }
 
 .post-status.in_progress {
-  background-color: #fef3c7;
+  background-color: var(--yellow-50);
   color: #d97706;
 }
 
@@ -189,8 +189,8 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .post-status.declined {
-  background-color: #fef2f2;
-  color: #dc2626;
+  background-color: var(--red-50);
+  color: var(--redHover);
 }
 
 .post-body {
@@ -247,14 +247,14 @@ header .header-inner .menu-container .menu .community:after {
   padding: 5px 8px;
   border: 1px solid #d1d5db;
   border-radius: 4px;
-  background-color: white;
+  background-color: var(--white);
   font-size: 14px;
   min-height: 40px;
 }
 
 .delete-post-btn {
   background-color: #fee2e2;
-  color: #dc2626;
+  color: var(--redHover);
   border: none;
   padding: 5px 10px;
   border-radius: 4px;
@@ -327,12 +327,12 @@ header .header-inner .menu-container .menu .community:after {
 
 .delete-comment-btn {
   background-color: #fee2e2;
-  color: #dc2626;
+  color: var(--redHover);
 }
 
 /* Comment form */
 .comment-form {
-  background-color: white;
+  background-color: var(--white);
   border-radius: 6px;
 }
 
@@ -433,7 +433,7 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .comment-vote-btn.voted.downvote {
-  color: #dc2626;
+  color: var(--redHover);
 }
 
 /* Vote count display */
@@ -447,7 +447,7 @@ header .header-inner .menu-container .menu .community:after {
 .comment-main {
   flex: 1;
   padding: 8px;
-  background-color: white;
+  background-color: var(--white);
   border: 1px solid #e5e7eb;
   border-left: none;
   border-radius: 0 6px 6px 0;
@@ -752,7 +752,7 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .bug-info-item {
-  background-color: white;
+  background-color: var(--white);
   border: 1px solid #e5e7eb;
   border-radius: 6px;
   padding: 12px 15px;
@@ -772,7 +772,7 @@ header .header-inner .menu-container .menu .community:after {
 
 /* Bug detailed sections */
 .bug-info-section {
-  background-color: white;
+  background-color: var(--white);
   border: 1px solid #e5e7eb;
   border-radius: 6px;
   padding: 15px;

--- a/documentation/style.css
+++ b/documentation/style.css
@@ -357,7 +357,7 @@ body {
 }
 
 .warning-box {
-  background: #fef3c7;
+  background: var(--yellow-50);
   border-left: 4px solid #d97706;
   padding: 1rem;
   margin: 1rem 0;

--- a/email.css
+++ b/email.css
@@ -1,5 +1,7 @@
+@import url("resources/styles/custom-colors.css");
+
 body {
-    background-color: #f6f9fc;
+    background-color: var(--light-page-bg);
     font-family: 'Segoe UI', Arial, sans-serif;
     font-size: 14px;
     line-height: 1.6;
@@ -12,7 +14,7 @@ body {
 .container {
     max-width: 600px;
     margin: 0 auto;
-    background-color: #ffffff;
+    background-color: var(--white);
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -22,7 +24,7 @@ body {
 
 /* Header styles */
 .header {
-    background-color: #1e3a8a;
+    background-color: var(--blueText);
     padding: 20px;
     text-align: center;
 }
@@ -35,7 +37,7 @@ body {
 /* Content styles */
 .content {
     padding: 30px;
-    color: #333;
+    color: var(--dark-gray);
 }
 
 .content-centered {
@@ -43,15 +45,15 @@ body {
 }
 
 h1 {
-    color: #1e3a8a;
+    color: var(--blueText);
     font-size: 24px;
     margin-top: 0;
     text-align: center;
 }
 
 .license-key {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
+    background-color: var(--gray-50);
+    border: 1px solid var(--gray-200);
     border-radius: 4px;
     font-family: monospace;
     font-size: 18px;
@@ -74,7 +76,7 @@ h1 {
 }
 
 .steps h2 {
-    color: #1e3a8a;
+    color: var(--blueText);
     font-size: 18px;
     margin-bottom: 15px;
     text-align: center;
@@ -114,9 +116,9 @@ h1 {
 
 /* Button styles */
 .button {
-    background-color: #2563eb;
+    background-color: var(--blue-600);
     border-radius: 4px;
-    color: #ffffff;
+    color: var(--white);
     display: inline-block;
     font-weight: bold;
     margin-top: 15px;
@@ -136,9 +138,9 @@ h1 {
 
 /* Footer styles */
 .footer {
-    background-color: #f8fafc;
-    border-top: 1px solid #e2e8f0;
-    color: #64748b;
+    background-color: var(--gray-50);
+    border-top: 1px solid var(--gray-200);
+    color: var(--gray-500);
     font-size: 12px;
     padding: 20px;
     text-align: center;

--- a/resources/styles/custom-colors.css
+++ b/resources/styles/custom-colors.css
@@ -1,15 +1,26 @@
 :root {
+  --white: #ffffff;
   --whiteBackground: #f9fafb;
   --primary-blue: #3b82f6;
+  --primary-blue-light: #3370d5;
+  --blue-600: #2563eb;
   --blueHover: #1d4ed8;
   --primary-blue-dark: #1e40af;
   --secondary-blue: #60a5fa;
   --green: rgb(43, 190, 97);
   --success-green: #4ade80;
+  --success-green-dark: #059669;
   --blueText: #1e3a8a;
   --warning-yellow: #fbbf24;
+  --yellow-50: #fef3c7;
   --red: #ef4444;
   --redHover: #dc2626;
+  --red-50: #fef2f2;
+  --red-800: #991b1b;
+  --green-50: #f0fdf4;
+  --green-800: #166534;
+  --dark-gray: #333333;
+  --light-page-bg: #f6f9fc;
   --gray-50: #f8fafc;
   --gray-100: #f1f5f9;
   --gray-200: #e2e8f0;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   line-height: 1.6;
   color: var(--gray-800);
-  background-color: #ffffff;
+  background-color: var(--white);
   overflow-x: hidden;
 }
 
@@ -48,7 +48,7 @@ h4 {
 }
 
 .card {
-  background: white;
+  background: var(--white);
   padding: 40px 32px;
   border-radius: 20px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
@@ -148,10 +148,10 @@ h4 {
 .btn-primary {
   background: linear-gradient(
     135deg,
-    #3370d5 0%,
+    var(--primary-blue-light) 0%,
     var(--primary-blue-dark) 100%
   );
-  color: white;
+  color: var(--white);
   box-shadow: 0 4px 14px rgba(59, 130, 246, 0.4);
   width: 250px !important;
 }
@@ -162,7 +162,7 @@ h4 {
 }
 
 .btn-secondary {
-  background: white;
+  background: var(--white);
   color: var(--primary-blue);
   border: 2px solid var(--primary-blue);
   display: flex !important;
@@ -170,7 +170,7 @@ h4 {
 
 .btn-secondary:hover {
   background: var(--primary-blue);
-  color: white;
+  color: var(--white);
   transform: translateY(-2px);
 }
 
@@ -268,7 +268,7 @@ h4 {
 }
 
 .hero-content {
-  color: white;
+  color: var(--white);
 }
 
 .hero-badge {
@@ -389,7 +389,7 @@ h4 {
 
 .floating-metric {
   position: absolute;
-  background: white;
+  background: var(--white);
   border-radius: 16px;
   padding: 16px 20px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
@@ -465,8 +465,8 @@ h4 {
 
 .feature-badge {
   display: inline-block;
-  background: linear-gradient(135deg, var(--success-green), #059669);
-  color: white;
+  background: linear-gradient(135deg, var(--success-green), var(--success-green-dark));
+  color: var(--white);
   padding: 6px 16px;
   border-radius: 20px;
   font-size: 0.8rem;
@@ -514,7 +514,7 @@ h4 {
 }
 
 .insight-card {
-  background: white;
+  background: var(--white);
   padding: 16px 20px;
   border-radius: 12px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
@@ -542,7 +542,7 @@ h4 {
 
 /* Comparison Table */
 .comparison-table {
-  background: white;
+  background: var(--white);
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
@@ -556,7 +556,7 @@ h4 {
   display: grid;
   grid-template-columns: 2fr 1.5fr 1.5fr;
   background: var(--primary-blue);
-  color: white;
+  color: var(--white);
 }
 
 .header-item {
@@ -571,7 +571,7 @@ h4 {
 }
 
 .header-item.featured {
-  background: linear-gradient(135deg, var(--success-green), #059669);
+  background: linear-gradient(135deg, var(--success-green), var(--success-green-dark));
 }
 
 .comparison-row {
@@ -607,13 +607,13 @@ h4 {
 }
 
 .row-item.negative {
-  background: #fef2f2;
-  color: #991b1b;
+  background: var(--red-50);
+  color: var(--red-800);
 }
 
 .row-item.positive {
-  background: #f0fdf4;
-  color: #166534;
+  background: var(--green-50);
+  color: var(--green-800);
 }
 
 /* Security Features */
@@ -676,7 +676,7 @@ h4 {
   border-radius: 20px;
   font-size: 0.8rem;
   font-weight: 600;
-  color: white;
+  color: var(--white);
 }
 
 .plan-badge.popular {
@@ -743,7 +743,7 @@ h4 {
 }
 
 .feature-item.premium-feature {
-  background: #fef3c7;
+  background: var(--yellow-50);
   padding: 8px 12px;
   border-radius: 8px;
   border: 1px solid var(--warning-yellow);
@@ -778,7 +778,7 @@ h4 {
   display: inline-flex;
   align-items: center;
   gap: 16px;
-  background: white;
+  background: var(--white);
   padding: 20px 32px;
   border-radius: 16px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
@@ -805,7 +805,7 @@ h4 {
     var(--primary-blue-dark) 0%,
     var(--primary-blue) 100%
   );
-  color: white;
+  color: var(--white);
   text-align: center;
 }
 
@@ -939,7 +939,7 @@ h4 {
 
   .comparison-row {
     display: block;
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
     margin-bottom: 20px;

--- a/whats-new/style.css
+++ b/whats-new/style.css
@@ -136,7 +136,7 @@ header .header-inner .menu-container .menu .whats-new:after {
 
 .enhancement {
   background: #dcfce7;
-  color: #166534;
+  color: var(--green-800);
 }
 
 .feature {
@@ -146,7 +146,7 @@ header .header-inner .menu-container .menu .whats-new:after {
 
 .fix {
   background: #fee2e2;
-  color: #991b1b;
+  color: var(--red-800);
 }
 
 .documentation-link {


### PR DESCRIPTION
## Summary
- consolidate frequently used color values into `custom-colors.css`
- replace hardcoded hex colors in site, email, community, and admin styles with CSS variables

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit tests/RateLimitTest.php` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acd944cb108325b1e99de26f95b4e0