### PR TITLE
Fix null checkbox and active menu states

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -100,7 +100,7 @@ $base_path = $in_subdir ? '../' : '';
                             Home
                         </a>
                     </li>
-                    <li><a href="<?php echo $base_path; ?>index.php" class="<?php echo $current_dir === 'license' ? 'active' : ''; ?>">Dashboard</a></li>
+                    <li><a href="<?php echo $base_path; ?>index.php" class="<?php echo $current_dir === 'admin' ? 'active' : ''; ?>">Dashboard</a></li>
                     <li><a href="<?php echo $base_path; ?>license/" class="<?php echo $current_dir === 'license' ? 'active' : ''; ?>">License Keys</a></li>
                     <li><a href="<?php echo $base_path; ?>app-stats/" class="<?php echo $current_dir === 'app-stats' ? 'active' : ''; ?>">App Stats</a></li>
                     <li><a href="<?php echo $base_path; ?>website-stats/" class="<?php echo $current_dir === 'website-stats' ? 'active' : ''; ?>">Website Stats</a></li>

--- a/admin/license/main.js
+++ b/admin/license/main.js
@@ -145,26 +145,30 @@ document.addEventListener('DOMContentLoaded', function () {
             btn.disabled = count === 0;
         });
 
-        // Update select-all checkbox state
-        if (count === 0) {
-            selectAllCheckbox.checked = false;
-            selectAllCheckbox.indeterminate = false;
-        } else if (count === rowCheckboxes.length) {
-            selectAllCheckbox.checked = true;
-            selectAllCheckbox.indeterminate = false;
-        } else {
-            selectAllCheckbox.checked = false;
-            selectAllCheckbox.indeterminate = true;
+        // Update select-all checkbox state (only if it exists)
+        if (selectAllCheckbox) {
+            if (count === 0) {
+                selectAllCheckbox.checked = false;
+                selectAllCheckbox.indeterminate = false;
+            } else if (count === rowCheckboxes.length) {
+                selectAllCheckbox.checked = true;
+                selectAllCheckbox.indeterminate = false;
+            } else {
+                selectAllCheckbox.checked = false;
+                selectAllCheckbox.indeterminate = true;
+            }
         }
     }
 
-    // Select all functionality
-    selectAllCheckbox.addEventListener('change', function () {
-        rowCheckboxes.forEach(checkbox => {
-            checkbox.checked = this.checked;
+    // Select all functionality (only if checkbox exists)
+    if (selectAllCheckbox) {
+        selectAllCheckbox.addEventListener('change', function () {
+            rowCheckboxes.forEach(checkbox => {
+                checkbox.checked = this.checked;
+            });
+            updateSelectedCount();
         });
-        updateSelectedCount();
-    });
+    }
 
     // Individual checkbox changes
     rowCheckboxes.forEach(checkbox => {

--- a/admin/website-stats/index.php
+++ b/admin/website-stats/index.php
@@ -49,7 +49,7 @@ function get_stats_by_period($table, $period = 'month', $limit = 12, $where_clau
             COUNT(*) as count
         FROM $table
         $where
-        GROUP BY period
+        GROUP BY period, display_period
         ORDER BY period DESC
         LIMIT ?";
 
@@ -128,14 +128,14 @@ function get_page_views_by_period($period = 'month', $limit = 12)
     }
 
     $query = "
-        SELECT 
-            $sql_period as period, 
+        SELECT
+            $sql_period as period,
             $display_format as display_period,
-            COUNT(*) as count 
-        FROM statistics 
-        WHERE event_type = 'page_view' 
-        GROUP BY period 
-        ORDER BY period DESC 
+            COUNT(*) as count
+        FROM statistics
+        WHERE event_type = 'page_view'
+        GROUP BY period, display_period
+        ORDER BY period DESC
         LIMIT ?";
 
     $stmt = $db->prepare($query);


### PR DESCRIPTION
- Add null check for selectAllCheckbox in license/main.js to prevent error when no license keys exist
- Fix burger menu active state in admin_header.php - Dashboard link now correctly checks for 'admin' directory instead of 'license'
- Fix SQL GROUP BY clause in website-stats/index.php to include display_period column, resolving MySQL ONLY_FULL_GROUP_BY error