### PR TITLE
Remove /index.php from links

### DIFF
--- a/about-us/index.php
+++ b/about-us/index.php
@@ -266,7 +266,7 @@
                 <p>As a growing Calgary-based startup, we're excited about what's ahead. Our roadmap is filled with new
                     features and improvements based directly on user feedback. We're committed to expanding our offerings
                     while maintaining the simplicity and affordability that makes Argo special.</p>
-                <a href="../whats-new/index.php" class="btn btn-secondary">
+                <a href="../whats-new/" class="btn btn-secondary">
                     <span>View Changelog</span>
                     <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M5 12h14M12 5l7 7-7 7"/>

--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -39,7 +39,7 @@ $base_path = $in_subdir ? '../' : '';
             <div class="header-container">
                 <!-- Left: Home button and Logo -->
                 <div class="header-left">
-                    <a href="<?php echo $base_path; ?>../index.php" class="btn-small btn-home" title="Go to Main Site">
+                    <a href="<?php echo $base_path; ?>../" class="btn-small btn-home" title="Go to Main Site">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
                         </svg>
@@ -93,7 +93,7 @@ $base_path = $in_subdir ? '../' : '';
             <div id="menu" class="hamburger-nav-menu">
                 <ul>
                     <li>
-                        <a href="<?php echo $base_path; ?>../index.php" class="home-link">
+                        <a href="<?php echo $base_path; ?>../" class="home-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
                             </svg>

--- a/community/create_post.php
+++ b/community/create_post.php
@@ -296,7 +296,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         </div>
 
                         <div class="form-actions">
-                            <a href="index.php" class="btn btn-black">Cancel</a>
+                            <a href="./" class="btn btn-black">Cancel</a>
                             <button type="submit" class="btn btn-blue">Create Post</button>
                         </div>
                     </form>

--- a/community/guidelines.php
+++ b/community/guidelines.php
@@ -31,7 +31,7 @@
             <p>Help us keep the community friendly, professional, and productive.</p>
 
             <div class="back-button-container">
-                <a href="index.php" class="btn back-button">← Back to Community</a>
+                <a href="./" class="btn back-button">← Back to Community</a>
             </div>
         </div>
 
@@ -141,7 +141,7 @@
         </div>
 
         <div class="back-button-container">
-            <a href="index.php" class="btn back-button">← Back to Community</a>
+            <a href="./" class="btn back-button">← Back to Community</a>
         </div>
     </div>
 

--- a/community/users/profile.php
+++ b/community/users/profile.php
@@ -537,7 +537,7 @@ if ($is_own_profile) {
                 <h2>The user "<?php echo htmlspecialchars($requested_username); ?>" could not be found</h2>
                 <p>The username you are looking for does not exist or may have been removed.</p>
                 <div class="not-found-actions">
-                    <a href="../index.php" class="btn btn-blue">Return to Community</a>
+                    <a href="../" class="btn btn-blue">Return to Community</a>
                 </div>
             </div>
         </div>

--- a/community/users/resend_license.php
+++ b/community/users/resend_license.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['resend_license']) && 
     if ($email_sent) {
         $license_success = 'Your license key has been sent to your email address.';
     } else {
-        $license_error = 'Failed to send email. Please try again later or <a href="../../contact/index.php">contact support</a>.';
+        $license_error = 'Failed to send email. Please try again later or <a href="../../contact-us/">contact support</a>.';
     }
 }
 

