### PR TITLE
Add keyboard navigation to documentation search results

### DIFF
--- a/documentation/search.css
+++ b/documentation/search.css
@@ -73,6 +73,11 @@
     background: #f9fafb;
 }
 
+.search-result-item.selected {
+    background: #eff6ff;
+    border-left: 3px solid var(--primary-blue);
+}
+
 .search-result-item:last-child {
     border-bottom: none;
 }

--- a/index.php
+++ b/index.php
@@ -680,7 +680,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                     </div>
 
                     <div class="plan-cta">
-                        <a href="upgrade/index.php" class="btn btn-primary">Upgrade Now</a>
+                        <a href="upgrade/index.php" class="btn btn-get-now">Upgrade Now</a>
                         <p class="plan-note">30-day money back guarantee</p>
                     </div>
                 </div>

--- a/whats-new/index.php
+++ b/whats-new/index.php
@@ -135,8 +135,9 @@
                             </div>
                             <div class="feature-content">
                                 <h3>Enhanced AI Search<span class="type-tag enhancement">Enhancement</span></h3>
-                                <p>Improved AI search capabilities to better understand natural language queries to
-                                    provide better results.</p>
+                                <p>Improved AI search capabilities to better understand natural language queries.
+                                    It now understands what 'high' and 'low' means for numerical values by calculating
+                                    percentile-based thresholds. The AI does not have access to your financial information.</p>
                             </div>
                         </div>
 


### PR DESCRIPTION
- Support arrow up/down keys to navigate through results
- Support tab/shift+tab to move forward/backward through results
- Press Enter to activate selected result
- Add Escape key to close search results
- Visual highlight for selected result (blue background with left border)
- Auto-scroll selected item into view
- Wrap navigation at boundaries (top/bottom)