### PR TITLE
Add meta description tags to reference pages

### DIFF
--- a/documentation/references/accepted_countries.php
+++ b/documentation/references/accepted_countries.php
@@ -9,6 +9,7 @@ require_once '../../community/formatting/formatting_functions.php';
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Complete list of accepted country names and variants for importing data into Argo Sales Tracker. Find all recognized country codes and alternative names.">
     <link rel="shortcut icon" type="image/x-icon" href="../../images/argo-logo/A-logo.ico">
     <title>Accepted Country Names - Argo Community</title>
 

--- a/documentation/references/keyboard_shortcuts.php
+++ b/documentation/references/keyboard_shortcuts.php
@@ -9,6 +9,7 @@ require_once '../../community/formatting/formatting_functions.php';
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Master the keyboard shortcuts for Argo Sales Tracker's Report Generator. Speed up your workflow with shortcuts for element movement, alignment, selection, and editing.">
     <link rel="shortcut icon" type="image/x-icon" href="../../images/argo-logo/A-logo.ico">
     <title>Accepted Country Names - Argo Community</title>
 

--- a/documentation/references/supported_currencies.php
+++ b/documentation/references/supported_currencies.php
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Argo Sales Tracker supports 28 international currencies with real-time exchange rates. View the complete list of supported currencies with their symbols and regions.">
     <link rel="shortcut icon" type="image/x-icon" href="../../images/argo-logo/A-logo.ico">
     <title>Supported Currencies - Argo Community</title>
 

--- a/documentation/references/supported_languages.php
+++ b/documentation/references/supported_languages.php
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Argo Sales Tracker supports 54 international languages. Browse the complete list of supported languages and their regions, and learn how to change your language settings.">
     <link rel="shortcut icon" type="image/x-icon" href="../../images/argo-logo/A-logo.ico">
     <title>Supported Languages - Argo Community</title>
 


### PR DESCRIPTION
Added SEO-optimized meta descriptions to the following documentation pages:
- Supported Languages (54 languages)
- Keyboard Shortcuts (Report Generator)
- Accepted Countries (country names and variants)
- Supported Currencies (28 currencies)

These meta descriptions improve search engine visibility and provide clear summaries of page content.