--- a/community/view_post.php
+++ b/community/view_post.php
@@ -170,7 +170,7 @@ if (isset($_GET['created']) && $_GET['created'] == '1') {
     <div class="community-container">
         <div class="page-header">
             <div class="header-left">
-                <a href="index.php" class="btn back-button">
+                <a href="./" class="btn back-button">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                         <path stroke-width="2" d="M19 12H5M12 19l-7-7 7-7" />
                     </svg>

--- a/contact-us/index.php
+++ b/contact-us/index.php
@@ -142,7 +142,7 @@ if (isset($_SESSION['contact_success'])) {
           </div>
           <h3>Community Forum</h3>
           <p>Connect with other users, share tips, and get help from the community.</p>
-          <a href="../community/index.php" class="option-link">
+          <a href="../community/" class="option-link">
             Visit Community
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M5 12h14M12 5l7 7-7 7"/>
@@ -245,7 +245,7 @@ if (isset($_SESSION['contact_success'])) {
           </div>
           <h4>Check the Docs First</h4>
           <p>Many common questions are already answered in our documentation.</p>
-          <a href="../documentation/index.php" class="sidebar-link">View Documentation</a>
+          <a href="../documentation/" class="sidebar-link">View Documentation</a>
         </div>
 
         <div class="sidebar-card">

--- a/contact-us/message-sent-successfully/index.php
+++ b/contact-us/message-sent-successfully/index.php
@@ -50,8 +50,8 @@
         </div>
 
         <div class="action-buttons">
-          <a href="../../index.php" class="btn primary-btn">Return to Home</a>
-          <a href="../index.php" class="btn secondary-btn">Back to Contact</a>
+          <a href="/" class="btn primary-btn">Return to Home</a>
+          <a href="../" class="btn secondary-btn">Back to Contact</a>
         </div>
       </div>
     </div>

--- a/documentation/index.php
+++ b/documentation/index.php
@@ -182,7 +182,7 @@ $systemRequirements = getSystemRequirements();
 
                 <div class="contact-box">
                     <p><strong>Need Help?</strong> If you have questions or need assistance, please <a
-                            href="../contact-us/index.php" class="link">contact us</a>. Our support team is here to help
+                            href="../contact-us/" class="link">contact us</a>. Our support team is here to help
                         you succeed with Argo Books.</p>
                 </div>
             </section>
@@ -258,8 +258,8 @@ $systemRequirements = getSystemRequirements();
                     <p>Argo Books offers two versions to match your business needs. Start with our free version,
                         perfect for small businesses just getting started with inventory tracking. As your business
                         grows, seamlessly upgrade to our paid version for unlimited products and advanced features.</p>
-                    <p>Not sure which version is right for you? <a href="../index.php" class="link">Try our free
-                            version first</a> – you can always <a href="../upgrade/index.php" class="link">upgrade
+                    <p>Not sure which version is right for you? <a href="../" class="link">Try our free
+                            version first</a> – you can always <a href="../upgrade/" class="link">upgrade
                             later</a> when you need more features.</p>
                 </div>
 
@@ -395,7 +395,7 @@ $systemRequirements = getSystemRequirements();
 
                 <div class="warning-box">
                     <strong>Important:</strong> Free version users are limited to 10 products. Upgrade to the paid
-                    version <a class="link" href="../upgrade/index.php">here</a> for unlimited products.
+                    version <a class="link" href="../upgrade/">here</a> for unlimited products.
                 </div>
             </section>
 
@@ -716,7 +716,7 @@ $systemRequirements = getSystemRequirements();
 
                 <div class="warning-box">
                     <strong>Internet Connection Required:</strong> AI search requires an internet connection and is only
-                    available in the paid version. <a class="link" href="../upgrade/index.php">Upgrade here</a> to
+                    available in the paid version. <a class="link" href="../upgrade/">Upgrade here</a> to
                     access this feature.
                 </div>
             </section>

--- a/documentation/references/accepted_countries.php
+++ b/documentation/references/accepted_countries.php
@@ -33,7 +33,7 @@ require_once '../../community/formatting/formatting_functions.php';
     </header>
 
     <div class="reference-container">
-        <a href="../index.php#spreadsheets" class="link-no-underline back-link">← Back to Documentation</a>
+        <a href="../#spreadsheets" class="link-no-underline back-link">← Back to Documentation</a>
 
         <div class="reference-header">
             <h1>Accepted Country Names</h1>
@@ -1823,8 +1823,8 @@ require_once '../../community/formatting/formatting_functions.php';
         <div class="pattern-note">
             <strong>Note:</strong> Country names are case-insensitive, so "United States", "united states", and "UNITED
             STATES" are all accepted. If a country variant is not listed above, you can request it to be added by
-            <a class="link" href="../community/index.php">posting a feature request</a> or by <a class="link"
-                href="../contact-us/index.php">contacting support</a>.
+            <a class="link" href="../../community/">posting a feature request</a> or by <a class="link"
+                href="../../contact-us/">contacting support</a>.
         </div>
     </div>
 

--- a/documentation/references/keyboard_shortcuts.php
+++ b/documentation/references/keyboard_shortcuts.php
@@ -32,7 +32,7 @@ require_once '../../community/formatting/formatting_functions.php';
     </header>
 
     <div class="reference-container">
-        <a href="../index.php#keyboard-shortcuts" class="link-no-underline back-link">← Back to Documentation</a>
+        <a href="../#keyboard-shortcuts" class="link-no-underline back-link">← Back to Documentation</a>
 
         <div class="reference-header">
             <h1>Report Generator Keyboard Shortcuts</h1>

--- a/documentation/references/supported_currencies.php
+++ b/documentation/references/supported_currencies.php
@@ -71,7 +71,7 @@
     </header>
 
     <div class="reference-container">
-        <a href="../index.php#supported-currencies" class="link-no-underline back-link">← Back to Documentation</a>
+        <a href="../#supported-currencies" class="link-no-underline back-link">← Back to Documentation</a>
 
         <div class="reference-header">
             <h1>Supported Currencies</h1>

--- a/documentation/references/supported_languages.php
+++ b/documentation/references/supported_languages.php
@@ -28,7 +28,7 @@
     </header>
 
     <div class="reference-container">
-        <a href="../index.php#supported-languages" class="link-no-underline back-link">← Back to Documentation</a>
+        <a href="../#supported-languages" class="link-no-underline back-link">← Back to Documentation</a>
 
         <div class="reference-header">
             <h1>Supported Languages</h1>

--- a/email_sender.php
+++ b/email_sender.php
@@ -79,10 +79,10 @@ function send_license_email($to_email, $license_key)
         </div>
 
         <div class="button-container">
-            <a href="https://argorobots.com/documentation/index.php" class="button">View Documentation</a>
+            <a href="https://argorobots.com/documentation/" class="button">View Documentation</a>
         </div>
 
-        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/index.php">contact our support team</a>.</p>
+        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/">contact our support team</a>.</p>
         <p>Thank you for choosing Argo Books!</p>
         HTML;
 
@@ -115,10 +115,10 @@ function resend_license_email($to_email, $license_key)
         </div>
 
         <div class="button-container">
-            <a href="https://argorobots.com/documentation/index.php" class="button">View Documentation</a>
+            <a href="https://argorobots.com/documentation/" class="button">View Documentation</a>
         </div>
 
-        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/index.php">contact our support team</a>.</p>
+        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/">contact our support team</a>.</p>
         <p>Thank you for using Argo Books!</p>
         HTML;
 
@@ -164,7 +164,7 @@ function resend_subscription_id_email($to_email, $subscription_id, $billing_cycl
         </div>
 
         <p>Keep this ID safe. You may need it when contacting support about your subscription.</p>
-        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/index.php">contact our support team</a>.</p>
+        <p>If you have any questions or need assistance, please don't hesitate to <a href="https://argorobots.com/contact-us/">contact our support team</a>.</p>
         HTML;
 
     return send_styled_email($to_email, 'Your Requested Argo AI Subscription ID', $body, 'background: linear-gradient(135deg, #8b5cf6, #7c3aed);');
@@ -599,7 +599,7 @@ function send_ban_notification_email($email, $username, $ban_reason, $ban_durati
         $expiration_info = "<p>Your ban will expire on <strong>{$formatted_date}</strong>.</p>";
     }
 
-    $appeal_text = $can_appeal ? '<p>If you believe this ban was issued in error, you can <a href="https://argorobots.com/contact-us/index.php">contact our support team</a> to request a review. Please include your username and explain why you believe the ban should be reconsidered.</p>' : '';
+    $appeal_text = $can_appeal ? '<p>If you believe this ban was issued in error, you can <a href="https://argorobots.com/contact-us/">contact our support team</a> to request a review. Please include your username and explain why you believe the ban should be reconsidered.</p>' : '';
 
     $email_html = <<<HTML
         <!DOCTYPE html>
@@ -799,7 +799,7 @@ function send_username_reset_email($email, $old_username, $new_username, $violat
                         <li>All your posts and comments have been updated with the new username</li>
                     </ul>
 
-                    <p>If you believe this action was taken in error, please <a href="https://argorobots.com/contact-us/index.php">contact our support team</a> with your account details.</p>
+                    <p>If you believe this action was taken in error, please <a href="https://argorobots.com/contact-us/">contact our support team</a> with your account details.</p>
 
                     <p>Please review our <a href="https://argorobots.com/community/guidelines.php">community guidelines</a> to ensure future compliance.</p>
 
@@ -886,7 +886,7 @@ function send_bio_cleared_email($email, $username, $violation_type, $additional_
                         <li>Ensure your bio content is appropriate and respectful</li>
                     </ul>
 
-                    <p>If you believe this action was taken in error, please <a href="https://argorobots.com/contact-us/index.php">contact our support team</a> with your account details.</p>
+                    <p>If you believe this action was taken in error, please <a href="https://argorobots.com/contact-us/">contact our support team</a> with your account details.</p>
 
                     <p>Please review our <a href="https://argorobots.com/community/guidelines.php">community guidelines</a> to ensure future compliance.</p>
 

--- a/error-pages/400.html
+++ b/error-pages/400.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">400</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/error-pages/401.html
+++ b/error-pages/401.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">401</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/error-pages/403.html
+++ b/error-pages/403.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">403</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/error-pages/404.html
+++ b/error-pages/404.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">404</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/error-pages/500.html
+++ b/error-pages/500.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">500</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/error-pages/503.html
+++ b/error-pages/503.html
@@ -20,7 +20,7 @@
     <div class="text-container">
       <p class="main-title">503</p>
       <p class="sub-title">Looks like you're lost in space</p>
-      <a href="../../index.php" class="btn">Return To Earth</a>
+      <a href="/" class="btn">Return To Earth</a>
     </div>
   </div>
 

--- a/index.php
+++ b/index.php
@@ -1205,7 +1205,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                             <span><strong>Lifetime updates</strong></span>
                         </li>
                     </ul>
-                    <a href="upgrade/index.php" class="btn btn-primary btn-block">Upgrade Now</a>
+                    <a href="upgrade/" class="btn btn-primary btn-block">Upgrade Now</a>
                     <p class="pricing-note">30-day money-back guarantee</p>
                 </div>
 
@@ -1424,7 +1424,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                     </div>
                     <h3>Community</h3>
                     <p>Join our community to connect with other users and share tips.</p>
-                    <a href="community/index.php" class="contact-link">
+                    <a href="community/" class="contact-link">
                         Visit Community
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M5 12h14M12 5l7 7-7 7"/>
@@ -1441,7 +1441,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                     </div>
                     <h3>Documentation</h3>
                     <p>Browse guides, tutorials, and references to get the most out of Argo Books.</p>
-                    <a href="documentation/index.php" class="contact-link">
+                    <a href="documentation/" class="contact-link">
                         View Docs
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M5 12h14M12 5l7 7-7 7"/>
@@ -1451,7 +1451,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
             </div>
             <div class="contact-cta animate-on-scroll">
                 <p>Want to reach out directly?</p>
-                <a href="contact-us/index.php" class="btn btn-primary">
+                <a href="contact-us/" class="btn btn-primary">
                     <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"/>
                     </svg>
@@ -1476,7 +1476,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                                 <path d="M5 12h14M12 5l7 7-7 7"/>
                             </svg>
                         </a>
-                        <a href="upgrade/index.php" class="btn btn-outline-white btn-lg">
+                        <a href="upgrade/" class="btn btn-outline-white btn-lg">
                             <span>View Pricing</span>
                         </a>
                     </div>

--- a/legal/refund.php
+++ b/legal/refund.php
@@ -73,7 +73,7 @@
             <p>You can contact our support team:</p>
             <ul>
                 <li>By email: <a class="link" href="mailto:contact@argorobots.com">contact@argorobots.com</a></li>
-                <li>Through the <a class="link" href="../contact-us/index.php">Contact Us Page</a> on our website</li>
+                <li>Through the <a class="link" href="../contact-us/">Contact Us Page</a> on our website</li>
             </ul>
 
             <h2>Refund Processing</h2>
@@ -93,10 +93,10 @@
             <h2>Technical Issues</h2>
             <p>If you are experiencing technical issues with Argo Books, we encourage you to:</p>
             <ol>
-                <li>Review our <a class="link" href="../documentation/index.php">Documentation</a> for troubleshooting
+                <li>Review our <a class="link" href="../documentation/">Documentation</a> for troubleshooting
                     guides and frequently asked questions</li>
                 <li>Contact our technical support team through our <a class="link"
-                        href="../contact-us/index.php">Contact Us Page</a> or by email</li>
+                        href="../contact-us/">Contact Us Page</a> or by email</li>
             </ol>
             <p>Many issues can be resolved with proper guidance, and we are committed to helping you get the most out of
                 our software.</p>

--- a/resources/header/index.html
+++ b/resources/header/index.html
@@ -4,19 +4,19 @@
 
 <div class="header-inner">
   <!-- LOGO -->
-  <a href="/index.php">
+  <a href="/">
     <img class="logo" id="logo" alt="logo" src="/images/argo-logo/Argo-white.svg">
   </a>
 
   <div class="menu-container" id="menu-container">
     <!-- MENU -->
     <ul class="menu">
-      <li><a class="upgrade-now" href="/upgrade/index.php">Upgrade now</a></li>
-      <li><a class="whats-new" href="/whats-new/index.php">What's new</a></li>
-      <li><a class="about-us" href="/about-us/index.php">About us</a></li>
-      <li><a class="documentation" href="/documentation/index.php">Documentation</a></li>
-      <li><a class="community" href="/community/index.php">Community</a></li>
-      <li><a class="contact-us" href="/contact-us/index.php">Contact us</a></li>
+      <li><a class="upgrade-now" href="/upgrade/">Upgrade now</a></li>
+      <li><a class="whats-new" href="/whats-new/">What's new</a></li>
+      <li><a class="about-us" href="/about-us/">About us</a></li>
+      <li><a class="documentation" href="/documentation/">Documentation</a></li>
+      <li><a class="community" href="/community/">Community</a></li>
+      <li><a class="contact-us" href="/contact-us/">Contact us</a></li>
     </ul>
   </div>
 
@@ -36,12 +36,12 @@
 
 <div id="menu" class="hamburger-nav-menu">
   <ul>
-    <li><a href="/upgrade/index.php">Upgrade now</a></li>
-    <li><a href="/whats-new/index.php">What's new</a></li>
-    <li><a href="/about-us/index.php">About us</a></li>
-    <li><a href="/documentation/index.php">Documentation</a></li>
-    <li><a href="/community/index.php">Community</a></li>
-    <li><a href="/contact-us/index.php">Contact Us</a></li>
+    <li><a href="/upgrade/">Upgrade now</a></li>
+    <li><a href="/whats-new/">What's new</a></li>
+    <li><a href="/about-us/">About us</a></li>
+    <li><a href="/documentation/">Documentation</a></li>
+    <li><a href="/community/">Community</a></li>
+    <li><a href="/contact-us/">Contact Us</a></li>
     <li><a href="/community/users/login.php" id="mobile-account-link">My Account</a></li>
   </ul>
 </div>

--- a/upgrade/ai/thank-you/index.php
+++ b/upgrade/ai/thank-you/index.php
@@ -104,7 +104,7 @@
 
         <div class="cta-buttons">
             <a href="../../../downloads" class="btn btn-purple">Download Argo Books</a>
-            <a href="../../../documentation/index.php" class="btn btn-outline-purple">View Documentation</a>
+            <a href="/documentation/" class="btn btn-outline-purple">View Documentation</a>
         </div>
     </div>
 

--- a/upgrade/premium/checkout/main.js
+++ b/upgrade/premium/checkout/main.js
@@ -105,7 +105,7 @@ document.addEventListener("DOMContentLoaded", function () {
                   if (data.success) {
                     // Redirect to thank you page with license key and other details
                     window.location.href =
-                      "../thank-you/index.php?order_id=" +
+                      "../thank-you/?order_id=" +
                       encodeURIComponent(data.order_id || "") +
                       "&transaction_id=" +
                       encodeURIComponent(data.transaction_id || "") +
@@ -374,7 +374,7 @@ document.addEventListener("DOMContentLoaded", function () {
             method: "stripe",
           });
 
-          window.location.href = `../thank-you/index.php?${params.toString()}`;
+          window.location.href = `../thank-you/?${params.toString()}`;
         } catch (error) {
           console.error("Stripe payment error:", error);
 
@@ -572,7 +572,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
               if (data.success) {
                 // Redirect to thank you page
-                window.location.href = `../thank-you/index.php?order_id=${encodeURIComponent(
+                window.location.href = `../thank-you/?order_id=${encodeURIComponent(
                   data.order_id || ""
                 )}&transaction_id=${encodeURIComponent(
                   data.transaction_id || ""

--- a/upgrade/premium/index.php
+++ b/upgrade/premium/index.php
@@ -120,17 +120,17 @@ if (isset($_SESSION['user_id'])) {
                     <p>Choose how you'd like to pay</p>
 
                     <div class="payment-options">
-                        <button class="payment-option" onclick="window.location.href='checkout/index.php?method=paypal'">
+                        <button class="payment-option" onclick="window.location.href='checkout/?method=paypal'">
                             <img src="../../images/PayPal-logo.svg" alt="PayPal">
                             <span class="payment-desc">PayPal balance or linked card</span>
                         </button>
 
-                        <button class="payment-option" onclick="window.location.href='checkout/index.php?method=stripe'">
+                        <button class="payment-option" onclick="window.location.href='checkout/?method=stripe'">
                             <img src="../../images/Stripe-logo.svg" alt="Stripe">
                             <span class="payment-desc">Visa, Mastercard, Amex via Stripe</span>
                         </button>
 
-                        <button class="payment-option" onclick="window.location.href='checkout/index.php?method=square'">
+                        <button class="payment-option" onclick="window.location.href='checkout/?method=square'">
                             <img src="../../images/Square-logo.svg" alt="Square">
                             <span class="payment-desc">Visa, Mastercard, Amex via Square</span>
                         </button>

--- a/upgrade/premium/thank-you/index.php
+++ b/upgrade/premium/thank-you/index.php
@@ -142,7 +142,7 @@
 
         <div class="cta-buttons">
             <a href="../../../downloads" class="btn-primary">Download Argo Books</a>
-            <a href="../../../documentation/index.php" class="btn-secondary">View Documentation</a>
+            <a href="/documentation/" class="btn-secondary">View Documentation</a>
         </div>
     </div>
 

--- a/whats-new/index.php
+++ b/whats-new/index.php
@@ -80,7 +80,7 @@
                     </svg>
                     Download Latest
                 </a>
-                <a href="../older-versions/index.php" class="btn btn-secondary">
+                <a href="../older-versions/" class="btn btn-secondary">
                     Older Versions
                 </a>
             </div>
@@ -174,7 +174,7 @@
                                     making imports more flexible and reliable even if your spreadsheet columns are
                                     rearranged. It also no longer requires certain columns. We updated the documentation to
                                     include a list of required columns
-                                    <a class="link-no-underline" href="../documentation/index.php#spreadsheet-import">here</a>.
+                                    <a class="link-no-underline" href="../documentation/#spreadsheet-import">here</a>.
                                 </p>
                             </div>
                         </div>
@@ -624,7 +624,7 @@
                     <div class="documentation-link">
                         <p>
                             <strong>For more information about the updated spreadsheet import/export process,
-                                <a class="link-no-underline" href="../documentation/index.php#spreadsheet-import">visit our
+                                <a class="link-no-underline" href="../documentation/#spreadsheet-import">visit our
                                     documentation</a></strong>
                         </p>
                     </div>


### PR DESCRIPTION
Simplified internal links by removing explicit /index.php references, relying on server DirectoryIndex to serve index files automatically. This results in cleaner, more SEO-friendly URLs.