### PR TITLE
Add user profile editing

### DIFF
--- a/community/users/edit-profile.css
+++ b/community/users/edit-profile.css
@@ -1,0 +1,45 @@
+.edit-profile-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.edit-profile-form {
+  background: #fff;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.edit-profile-form label {
+  font-weight: 600;
+}
+
+.edit-profile-form input {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.error-message {
+  background: #fee2e2;
+  color: #b91c1c;
+  padding: 10px 15px;
+  border-radius: 4px;
+  margin-bottom: 15px;
+}

--- a/community/users/edit_profile.php
+++ b/community/users/edit_profile.php
@@ -1,0 +1,92 @@
+<?php
+session_start();
+require_once '../../db_connect.php';
+require_once '../community_functions.php';
+require_once 'user_functions.php';
+
+// Ensure user is logged in
+require_login('', true);
+
+$user_id = $_SESSION['user_id'];
+$user = get_user($user_id);
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    $confirm = trim($_POST['confirm_password'] ?? '');
+
+    if ($password !== $confirm) {
+        $errors[] = 'Passwords do not match';
+    } else {
+        $result = update_user_profile($user_id, $username, $email, $password);
+        if ($result['success']) {
+            $_SESSION['username'] = $username;
+            $_SESSION['email'] = $email;
+            header('Location: profile.php?username=' . urlencode($username));
+            exit;
+        } else {
+            $errors[] = $result['message'];
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Account - Argo Community</title>
+    <link rel="shortcut icon" type="image/x-icon" href="../../images/argo-logo/A-logo.ico">
+    <script src="../../resources/scripts/jquery-3.6.0.js"></script>
+    <script src="../../resources/scripts/main.js"></script>
+    <script src="../../resources/notifications/notifications.js" defer></script>
+    <link rel="stylesheet" href="edit-profile.css">
+    <link rel="stylesheet" href="../../resources/styles/button.css">
+    <link rel="stylesheet" href="../../resources/styles/custom-colors.css">
+    <link rel="stylesheet" href="../../resources/header/style.css">
+    <link rel="stylesheet" href="../../resources/header/dark.css">
+    <link rel="stylesheet" href="../../resources/footer/style.css">
+    <link rel="stylesheet" href="../../resources/notifications/notifications.css">
+</head>
+<body>
+<header>
+    <div id="includeHeader"></div>
+</header>
+
+<div class="edit-profile-container">
+    <h1>Edit Account</h1>
+    <?php if (!empty($errors)): ?>
+        <div class="error-message">
+            <?php foreach ($errors as $error): ?>
+                <p><?php echo htmlspecialchars($error); ?></p>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+    <form method="post" class="edit-profile-form">
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" value="<?php echo htmlspecialchars($user['username']); ?>" required>
+
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($user['email']); ?>" required>
+
+        <label for="password">New Password</label>
+        <input type="password" id="password" name="password">
+
+        <label for="confirm_password">Confirm Password</label>
+        <input type="password" id="confirm_password" name="confirm_password">
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-blue">Save Changes</button>
+            <a href="profile.php?username=<?php echo urlencode($user['username']); ?>" class="btn btn-gray">Cancel</a>
+        </div>
+    </form>
+</div>
+
+<footer class="footer">
+    <div id="includeFooter"></div>
+</footer>
+</body>
+</html>

--- a/community/users/profile.php
+++ b/community/users/profile.php
@@ -643,7 +643,8 @@ if ($is_own_profile && isset($user['email'])) {
                                         Notification Settings
                                     </a>
                                 <?php endif; ?>
-
+                                <a href="edit_profile.php" class="btn btn-blue">Edit Account</a>
+                                <a href="delete_account.php" class="btn btn-red">Delete Account</a>
                                 <a href="logout.php" class="btn btn-gray">Log Out</a>
                             <?php endif; ?>
                         </div>


### PR DESCRIPTION
## Summary
- allow users to update username, email, and password on a new Edit Account page
- propagate username and email changes to existing posts and comments
- add Edit Account button alongside Delete Account on profile page

## Testing
- `php -l community/users/edit_profile.php`
- `php -l community/users/user_functions.php`
- `php -l community/users/profile.php`

------
https://chatgpt.com/codex/tasks/task_e_68b4c98621bc8325a7b835ee027ede8b