### PR TITLE
Update version tag format from lowercase to uppercase with period

### DIFF
--- a/downloads/index.php
+++ b/downloads/index.php
@@ -167,7 +167,7 @@ $systemRequirements = getSystemRequirements();
                     <p class="platform-desc">For Windows 10 and later</p>
                     <?php if ($latestVersion): ?>
                         <div class="version-details">
-                            <span class="version-tag">v<?php echo htmlspecialchars($latestVersion['version']); ?></span>
+                            <span class="version-tag">V.<?php echo htmlspecialchars($latestVersion['version']); ?></span>
                             <span class="file-size"><?php echo formatFileSize($latestVersion['filesize']); ?></span>
                         </div>
                     <?php endif; ?>
@@ -182,7 +182,7 @@ $systemRequirements = getSystemRequirements();
                         Download for Windows
                     </a>
                     <?php if ($latestVersion): ?>
-                        <span class="platform-badge available">v<?php echo htmlspecialchars($latestVersion['version']); ?></span>
+                        <span class="platform-badge available">V.<?php echo htmlspecialchars($latestVersion['version']); ?></span>
                     <?php endif; ?>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Updated the version tag display format in the downloads page from lowercase `v` to uppercase `V.` (with a period) for consistency and improved visual presentation.

## Changes
- Changed version tag format from `v{version}` to `V.{version}` in the Windows 10+ platform section (line 170)
- Changed version badge format from `v{version}` to `V.{version}` in the download button section (line 185)

## Details
This change affects two locations where the latest version number is displayed to users on the downloads page. The new format `V.` provides a more formal appearance while maintaining the same functionality. Both instances use `htmlspecialchars()` for proper escaping, ensuring no security implications from this formatting change.

https://claude.ai/code/session_01726aiw5qsBFUiyHJvrxMCW