### PR TITLE
Centralize pricing configuration and add processing fees

### DIFF
--- a/community/users/reactivate-subscription.php
+++ b/community/users/reactivate-subscription.php
@@ -5,6 +5,7 @@ require_once '../../email_sender.php';
 require_once '../community_functions.php';
 require_once 'user_functions.php';
 require_once '../../webhooks/paypal-helper.php';
+require_once '../../config/pricing.php';
 
 // Ensure user is logged in
 require_login();
@@ -155,11 +156,11 @@ $billing_cycle = $premium_subscription['billing_cycle'] ?? 'monthly';
                     <div class="billing-cycle-options">
                         <div class="billing-cycle-btn <?php echo $billing_cycle === 'monthly' ? 'current' : ''; ?>" data-billing="monthly">
                             <span class="billing-cycle-name">Monthly</span>
-                            <span class="billing-cycle-price">$5/month</span>
+                            <span class="billing-cycle-price">$<?php echo number_format(get_pricing_config()['premium_monthly_price'], 0); ?>/month</span>
                         </div>
                         <div class="billing-cycle-btn <?php echo $billing_cycle === 'yearly' ? 'current' : ''; ?>" data-billing="yearly">
                             <span class="billing-cycle-name">Yearly</span>
-                            <span class="billing-cycle-price">$50/year</span>
+                            <span class="billing-cycle-price">$<?php echo number_format(get_pricing_config()['premium_yearly_price'], 0); ?>/year</span>
                         </div>
                     </div>
                 </div>

--- a/community/users/retry-payment-ajax.php
+++ b/community/users/retry-payment-ajax.php
@@ -12,6 +12,7 @@ require_once '../../vendor/autoload.php';
 require_once '../community_functions.php';
 require_once 'user_functions.php';
 require_once '../../webhooks/paypal-helper.php';
+require_once '../../config/pricing.php';
 
 // Ensure user is logged in
 if (!isset($_SESSION['user_id'])) {
@@ -47,8 +48,11 @@ $payment_method = strtolower($premium_subscription['payment_method'] ?? '');
 $billing_cycle = $premium_subscription['billing_cycle'] ?? 'monthly';
 $subscription_id = $premium_subscription['subscription_id'];
 
-// Calculate amount based on billing cycle
-$amount = ($billing_cycle === 'yearly') ? 50.00 : 5.00;
+// Calculate amount based on billing cycle using centralized pricing
+$pricing = get_pricing_config();
+$base_amount = ($billing_cycle === 'yearly') ? $pricing['premium_yearly_price'] : $pricing['premium_monthly_price'];
+$fee = calculate_processing_fee($base_amount);
+$amount = $base_amount + $fee;
 
 // Get environment configuration
 $isProduction = ($_ENV['APP_ENV'] ?? 'development') === 'production';

--- a/community/users/subscription.php
+++ b/community/users/subscription.php
@@ -3,6 +3,12 @@ session_start();
 require_once '../../db_connect.php';
 require_once '../community_functions.php';
 require_once 'user_functions.php';
+require_once __DIR__ . '/../../config/pricing.php';
+$pricing = get_pricing_config();
+$monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$premiumDiscount = $pricing['premium_discount'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
 
 // Ensure user is logged in
 require_login();
@@ -146,11 +152,11 @@ if ($premium_subscription) {
                             if ($premium_subscription['discount_applied'] && $creditBalance > 0): ?>
                             <div class="detail-item">
                                 <span class="detail-label">Discount</span>
-                                <span class="detail-value discount">$20 Standard Discount Applied</span>
+                                <span class="detail-value discount">$<?php echo number_format($premiumDiscount, 0); ?> Standard Discount Applied</span>
                             </div>
                             <?php endif; ?>
                             <?php if ($creditBalance > 0):
-                                $monthsRemaining = floor($creditBalance / 5); // $5/month
+                                $monthsRemaining = floor($creditBalance / $monthlyPrice);
                             ?>
                             <div class="detail-item">
                                 <span class="detail-label">Credit Balance</span>
@@ -277,11 +283,11 @@ if ($premium_subscription) {
                     <h3>No Active Subscription</h3>
                     <p>Get access to invoices & payments and AI-powered features like receipt scanning, and predictive analysis.</p>
                     <div class="pricing-preview">
-                        <span class="price">$5</span>
+                        <span class="price">$<?php echo number_format($monthlyPrice, 0); ?></span>
                         <span class="period">CAD/month</span>
                         <span class="divider">or</span>
-                        <span class="price">$50</span>
-                        <span class="period">CAD/year (save $10)</span>
+                        <span class="price">$<?php echo number_format($yearlyPrice, 0); ?></span>
+                        <span class="period">CAD/year (save $<?php echo number_format($yearlySavings, 0); ?>)</span>
                     </div>
                     <a href="../../upgrade/premium/" class="btn btn-purple btn-subscribe">Subscribe to Premium</a>
                 </div>

--- a/config/pricing.php
+++ b/config/pricing.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Centralized Pricing Configuration
+ *
+ * All prices are in CAD. Override any price via environment variables.
+ * Default values match current production prices so the system works
+ * identically without any env vars set.
+ *
+ * Environment variables:
+ *   STANDARD_PRICE              - Standard one-time price (default: 20.00)
+ *   PREMIUM_MONTHLY_PRICE       - Premium monthly subscription (default: 5.00)
+ *   PREMIUM_YEARLY_PRICE        - Premium yearly subscription (default: 50.00)
+ *   PREMIUM_STANDARD_DISCOUNT   - Discount for Standard users upgrading to Premium (default: 20.00)
+ */
+
+/**
+ * Get the pricing configuration array.
+ * Uses static caching so env vars are only parsed once per request.
+ *
+ * @return array Pricing configuration with keys:
+ *   - standard_price (float)
+ *   - premium_monthly_price (float)
+ *   - premium_yearly_price (float)
+ *   - premium_discount (float)
+ *   - currency (string)
+ */
+function get_pricing_config() {
+    static $config = null;
+
+    if ($config !== null) {
+        return $config;
+    }
+
+    $config = [
+        'standard_price'        => _pricing_parse_env('STANDARD_PRICE', 20.00),
+        'premium_monthly_price' => _pricing_parse_env('PREMIUM_MONTHLY_PRICE', 5.00),
+        'premium_yearly_price'  => _pricing_parse_env('PREMIUM_YEARLY_PRICE', 50.00),
+        'premium_discount'      => _pricing_parse_env('PREMIUM_STANDARD_DISCOUNT', 20.00),
+        'currency'              => 'CAD',
+    ];
+
+    return $config;
+}
+
+/**
+ * Parse a price value from an environment variable.
+ * Returns the default if the env var is missing, empty, non-numeric, or negative.
+ *
+ * @param string $key     Environment variable name
+ * @param float  $default Default value if env var is invalid
+ * @return float Validated price value rounded to 2 decimal places
+ */
+function _pricing_parse_env($key, $default) {
+    if (!isset($_ENV[$key]) || $_ENV[$key] === '' || !is_numeric($_ENV[$key])) {
+        return $default;
+    }
+
+    $value = round(floatval($_ENV[$key]), 2);
+
+    if ($value < 0) {
+        return $default;
+    }
+
+    return $value;
+}
+
+/**
+ * Convert a dollar amount to cents safely (avoids floating-point precision issues).
+ *
+ * @param float $amount Dollar amount
+ * @return int Amount in cents
+ */
+function price_to_cents($amount) {
+    return (int) round($amount * 100);
+}

--- a/config/pricing.php
+++ b/config/pricing.php
@@ -11,6 +11,8 @@
  *   PREMIUM_MONTHLY_PRICE       - Premium monthly subscription (default: 5.00)
  *   PREMIUM_YEARLY_PRICE        - Premium yearly subscription (default: 50.00)
  *   PREMIUM_STANDARD_DISCOUNT   - Discount for Standard users upgrading to Premium (default: 20.00)
+ *   PROCESSING_FEE_PERCENT      - Payment processing fee percentage (default: 2.90)
+ *   PROCESSING_FEE_FIXED        - Payment processing fixed fee in CAD (default: 0.30)
  */
 
 /**
@@ -22,6 +24,8 @@
  *   - premium_monthly_price (float)
  *   - premium_yearly_price (float)
  *   - premium_discount (float)
+ *   - processing_fee_percent (float)
+ *   - processing_fee_fixed (float)
  *   - currency (string)
  */
 function get_pricing_config() {
@@ -36,6 +40,8 @@ function get_pricing_config() {
         'premium_monthly_price' => _pricing_parse_env('PREMIUM_MONTHLY_PRICE', 5.00),
         'premium_yearly_price'  => _pricing_parse_env('PREMIUM_YEARLY_PRICE', 50.00),
         'premium_discount'      => _pricing_parse_env('PREMIUM_STANDARD_DISCOUNT', 20.00),
+        'processing_fee_percent' => _pricing_parse_env('PROCESSING_FEE_PERCENT', 2.90),
+        'processing_fee_fixed'   => _pricing_parse_env('PROCESSING_FEE_FIXED', 0.30),
         'currency'              => 'CAD',
     ];
 
@@ -62,6 +68,21 @@ function _pricing_parse_env($key, $default) {
     }
 
     return $value;
+}
+
+/**
+ * Calculate the processing fee for a given subtotal.
+ * Returns 0 if subtotal is zero or negative (e.g. credit-covered payments).
+ *
+ * @param float $subtotal The pre-fee charge amount
+ * @return float Fee amount rounded to 2 decimal places
+ */
+function calculate_processing_fee($subtotal) {
+    if ($subtotal <= 0) {
+        return 0.00;
+    }
+    $config = get_pricing_config();
+    return round(($subtotal * $config['processing_fee_percent'] / 100) + $config['processing_fee_fixed'], 2);
 }
 
 /**

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -413,6 +413,7 @@ function processSquareRenewal($cardId, $amount, $subscriptionId, $email, $access
         ]);
         $cardResponse = curl_exec($ch);
         $cardHttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
 
         $cardResult = json_decode($cardResponse, true);
         if ($cardHttpCode < 200 || $cardHttpCode >= 300 || !isset($cardResult['card'])) {
@@ -451,6 +452,7 @@ function processSquareRenewal($cardId, $amount, $subscriptionId, $email, $access
 
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
 
         $result = json_decode($response, true);
 

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -154,6 +154,12 @@ foreach ($subscriptions as $subscription) {
         }
     }
 
+    // Add processing fee on the amount actually charged to the card
+    if ($amountToCharge > 0) {
+        $processingFee = calculate_processing_fee($amountToCharge);
+        $amountToCharge += $processingFee;
+    }
+
     // Skip payment processing if fully covered by credit
     if ($amountToCharge <= 0 && $useCredit) {
         try {

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -39,6 +39,7 @@ set_time_limit(300);
 require_once __DIR__ . '/../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->load();
+require_once __DIR__ . '/../config/pricing.php';
 
 // Only allow CLI or authenticated web requests
 $isCli = php_sapi_name() === 'cli';
@@ -127,9 +128,10 @@ foreach ($subscriptions as $subscription) {
 
     logMessage("Processing renewal for subscription: $subscriptionId (User: $userId, Method: $paymentMethod, Credit: $$creditBalance)");
 
-    // Calculate renewal amount
-    $baseMonthly = 5.00;
-    $baseYearly = 50.00;
+    // Calculate renewal amount from centralized config
+    $pricingConfig = get_pricing_config();
+    $baseMonthly = $pricingConfig['premium_monthly_price'];
+    $baseYearly = $pricingConfig['premium_yearly_price'];
     $amount = ($billing === 'yearly') ? $baseYearly : $baseMonthly;
 
     // Check if renewal can be covered by credit

--- a/documentation/pages/getting-started/version-comparison.php
+++ b/documentation/pages/getting-started/version-comparison.php
@@ -4,6 +4,12 @@ $pageDescription = 'Compare Argo Books free, standard, and premium versions. Lea
 $currentPage = 'version-comparison';
 $pageCategory = 'getting-started';
 
+require_once __DIR__ . '/../../../config/pricing.php';
+$pricing = get_pricing_config();
+$monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
+
 include '../../docs-header.php';
 ?>
 
@@ -126,8 +132,8 @@ include '../../docs-header.php';
                     <div class="card-header">
                         <h3 class="version-title">Premium</h3>
                         <p class="version-subtitle">Includes AI-powered features</p>
-                        <div class="version-price">$5 <span class="price-period">CAD/month</span></div>
-                        <p class="price-alt">or $50 CAD/year (save $10)</p>
+                        <div class="version-price">$<?php echo number_format($monthlyPrice, 0); ?> <span class="price-period">CAD/month</span></div>
+                        <p class="price-alt">or $<?php echo number_format($yearlyPrice, 0); ?> CAD/year (save $<?php echo number_format($yearlySavings, 0); ?>)</p>
                     </div>
                     <ul class="feature-list">
                         <li class="feature-item">

--- a/email_sender.php
+++ b/email_sender.php
@@ -1352,6 +1352,43 @@ function send_free_subscription_key_email($email, $subscriptionKey, $durationMon
  * @param string $subscriptionId Subscription ID
  * @return bool Success status
  */
+/**
+ * Send payment failed notification email
+ *
+ * @param string $email User's email address
+ * @param string $subscriptionId Subscription ID
+ * @param string $errorMessage Description of the failure
+ * @return bool Success status
+ */
+function send_payment_failed_email($email, $subscriptionId, $errorMessage = '')
+{
+    $body = <<<HTML
+        <h1>Payment Failed</h1>
+        <p>We were unable to process your subscription renewal payment.</p>
+
+        <div class="info-box info-box-warning">
+            <p><strong>Subscription ID:</strong> {$subscriptionId}</p>
+        </div>
+
+        <p><strong>What to do next:</strong></p>
+        <ul>
+            <li>Check that your payment method is up to date</li>
+            <li>Ensure there are sufficient funds available</li>
+            <li>Update your payment information in your account settings</li>
+        </ul>
+
+        <p>If the payment continues to fail, your subscription may be suspended. Please update your payment method to avoid interruption of service.</p>
+
+        <div class="button-container">
+            <a href="https://argorobots.com/community/users/subscription.php" class="button button-purple">Update Payment Method</a>
+        </div>
+
+        <p>If you need assistance, please <a href="https://argorobots.com/contact-us/">contact our support team</a>.</p>
+        HTML;
+
+    return send_styled_email($email, 'Payment Failed - Argo Premium Subscription', $body, 'purple');
+}
+
 function send_free_credit_email($email, $creditAmount, $note = '', $subscriptionId = '')
 {
     $css = file_get_contents(__DIR__ . '/email.css');

--- a/index.php
+++ b/index.php
@@ -3,6 +3,11 @@ session_start();
 require_once 'community/users/user_functions.php';
 require_once 'track_referral.php';
 require_once 'statistics.php';
+require_once __DIR__ . '/config/pricing.php';
+$pricing = get_pricing_config();
+$monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
 
 track_page_view($_SERVER['REQUEST_URI']);
 
@@ -1215,10 +1220,10 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                         <span class="pricing-tag ai">Premium</span>
                         <div class="pricing-amount">
                             <span class="currency">$</span>
-                            <span class="amount">5</span>
+                            <span class="amount"><?php echo number_format($monthlyPrice, 0); ?></span>
                             <span class="period">CAD/month</span>
                         </div>
-                        <p class="pricing-alt">or $50 CAD/year (save $10)</p>
+                        <p class="pricing-alt">or $<?php echo number_format($yearlyPrice, 0); ?> CAD/year (save $<?php echo number_format($yearlySavings, 0); ?>)</p>
                         <p class="pricing-description">Unlock AI-powered features</p>
                     </div>
                     <ul class="pricing-features">

--- a/legal/terms.php
+++ b/legal/terms.php
@@ -88,7 +88,11 @@
             <h2>Argo Premium Subscription</h2>
             <p>Argo Premium is an optional subscription service that provides invoices and AI-powered features. By subscribing, you agree to the following:</p>
             <ul>
-                <li><strong>Billing</strong>: Subscriptions are billed monthly ($5 CAD) or yearly ($50 CAD). Standard license holders receive a $20 discount.</li>
+<?php
+                    require_once __DIR__ . '/../config/pricing.php';
+                    $pricing = get_pricing_config();
+                ?>
+                <li><strong>Billing</strong>: Subscriptions are billed monthly ($<?php echo number_format($pricing['premium_monthly_price'], 0); ?> CAD) or yearly ($<?php echo number_format($pricing['premium_yearly_price'], 0); ?> CAD). Standard license holders receive a $<?php echo number_format($pricing['premium_discount'], 0); ?> discount.</li>
                 <li><strong>Auto-Renewal</strong>: Subscriptions automatically renew unless cancelled before the billing date.</li>
                 <li><strong>Cancellation</strong>: You may cancel at any time. Access continues until the end of your billing period.</li>
                 <li><strong>Payment Methods</strong>: We accept payments via Stripe, PayPal, and Square.</li>

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -214,7 +214,7 @@ $yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
                     </div>
                     <div class="faq-answer">
                         <div class="faq-answer-content">
-                            <p>If you've purchased Standard, you get $<?php echo number_format($discount, 0); ?> off your first year of Premium. Just enter your license key when subscribing, and the yearly price drops from $<?php echo number_format($yearlyPrice, 0); ?> to $<?php echo number_format($yearlyPrice - $discount, 0); ?>. You will still have access to your standard license key after you switch to the Premium subscription.</p>
+                            <p>If you've purchased Standard, you get $<?php echo number_format($discount, 0); ?> off your first year of Premium. Just enter your license key when subscribing, and your first year drops from $<?php echo number_format($yearlyPrice, 0); ?> to $<?php echo number_format($yearlyPrice - $discount, 0); ?>. After that, it renews at the regular $<?php echo number_format($yearlyPrice, 0); ?>/year price. You will still have access to your standard license key after you switch to the Premium subscription.</p>
                         </div>
                     </div>
                 </div>

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,3 +1,13 @@
+<?php
+require_once __DIR__ . '/../db_connect.php';
+require_once __DIR__ . '/../config/pricing.php';
+$pricing = get_pricing_config();
+$standardPrice = $pricing['standard_price'];
+$monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$discount = $pricing['premium_discount'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -9,14 +19,14 @@
 
     <!-- SEO Meta Tags -->
     <meta name="description"
-        content="Upgrade Argo Books. Get Standard for $20 CAD lifetime access or subscribe to Premium for $5/month. Unlimited products, Windows Hello, AI-powered insights, and more.">
+        content="Upgrade Argo Books. Get Standard for $<?php echo number_format($standardPrice, 0); ?> CAD lifetime access or subscribe to Premium for $<?php echo number_format($monthlyPrice, 0); ?>/month. Unlimited products, Windows Hello, AI-powered insights, and more.">
     <meta name="keywords"
         content="upgrade argo books, buy full version, lifetime access software, unlimited products, business software pricing, finance tracker, sales tracker standard, premium subscription">
 
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Upgrade - Argo Books">
     <meta property="og:description"
-        content="Upgrade Argo Books. Get Standard for $20 CAD lifetime access or subscribe to Premium for $5/month.">
+        content="Upgrade Argo Books. Get Standard for $<?php echo number_format($standardPrice, 0); ?> CAD lifetime access or subscribe to Premium for $<?php echo number_format($monthlyPrice, 0); ?>/month.">
     <meta property="og:url" content="https://argorobots.com/upgrade/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Argo Books">
@@ -26,7 +36,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Upgrade - Argo Books">
     <meta name="twitter:description"
-        content="Upgrade Argo Books. Get Standard for $20 CAD lifetime access or subscribe to Premium for $5/month.">
+        content="Upgrade Argo Books. Get Standard for $<?php echo number_format($standardPrice, 0); ?> CAD lifetime access or subscribe to Premium for $<?php echo number_format($monthlyPrice, 0); ?>/month.">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://argorobots.com/upgrade/">
@@ -77,7 +87,7 @@
                         <h2>Standard</h2>
                         <div class="card-price">
                             <span class="currency">$</span>
-                            <span class="amount">20</span>
+                            <span class="amount"><?php echo number_format($standardPrice, 0); ?></span>
                             <span class="period">CAD</span>
                         </div>
                         <p class="price-note">Lifetime access</p>
@@ -118,10 +128,10 @@
                         <h2>Premium</h2>
                         <div class="card-price">
                             <span class="currency">$</span>
-                            <span class="amount">5</span>
+                            <span class="amount"><?php echo number_format($monthlyPrice, 0); ?></span>
                             <span class="period">CAD/month</span>
                         </div>
-                        <p class="price-note">or $50 CAD/year (save $10)</p>
+                        <p class="price-note">or $<?php echo number_format($yearlyPrice, 0); ?> CAD/year (save $<?php echo number_format($yearlySavings, 0); ?>)</p>
 
                         <ul class="card-features">
                               <li>
@@ -143,7 +153,7 @@
                         </ul>
 
                         <div class="card-highlight ai-highlight">
-                            Standard users get a $20 discount!
+                            Standard users get a $<?php echo number_format($discount, 0); ?> discount!
                         </div>
 
                         <div class="card-cta">
@@ -188,14 +198,14 @@
                     </div>
                     <div class="faq-answer">
                         <div class="faq-answer-content">
-                            <p><strong>Standard ($20 one-time)</strong> unlocks unlimited products, Windows Hello security, lifetime updates, and priority support. <strong>Premium ($5/month)</strong> adds invoices & payments, AI-powered features like receipt scanning, and predictive analysis.</p>
+                            <p><strong>Standard ($<?php echo number_format($standardPrice, 0); ?> one-time)</strong> unlocks unlimited products, Windows Hello security, lifetime updates, and priority support. <strong>Premium ($<?php echo number_format($monthlyPrice, 0); ?>/month)</strong> adds invoices & payments, AI-powered features like receipt scanning, and predictive analysis.</p>
                         </div>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How does the $20 discount for Standard users work?</h3>
+                        <h3>How does the $<?php echo number_format($discount, 0); ?> discount for Standard users work?</h3>
                         <div class="faq-icon">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <polyline points="6,9 12,15 18,9"/>
@@ -204,7 +214,7 @@
                     </div>
                     <div class="faq-answer">
                         <div class="faq-answer-content">
-                            <p>If you've purchased Standard, you get $20 off your first year of Premium. Just enter your license key when subscribing, and the yearly price drops from $50 to $30. You will still have access to your standard license key after you switch to the Premium subscription.</p>
+                            <p>If you've purchased Standard, you get $<?php echo number_format($discount, 0); ?> off your first year of Premium. Just enter your license key when subscribing, and the yearly price drops from $<?php echo number_format($yearlyPrice, 0); ?> to $<?php echo number_format($yearlyPrice - $discount, 0); ?>. You will still have access to your standard license key after you switch to the Premium subscription.</p>
                         </div>
                     </div>
                 </div>

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -214,7 +214,7 @@ $yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
                     </div>
                     <div class="faq-answer">
                         <div class="faq-answer-content">
-                            <p>If you've purchased Standard, you get $<?php echo number_format($discount, 0); ?> off your first year of Premium. Just enter your license key when subscribing, and your first year drops from $<?php echo number_format($yearlyPrice, 0); ?> to $<?php echo number_format($yearlyPrice - $discount, 0); ?>. After that, it renews at the regular $<?php echo number_format($yearlyPrice, 0); ?>/year price. You will still have access to your standard license key after you switch to the Premium subscription.</p>
+                            <p>If you've purchased Standard, you get $<?php echo number_format($discount, 0); ?> off your first year of Premium. Your first year drops from $<?php echo number_format($yearlyPrice, 0); ?> to $<?php echo number_format($yearlyPrice - $discount, 0); ?>. After that, it renews at the regular $<?php echo number_format($yearlyPrice, 0); ?>/year price. You will still have access to your standard license key after you switch to the Premium subscription.</p>
                         </div>
                     </div>
                 </div>

--- a/upgrade/premium/checkout/index.php
+++ b/upgrade/premium/checkout/index.php
@@ -14,6 +14,9 @@
     session_start();
     require_once '../../../db_connect.php';
     require_once '../../../community/users/user_functions.php';
+    require_once '../../../config/pricing.php';
+
+    $pricing = get_pricing_config();
 
     // Require login to checkout
     require_login('upgrade/premium/');
@@ -115,10 +118,10 @@
         }
     }
 
-    // Calculate prices
-    $monthlyPrice = 5.00;
-    $yearlyPrice = 50.00;
-    $discount = 20.00;
+    // Calculate prices from centralized config
+    $monthlyPrice = $pricing['premium_monthly_price'];
+    $yearlyPrice = $pricing['premium_yearly_price'];
+    $discount = $pricing['premium_discount'];
 
     if ($billing === 'yearly') {
         $basePrice = $yearlyPrice;
@@ -223,15 +226,16 @@
                 </div>
                 <?php if ($hasDiscount && $billing === 'monthly'): ?>
                 <div class="credit-notice">
-                    <p><strong>$20 Credit Applied!</strong></p>
-                    <p>Your first 4 months are covered by this credit. You won't be charged today - your card will be saved for when the credit is depleted.</p>
+                    <p><strong>$<?php echo number_format($discount, 2); ?> Credit Applied!</strong></p>
+                    <p>Your first <?php echo floor($discount / $monthlyPrice); ?> months are covered by this credit. You won't be charged today - your card will be saved for when the credit is depleted.</p>
                 </div>
                 <?php endif; ?>
             </div>
 
             <div class="subscription-notice">
                 <?php if ($hasDiscount && $billing === 'monthly'): ?>
-                <p>This is a recurring subscription. Your $20 credit covers your first 4 months. You will be charged $<?php echo number_format($monthlyPrice, 2); ?> CAD/month starting month 5.</p>
+                <?php $creditMonths = floor($discount / $monthlyPrice); ?>
+                <p>This is a recurring subscription. Your $<?php echo number_format($discount, 2); ?> credit covers your first <?php echo $creditMonths; ?> months. You will be charged $<?php echo number_format($monthlyPrice, 2); ?> CAD/month starting month <?php echo $creditMonths + 1; ?>.</p>
                 <?php elseif ($hasDiscount && $billing === 'yearly'): ?>
                 <p>You will be charged $<?php echo number_format($finalPrice, 2); ?> CAD today (discounted), then $<?php echo number_format($yearlyPrice, 2); ?> CAD/year on each renewal.</p>
                 <?php else: ?>

--- a/upgrade/premium/checkout/main.js
+++ b/upgrade/premium/checkout/main.js
@@ -122,7 +122,7 @@ document.addEventListener("DOMContentLoaded", function () {
               subscriptionID: data.subscriptionID,
               orderID: data.orderID,
               paypal_subscription_id: data.subscriptionID,
-              amount: subscription.finalPrice.toFixed(2),
+              amount: subscription.totalCharge.toFixed(2),
               currency: "CAD",
               billing: subscription.billing,
               hasDiscount: subscription.hasDiscount,
@@ -162,7 +162,7 @@ document.addEventListener("DOMContentLoaded", function () {
               {
                 description: `Argo Premium Subscription (${subscription.billing})`,
                 amount: {
-                  value: subscription.finalPrice.toFixed(2),
+                  value: subscription.totalCharge.toFixed(2),
                   currency_code: "CAD",
                 },
               },
@@ -181,7 +181,7 @@ document.addEventListener("DOMContentLoaded", function () {
               body: JSON.stringify({
                 orderID: data.orderID,
                 payerID: data.payerID,
-                amount: subscription.finalPrice.toFixed(2),
+                amount: subscription.totalCharge.toFixed(2),
                 currency: "CAD",
                 billing: subscription.billing,
                 hasDiscount: subscription.hasDiscount,
@@ -295,7 +295,7 @@ document.addEventListener("DOMContentLoaded", function () {
             submitButton.disabled = false;
             submitButton.textContent = subscription.isMonthlyWithCredit
               ? "Subscribe - $0.00 Today (Credit Applied)"
-              : `Subscribe - $${subscription.finalPrice.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
+              : `Subscribe - $${subscription.totalCharge.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
             return;
           }
 
@@ -309,7 +309,7 @@ document.addEventListener("DOMContentLoaded", function () {
               payment_method_id: paymentMethod.id,
               email: email,
               name: cardHolder,
-              amount: subscription.finalPrice.toFixed(2),
+              amount: subscription.totalCharge.toFixed(2),
               currency: "CAD",
               billing: subscription.billing,
               hasDiscount: subscription.hasDiscount,
@@ -341,7 +341,7 @@ document.addEventListener("DOMContentLoaded", function () {
               submitButton.disabled = false;
               submitButton.textContent = subscription.isMonthlyWithCredit
                 ? "Subscribe - $0.00 Today (Credit Applied)"
-                : `Subscribe - $${subscription.finalPrice.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
+                : `Subscribe - $${subscription.totalCharge.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
             } else {
               window.location.href =
                 "../thank-you/?subscription_id=" +
@@ -357,7 +357,7 @@ document.addEventListener("DOMContentLoaded", function () {
             submitButton.disabled = false;
             submitButton.textContent = subscription.isMonthlyWithCredit
               ? "Subscribe - $0.00 Today (Credit Applied)"
-              : `Subscribe - $${subscription.finalPrice.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
+              : `Subscribe - $${subscription.totalCharge.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
           }
         } catch (err) {
           console.error("Error:", err);
@@ -368,7 +368,7 @@ document.addEventListener("DOMContentLoaded", function () {
           submitButton.disabled = false;
           submitButton.textContent = subscription.isMonthlyWithCredit
             ? "Subscribe - $0.00 Today (Credit Applied)"
-            : `Subscribe - $${subscription.finalPrice.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
+            : `Subscribe - $${subscription.totalCharge.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
         }
       });
     }
@@ -411,7 +411,7 @@ document.addEventListener("DOMContentLoaded", function () {
         // Create form HTML
         const buttonText = subscription.isMonthlyWithCredit
           ? "Subscribe - $0.00 Today (Credit Applied)"
-          : `Subscribe - $${subscription.finalPrice.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
+          : `Subscribe - $${subscription.totalCharge.toFixed(2)} CAD/${subscription.billing === "yearly" ? "year" : "month"}`;
 
         squareContainer.innerHTML = `
           <form id="square-payment-form">
@@ -466,7 +466,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 body: JSON.stringify({
                   source_id: result.token,
                   email: email,
-                  amount: subscription.finalPrice.toFixed(2),
+                  amount: subscription.totalCharge.toFixed(2),
                   currency: "CAD",
                   billing: subscription.billing,
                   hasDiscount: subscription.hasDiscount,

--- a/upgrade/premium/checkout/main.js
+++ b/upgrade/premium/checkout/main.js
@@ -388,7 +388,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Load Square SDK
     const squareScript = document.createElement("script");
-    squareScript.src = "https://sandbox.web.squarecdn.com/v1/square.js";
+    const isSandbox = window.PAYMENT_CONFIG?.square?.appId?.startsWith("sandbox-");
+    squareScript.src = isSandbox
+      ? "https://sandbox.web.squarecdn.com/v1/square.js"
+      : "https://web.squarecdn.com/v1/square.js";
     squareScript.onload = initializeSquare;
     squareScript.onerror = () => {
       squareContainer.innerHTML = `

--- a/upgrade/premium/checkout/process-subscription.php
+++ b/upgrade/premium/checkout/process-subscription.php
@@ -41,9 +41,21 @@ $userId = intval($input['user_id'] ?? 0);
 $pricingConfig = get_pricing_config();
 $discountAmount = $pricingConfig['premium_discount'];
 $monthlyPrice = $pricingConfig['premium_monthly_price'];
+$yearlyPrice = $pricingConfig['premium_yearly_price'];
 $isMonthlyWithCredit = ($billing === 'monthly' && $hasDiscount);
 $creditBalance = 0;
 $originalCredit = 0;
+
+// Compute server-side total (base price + processing fee) — never trust client amount
+if (!$isMonthlyWithCredit) {
+    if ($billing === 'yearly') {
+        $baseCharge = $hasDiscount ? ($yearlyPrice - $discountAmount) : $yearlyPrice;
+    } else {
+        $baseCharge = $monthlyPrice;
+    }
+    $processingFee = calculate_processing_fee($baseCharge);
+    $amount = $baseCharge + $processingFee;
+}
 
 // Get environment configuration
 $isProduction = ($_ENV['APP_ENV'] ?? 'development') === 'production';

--- a/upgrade/premium/checkout/process-subscription.php
+++ b/upgrade/premium/checkout/process-subscription.php
@@ -282,6 +282,7 @@ try {
                 }
                 $response = curl_exec($ch);
                 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+                curl_close($ch);
                 return ['response' => json_decode($response, true), 'http_code' => $httpCode];
             };
 

--- a/upgrade/premium/checkout/process-subscription.php
+++ b/upgrade/premium/checkout/process-subscription.php
@@ -9,6 +9,7 @@ header('Content-Type: application/json');
 require_once '../../../db_connect.php';
 require_once '../../../email_sender.php';
 require_once '../../../vendor/autoload.php';
+require_once __DIR__ . '/../../../config/pricing.php';
 
 // Only accept POST requests
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -36,9 +37,10 @@ $premiumLicenseKey = $input['premiumLicenseKey'] ?? '';
 $paymentMethod = $input['payment_method'] ?? 'unknown';
 $userId = intval($input['user_id'] ?? 0);
 
-// Credit configuration for monthly subscriptions with discount
-$discountAmount = 20.00;
-$monthlyPrice = 5.00;
+// Credit configuration for monthly subscriptions with discount (from centralized config)
+$pricingConfig = get_pricing_config();
+$discountAmount = $pricingConfig['premium_discount'];
+$monthlyPrice = $pricingConfig['premium_monthly_price'];
 $isMonthlyWithCredit = ($billing === 'monthly' && $hasDiscount);
 $creditBalance = 0;
 $originalCredit = 0;
@@ -366,8 +368,8 @@ try {
         // Update existing subscription with new payment method and billing cycle
         $subscriptionId = $existingSubscription['subscription_id'];
 
-        // Calculate new amount based on billing cycle
-        $newAmount = ($billing === 'yearly') ? 50.00 : 5.00;
+        // Calculate new amount based on billing cycle (from centralized config)
+        $newAmount = ($billing === 'yearly') ? $pricingConfig['premium_yearly_price'] : $pricingConfig['premium_monthly_price'];
 
         // Determine the new end date:
         // - If subscription still valid (end_date > now) AND not charged: keep existing end_date

--- a/upgrade/premium/index.php
+++ b/upgrade/premium/index.php
@@ -1,6 +1,13 @@
 <?php
 session_start();
 require_once '../../community/users/user_functions.php';
+require_once __DIR__ . '/../../config/pricing.php';
+$pricing = get_pricing_config();
+$monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$premiumDiscount = $pricing['premium_discount'];
+$standardPrice = $pricing['standard_price'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
 
 // Require login to access Premium subscription page
 require_login('upgrade/premium/');
@@ -30,14 +37,14 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
 
     <!-- SEO Meta Tags -->
     <meta name="description"
-        content="Subscribe to Argo Books Premium. Get invoices & payments, AI-powered receipt scanning, and predictive sales analysis. $5/month or $50/year. Standard users save $20!">
+        content="Subscribe to Argo Books Premium. Get invoices & payments, AI-powered receipt scanning, and predictive sales analysis. $<?php echo number_format($monthlyPrice, 0); ?>/month or $<?php echo number_format($yearlyPrice, 0); ?>/year. Standard users save $<?php echo number_format($premiumDiscount, 0); ?>!">
     <meta name="keywords"
         content="argo premium features, invoices payments, ai receipt scanning, predictive sales analysis, finance tracker, sales tracker subscription">
 
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Premium Subscription - Argo Books">
     <meta property="og:description"
-        content="Subscribe to Argo Books Premium. Get invoices & payments, AI-powered receipt scanning, and predictive sales analysis. $5/month or $50/year.">
+        content="Subscribe to Argo Books Premium. Get invoices & payments, AI-powered receipt scanning, and predictive sales analysis. $<?php echo number_format($monthlyPrice, 0); ?>/month or $<?php echo number_format($yearlyPrice, 0); ?>/year.">
     <meta property="og:url" content="https://argorobots.com/upgrade/premium/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Argo Books">
@@ -132,8 +139,8 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
             <p class="pricing-subtitle">Select billing frequency and enter your license key if you're a Standard user</p>
 
             <div class="license-discount">
-                <h3>Standard User? Get $20 Off!</h3>
-                <p>If you've purchased the $20 Standard version, enter your license key to receive a $20 discount.</p>
+                <h3>Standard User? Get $<?php echo number_format($premiumDiscount, 0); ?> Off!</h3>
+                <p>If you've purchased the $<?php echo number_format($standardPrice, 0); ?> Standard version, enter your license key to receive a $<?php echo number_format($premiumDiscount, 0); ?> discount.</p>
                 <div class="license-input-group">
                     <input type="text" id="license-key" placeholder="Enter your license key">
                     <button type="button" id="verify-license" class="btn-verify">Verify License</button>
@@ -143,21 +150,21 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
 
             <div class="billing-toggle">
                 <button type="button" class="billing-option active" data-billing="monthly">Monthly</button>
-                <button type="button" class="billing-option" data-billing="yearly">Yearly (Save $10)</button>
+                <button type="button" class="billing-option" data-billing="yearly">Yearly (Save $<?php echo number_format($yearlySavings, 0); ?>)</button>
             </div>
 
             <div class="pricing-display">
                 <div class="price-box" id="price-display">
                     <div class="original-price" id="original-price" style="display: none;">
-                        <span class="strikethrough">$50</span>
+                        <span class="strikethrough">$<?php echo number_format($yearlyPrice, 0); ?></span>
                     </div>
                     <div class="current-price">
                         <span class="currency">$</span>
-                        <span class="amount" id="price-amount">5</span>
+                        <span class="amount" id="price-amount"><?php echo number_format($monthlyPrice, 0); ?></span>
                         <span class="period" id="price-period">CAD/month</span>
                     </div>
                     <div class="discount-badge" id="discount-badge" style="display: none;">
-                        $20 Premium Discount Applied!
+                        $<?php echo number_format($premiumDiscount, 0); ?> Premium Discount Applied!
                     </div>
                 </div>
             </div>
@@ -198,7 +205,7 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
             <div class="faq-grid">
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How does the $20 discount work?</h3>
+                        <h3>How does the $<?php echo number_format($premiumDiscount, 0); ?> discount work?</h3>
                         <div class="faq-icon">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <polyline points="6,9 12,15 18,9"/>
@@ -207,7 +214,7 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
                     </div>
                     <div class="faq-answer">
                         <div class="faq-answer-content">
-                            <p>If you've purchased the $20 Standard version, the $20 discount will be applied to your first yearly subscription ($50 - $20 = $30 for the first year) or as credit toward monthly payments.</p>
+                            <p>If you've purchased the $<?php echo number_format($standardPrice, 0); ?> Standard version, the $<?php echo number_format($premiumDiscount, 0); ?> discount will be applied to your first yearly subscription ($<?php echo number_format($yearlyPrice, 0); ?> - $<?php echo number_format($premiumDiscount, 0); ?> = $<?php echo number_format($yearlyPrice - $premiumDiscount, 0); ?> for the first year) or as credit toward monthly payments.</p>
                         </div>
                     </div>
                 </div>
@@ -275,9 +282,9 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
             let hasDiscount = false;
             let verifiedLicenseKey = null;
 
-            const monthlyPrice = 5;
-            const yearlyPrice = 50;
-            const discount = 20;
+            const monthlyPrice = <?php echo $monthlyPrice; ?>;
+            const yearlyPrice = <?php echo $yearlyPrice; ?>;
+            const discount = <?php echo $premiumDiscount; ?>;
 
             // Billing toggle
             document.querySelectorAll('.billing-option').forEach(btn => {
@@ -347,7 +354,7 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
                     if (data.valid) {
                         hasDiscount = true;
                         verifiedLicenseKey = licenseKey;
-                        statusEl.innerHTML = '<span class="success">Standard license verified! $20 discount applied.</span>';
+                        statusEl.innerHTML = '<span class="success">Standard license verified! $' + discount + ' discount applied.</span>';
                         updatePriceDisplay();
                         // Reset attempts on success
                         verifyAttempts = 0;
@@ -377,7 +384,7 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
 
                     if (hasDiscount) {
                         discountBadge.style.display = 'block';
-                        discountBadge.textContent = '$20 credit will be applied to your account!';
+                        discountBadge.textContent = '$' + discount + ' credit will be applied to your account!';
                     } else {
                         discountBadge.style.display = 'none';
                     }
@@ -387,7 +394,7 @@ if ($existing_subscription && in_array($existing_subscription['status'], ['activ
                         originalPrice.style.display = 'block';
                         originalPrice.querySelector('.strikethrough').textContent = '$' + yearlyPrice;
                         discountBadge.style.display = 'block';
-                        discountBadge.textContent = '$20 Standard Discount Applied!';
+                        discountBadge.textContent = '$' + discount + ' Standard Discount Applied!';
                     } else {
                         priceAmount.textContent = yearlyPrice;
                         originalPrice.style.display = 'none';

--- a/upgrade/standard/checkout/index.php
+++ b/upgrade/standard/checkout/index.php
@@ -17,6 +17,9 @@
     require_once '../../../config/pricing.php';
 
     $pricing = get_pricing_config();
+    $standardPrice = $pricing['standard_price'];
+    $fee = calculate_processing_fee($standardPrice);
+    $totalPrice = $standardPrice + $fee;
 
     // Get environment-based keys
     $is_production = $_ENV['APP_ENV'] === 'production';
@@ -56,10 +59,10 @@
         };
 
         window.PRICING = {
-            standardPrice: <?php echo $pricing['standard_price']; ?>,
-            standardPriceCents: <?php echo price_to_cents($pricing['standard_price']); ?>,
+            standardPrice: <?php echo $totalPrice; ?>,
+            standardPriceCents: <?php echo price_to_cents($totalPrice); ?>,
             currency: '<?php echo $pricing['currency']; ?>',
-            formatted: '$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?>'
+            formatted: '$<?php echo number_format($totalPrice, 2); ?> <?php echo $pricing['currency']; ?>'
         };
     </script>
 
@@ -92,11 +95,15 @@
                 <h3>Order Summary</h3>
                 <div class="order-item">
                     <span>Argo Books Standard</span>
-                    <span>$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?></span>
+                    <span>$<?php echo number_format($standardPrice, 2); ?> <?php echo $pricing['currency']; ?></span>
+                </div>
+                <div class="order-item">
+                    <span>Processing Fee</span>
+                    <span>$<?php echo number_format($fee, 2); ?> <?php echo $pricing['currency']; ?></span>
                 </div>
                 <div class="order-total">
                     <span>Total</span>
-                    <span>$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?></span>
+                    <span>$<?php echo number_format($totalPrice, 2); ?> <?php echo $pricing['currency']; ?></span>
                 </div>
             </div>
 
@@ -122,7 +129,7 @@
                     </div>
 
                     <button type="submit" id="stripe-submit-btn" class="checkout-btn">
-                        Pay $<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?>
+                        Pay $<?php echo number_format($totalPrice, 2); ?> <?php echo $pricing['currency']; ?>
                     </button>
                 </form>
             </div>

--- a/upgrade/standard/checkout/index.php
+++ b/upgrade/standard/checkout/index.php
@@ -117,8 +117,7 @@
                     <div class="form-group">
                         <label for="card-element">Card Details</label>
                         <div id="card-element" class="form-control">
-                            <!-- Stripe Elements Placeholder -->
-                            <div id="card-element"></div>
+                            <!-- Stripe Elements will mount here -->
                         </div>
                         <div id="card-errors" role="alert" class="stripe-error"></div>
                     </div>

--- a/upgrade/standard/checkout/index.php
+++ b/upgrade/standard/checkout/index.php
@@ -14,6 +14,9 @@
     <?php
     // Load environment variables
     require_once '../../../db_connect.php';
+    require_once '../../../config/pricing.php';
+
+    $pricing = get_pricing_config();
 
     // Get environment-based keys
     $is_production = $_ENV['APP_ENV'] === 'production';
@@ -51,6 +54,13 @@
                 locationId: '<?php echo $square_location_id; ?>'
             }
         };
+
+        window.PRICING = {
+            standardPrice: <?php echo $pricing['standard_price']; ?>,
+            standardPriceCents: <?php echo price_to_cents($pricing['standard_price']); ?>,
+            currency: '<?php echo $pricing['currency']; ?>',
+            formatted: '$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?>'
+        };
     </script>
 
     <script src="main.js"></script>
@@ -82,11 +92,11 @@
                 <h3>Order Summary</h3>
                 <div class="order-item">
                     <span>Argo Books Standard</span>
-                    <span>$20.00 CAD</span>
+                    <span>$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?></span>
                 </div>
                 <div class="order-total">
                     <span>Total</span>
-                    <span>$20.00 CAD</span>
+                    <span>$<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?></span>
                 </div>
             </div>
 
@@ -112,7 +122,7 @@
                     </div>
 
                     <button type="submit" id="stripe-submit-btn" class="checkout-btn">
-                        Pay $20.00 CAD
+                        Pay $<?php echo number_format($pricing['standard_price'], 2); ?> <?php echo $pricing['currency']; ?>
                     </button>
                 </form>
             </div>

--- a/upgrade/standard/checkout/main.js
+++ b/upgrade/standard/checkout/main.js
@@ -1,4 +1,11 @@
 document.addEventListener("DOMContentLoaded", function () {
+  // Get pricing from server-injected config (see index.php)
+  const pricing = window.PRICING;
+  const priceFormatted = pricing.formatted;
+  const priceValue = pricing.standardPrice.toFixed(2);
+  const priceCents = pricing.standardPriceCents;
+  const currency = pricing.currency;
+
   // Get payment method from URL
   const urlParams = new URLSearchParams(window.location.search);
   const paymentMethod = urlParams.get("method");
@@ -72,8 +79,8 @@ document.addEventListener("DOMContentLoaded", function () {
               purchase_units: [
                 {
                   amount: {
-                    value: "20.00",
-                    currency_code: "CAD",
+                    value: priceValue,
+                    currency_code: currency,
                   },
                 },
               ],
@@ -90,8 +97,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 body: JSON.stringify({
                   orderID: data.orderID,
                   payerID: data.payerID,
-                  amount: "20.00",
-                  currency: "CAD",
+                  amount: priceValue,
+                  currency: currency,
                   status: "completed",
                   payer_email: details.payer.email_address,
                   payer_name:
@@ -197,7 +204,7 @@ document.addEventListener("DOMContentLoaded", function () {
         </div>
 
         <button type="submit" id="stripe-submit-btn" class="checkout-btn">
-          Pay $20.00 CAD
+          Pay ${priceFormatted}
         </button>
       </form>
     `;
@@ -300,8 +307,8 @@ document.addEventListener("DOMContentLoaded", function () {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                amount: 2000, // $20.00 in cents
-                currency: "CAD",
+                amount: priceCents,
+                currency: currency,
                 email: emailInput.value.trim(),
               }),
             }
@@ -351,8 +358,8 @@ document.addEventListener("DOMContentLoaded", function () {
               payment_intent_id: result.paymentIntent.id,
               payment_method_id: result.paymentIntent.payment_method,
               email: emailInput.value.trim(),
-              amount: "20.00",
-              currency: "CAD",
+              amount: priceValue,
+              currency: currency,
               status: result.paymentIntent.status,
             }),
           });
@@ -398,7 +405,7 @@ document.addEventListener("DOMContentLoaded", function () {
           // Re-enable submit button
           if (submitButton) {
             submitButton.disabled = false;
-            submitButton.textContent = "Pay $20.00 CAD";
+            submitButton.textContent = `Pay ${priceFormatted}`;
           }
         }
       });
@@ -437,7 +444,7 @@ document.addEventListener("DOMContentLoaded", function () {
         </div>
 
         <button type="submit" id="square-submit-btn" class="checkout-btn">
-          Pay $20.00 CAD
+          Pay ${priceFormatted}
         </button>
       </form>
     `;
@@ -612,7 +619,7 @@ document.addEventListener("DOMContentLoaded", function () {
             // Re-enable submit button
             if (submitButton) {
               submitButton.disabled = false;
-              submitButton.textContent = "Pay $20.00 CAD";
+              submitButton.textContent = `Pay ${priceFormatted}`;
             }
           }
         });

--- a/upgrade/standard/checkout/process-paypal-payment.php
+++ b/upgrade/standard/checkout/process-paypal-payment.php
@@ -4,8 +4,9 @@ session_start();
 // Set headers for JSON response
 header('Content-Type: application/json');
 
-// Load payment helper
+// Load payment helper and pricing config
 require_once 'payment-helper.php';
+require_once __DIR__ . '/../../../config/pricing.php';
 
 // Get user_id if logged in
 $user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : null;
@@ -69,9 +70,10 @@ try {
     }
 
     // Step 4: Extract transaction details
+    $pricing = get_pricing_config();
     $transaction_id = $order_id;
-    $amount = $data['amount'] ?? '20.00';
-    $currency = $data['currency'] ?? 'CAD';
+    $amount = $data['amount'] ?? number_format($pricing['standard_price'], 2, '.', '');
+    $currency = $data['currency'] ?? $pricing['currency'];
 
     // Get more specific transaction ID from capture details if available
     if (isset($order_details['purchase_units'][0]['payments']['captures'][0])) {

--- a/upgrade/standard/checkout/process-paypal-payment.php
+++ b/upgrade/standard/checkout/process-paypal-payment.php
@@ -122,6 +122,7 @@ function get_paypal_access_token($client_id, $client_secret, $api_url)
     $response = curl_exec($ch);
     $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $curl_error = curl_error($ch);
+    curl_close($ch);
 
     if ($http_code !== 200 || !$response) {
         error_log("PayPal auth error ($http_code): $curl_error");
@@ -157,6 +158,7 @@ function call_paypal_api($url, $method, $access_token, $data = null)
     $response = curl_exec($ch);
     $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $error = curl_error($ch);
+    curl_close($ch);
 
     if (($http_code < 200 || $http_code >= 300) || !$response) {
         error_log("PayPal API error ($http_code): $error, Response: $response");

--- a/upgrade/standard/checkout/process-square-payment.php
+++ b/upgrade/standard/checkout/process-square-payment.php
@@ -56,14 +56,16 @@ try {
         }
     }
 
-    // Create payment request for Square
+    // Create payment request for Square (price + processing fee)
     $pricing = get_pricing_config();
+    $fee = calculate_processing_fee($pricing['standard_price']);
+    $totalAmount = $pricing['standard_price'] + $fee;
     $idempotency_key = $data['idempotency_key'] ?? uniqid();
     $payment_data = [
         'source_id' => $data['source_id'],
         'idempotency_key' => $idempotency_key,
         'amount_money' => [
-            'amount' => price_to_cents($pricing['standard_price']),
+            'amount' => price_to_cents($totalAmount),
             'currency' => $pricing['currency']
         ],
         'autocomplete' => true,

--- a/upgrade/standard/checkout/process-square-payment.php
+++ b/upgrade/standard/checkout/process-square-payment.php
@@ -90,6 +90,7 @@ try {
     $response_data = curl_exec($ch);
     $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $curl_error = curl_error($ch);
+    curl_close($ch);
 
     if ($http_code >= 200 && $http_code < 300) {
         $payment_result = json_decode($response_data, true);

--- a/upgrade/standard/checkout/process-square-payment.php
+++ b/upgrade/standard/checkout/process-square-payment.php
@@ -4,8 +4,9 @@ session_start();
 // Set headers for JSON response
 header('Content-Type: application/json');
 
-// Load payment helper
+// Load payment helper and pricing config
 require_once 'payment-helper.php';
+require_once __DIR__ . '/../../../config/pricing.php';
 
 // Get user_id if logged in
 $user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : null;
@@ -56,13 +57,14 @@ try {
     }
 
     // Create payment request for Square
+    $pricing = get_pricing_config();
     $idempotency_key = $data['idempotency_key'] ?? uniqid();
     $payment_data = [
         'source_id' => $data['source_id'],
         'idempotency_key' => $idempotency_key,
         'amount_money' => [
-            'amount' => 2000, // $20.00 in cents
-            'currency' => 'CAD'
+            'amount' => price_to_cents($pricing['standard_price']),
+            'currency' => $pricing['currency']
         ],
         'autocomplete' => true,
         'location_id' => $square_location_id,

--- a/upgrade/standard/checkout/process-stripe-payment.php
+++ b/upgrade/standard/checkout/process-stripe-payment.php
@@ -32,6 +32,7 @@ $response = [
 
 try {
     $pricing = get_pricing_config();
+    $expectedTotal = $pricing['standard_price'] + calculate_processing_fee($pricing['standard_price']);
 
     // Validate payment status
     if (!isset($data['status']) || $data['status'] !== 'succeeded') {
@@ -40,8 +41,8 @@ try {
             'message' => 'Payment status is not completed'
         ];
     }
-    // Validate payment amount against configured price
-    else if (!isset($data['amount']) || floatval($data['amount']) < $pricing['standard_price']) {
+    // Validate payment amount against configured price + processing fee
+    else if (!isset($data['amount']) || floatval($data['amount']) < $expectedTotal) {
         $response = [
             'success' => false,
             'message' => 'Invalid payment amount'

--- a/upgrade/standard/checkout/process-stripe-payment.php
+++ b/upgrade/standard/checkout/process-stripe-payment.php
@@ -4,8 +4,9 @@ session_start();
 // Set headers for JSON response
 header('Content-Type: application/json');
 
-// Load payment helper
+// Load payment helper and pricing config
 require_once 'payment-helper.php';
+require_once __DIR__ . '/../../../config/pricing.php';
 
 // Get user_id if logged in
 $user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : null;
@@ -30,6 +31,8 @@ $response = [
 ];
 
 try {
+    $pricing = get_pricing_config();
+
     // Validate payment status
     if (!isset($data['status']) || $data['status'] !== 'succeeded') {
         $response = [
@@ -37,8 +40,8 @@ try {
             'message' => 'Payment status is not completed'
         ];
     }
-    // Validate payment amount
-    else if (!isset($data['amount']) || floatval($data['amount']) < 20.00) {
+    // Validate payment amount against configured price
+    else if (!isset($data['amount']) || floatval($data['amount']) < $pricing['standard_price']) {
         $response = [
             'success' => false,
             'message' => 'Invalid payment amount'

--- a/upgrade/standard/checkout/stripe-payment-intent.php
+++ b/upgrade/standard/checkout/stripe-payment-intent.php
@@ -65,10 +65,12 @@ try {
         $stmt->close();
     }
 
-    // Create a PaymentIntent using server-side configured price
+    // Create a PaymentIntent using server-side configured price + processing fee
     $pricing = get_pricing_config();
+    $fee = calculate_processing_fee($pricing['standard_price']);
+    $totalAmount = $pricing['standard_price'] + $fee;
     $payment_intent = \Stripe\PaymentIntent::create([
-        'amount' => price_to_cents($pricing['standard_price']),
+        'amount' => price_to_cents($totalAmount),
         'currency' => strtolower($pricing['currency']),
         'payment_method_types' => ['card'],
         'metadata' => [

--- a/upgrade/standard/checkout/stripe-payment-intent.php
+++ b/upgrade/standard/checkout/stripe-payment-intent.php
@@ -4,6 +4,7 @@ session_start();
 require_once '../../../vendor/autoload.php';
 require_once '../../../db_connect.php';
 require_once '../../../license_functions.php';
+require_once __DIR__ . '/../../../config/pricing.php';
 
 // Set headers for JSON response
 header('Content-Type: application/json');
@@ -64,10 +65,11 @@ try {
         $stmt->close();
     }
 
-    // Create a PaymentIntent
+    // Create a PaymentIntent using server-side configured price
+    $pricing = get_pricing_config();
     $payment_intent = \Stripe\PaymentIntent::create([
-        'amount' => $data['amount'],
-        'currency' => strtolower($data['currency']),
+        'amount' => price_to_cents($pricing['standard_price']),
+        'currency' => strtolower($pricing['currency']),
         'payment_method_types' => ['card'],
         'metadata' => [
             'product' => 'Argo Books - Premium License',

--- a/upgrade/standard/checkout/stripe-payment-intent.php
+++ b/upgrade/standard/checkout/stripe-payment-intent.php
@@ -74,12 +74,12 @@ try {
         'currency' => strtolower($pricing['currency']),
         'payment_method_types' => ['card'],
         'metadata' => [
-            'product' => 'Argo Books - Premium License',
+            'product' => 'Argo Books - Standard License',
             'email' => $data['email'] ?? '',
             'license_key' => $license_key ?? ''
         ],
         'receipt_email' => $data['email'] ?? null,
-        'description' => 'Argo Books - Premium License'
+        'description' => 'Argo Books - Standard License'
     ]);
 
     // Store the payment intent ID in our database

--- a/upgrade/standard/index.php
+++ b/upgrade/standard/index.php
@@ -1,6 +1,9 @@
 <?php
 session_start();
 require_once '../../db_connect.php';
+require_once __DIR__ . '/../../config/pricing.php';
+$pricing = get_pricing_config();
+$standardPrice = $pricing['standard_price'];
 
 // Check if logged-in user already has a license key
 if (isset($_SESSION['user_id'])) {
@@ -34,20 +37,20 @@ if (isset($_SESSION['user_id'])) {
 
     <!-- SEO Meta Tags -->
     <meta name="description"
-        content="Get Argo Books Standard for $20 CAD. Lifetime access to unlimited products, Windows Hello security, and priority support. Choose your payment method.">
+        content="Get Argo Books Standard for $<?php echo number_format($standardPrice, 0); ?> CAD. Lifetime access to unlimited products, Windows Hello security, and priority support. Choose your payment method.">
     <meta name="keywords"
         content="argo books standard, lifetime access, unlimited products, one time payment, business software">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Get Standard - Argo Books | $20 CAD">
+    <meta property="og:title" content="Get Standard - Argo Books | $<?php echo number_format($standardPrice, 0); ?> CAD">
     <meta property="og:description"
-        content="Get Argo Books Standard for $20 CAD. Lifetime access to unlimited products, Windows Hello security, and priority support.">
+        content="Get Argo Books Standard for $<?php echo number_format($standardPrice, 0); ?> CAD. Lifetime access to unlimited products, Windows Hello security, and priority support.">
     <meta property="og:url" content="https://argorobots.com/upgrade/standard/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Argo Books">
 
     <link rel="shortcut icon" type="image/x-icon" href="../../resources/images/argo-logo/A-logo.ico">
-    <title>Get Standard - Argo Books | $20 CAD Lifetime Access</title>
+    <title>Get Standard - Argo Books | $<?php echo number_format($standardPrice, 0); ?> CAD Lifetime Access</title>
 
     <script src="../../resources/scripts/jquery-3.6.0.js"></script>
     <script src="../../resources/scripts/main.js"></script>
@@ -84,11 +87,11 @@ if (isset($_SESSION['user_id'])) {
                         <h2>Order Summary</h2>
                         <div class="summary-item">
                             <span>Argo Books Standard</span>
-                            <span class="item-price">$20.00 CAD</span>
+                            <span class="item-price">$<?php echo number_format($standardPrice, 2); ?> CAD</span>
                         </div>
                         <div class="summary-total">
                             <span>Total</span>
-                            <span>$20.00 CAD</span>
+                            <span>$<?php echo number_format($standardPrice, 2); ?> CAD</span>
                         </div>
                         <div class="summary-note">
                             One-time payment. No recurring charges.

--- a/upgrade/standard/index.php
+++ b/upgrade/standard/index.php
@@ -4,6 +4,8 @@ require_once '../../db_connect.php';
 require_once __DIR__ . '/../../config/pricing.php';
 $pricing = get_pricing_config();
 $standardPrice = $pricing['standard_price'];
+$fee = calculate_processing_fee($standardPrice);
+$totalPrice = $standardPrice + $fee;
 
 // Check if logged-in user already has a license key
 if (isset($_SESSION['user_id'])) {
@@ -89,9 +91,13 @@ if (isset($_SESSION['user_id'])) {
                             <span>Argo Books Standard</span>
                             <span class="item-price">$<?php echo number_format($standardPrice, 2); ?> CAD</span>
                         </div>
+                        <div class="summary-item">
+                            <span>Processing Fee</span>
+                            <span class="item-price">$<?php echo number_format($fee, 2); ?> CAD</span>
+                        </div>
                         <div class="summary-total">
                             <span>Total</span>
-                            <span>$<?php echo number_format($standardPrice, 2); ?> CAD</span>
+                            <span>$<?php echo number_format($totalPrice, 2); ?> CAD</span>
                         </div>
                         <div class="summary-note">
                             One-time payment. No recurring charges.

--- a/webhooks/paypal-helper.php
+++ b/webhooks/paypal-helper.php
@@ -56,6 +56,7 @@ function getPayPalAccessToken() {
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     if ($httpCode !== 200) {
         error_log("Failed to get PayPal access token. HTTP Code: $httpCode, Response: $response");
@@ -125,6 +126,7 @@ function verifyPayPalWebhookSignature($headers, $body, $webhookId) {
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     if ($httpCode !== 200) {
         error_log("PayPal webhook verification failed. HTTP Code: $httpCode, Response: $response");
@@ -162,6 +164,7 @@ function getPayPalSubscriptionDetails($subscriptionId) {
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     if ($httpCode !== 200) {
         error_log("Failed to get PayPal subscription details. HTTP Code: $httpCode");
@@ -200,6 +203,7 @@ function cancelPayPalSubscription($subscriptionId, $reason = 'Cancelled by user'
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     // PayPal returns 204 No Content on successful cancellation
     if ($httpCode !== 204) {
@@ -236,7 +240,9 @@ function suspendPayPalSubscription($subscriptionId, $reason = 'Payment failed') 
         ]
     ]);
 
+    curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     return $httpCode === 204;
 }
@@ -267,7 +273,9 @@ function activatePayPalSubscription($subscriptionId, $reason = 'Reactivated by u
         ]
     ]);
 
+    curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     return $httpCode === 204;
 }
@@ -297,6 +305,7 @@ function getPayPalCaptureDetails($captureId) {
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
 
     if ($httpCode !== 200) {
         return false;


### PR DESCRIPTION
## Summary
This PR introduces a centralized pricing configuration system and implements payment processing fees across all checkout flows. All prices are now managed through environment variables with sensible defaults, making it easy to adjust pricing without code changes.

## Key Changes

- **New centralized pricing config** (`config/pricing.php`):
  - Single source of truth for all prices (Standard, Premium monthly/yearly, discounts)
  - Environment variable overrides for all prices with validation
  - Helper functions: `get_pricing_config()`, `calculate_processing_fee()`, `price_to_cents()`
  - All prices default to current production values (Standard: $20, Premium: $5/month or $50/year, discount: $20)

- **Processing fees implementation**:
  - Added 2.90% + $0.30 CAD processing fee calculation to all payment flows
  - Fees applied to Standard checkout, Premium subscriptions, and subscription renewals
  - Zero fees for credit-covered payments (e.g., monthly Premium with discount)
  - Server-side fee calculation prevents client-side manipulation

- **Updated all pricing references**:
  - Premium checkout: displays base price, processing fee, and total separately
  - Standard checkout: includes processing fee in order summary
  - Subscription renewal cron: calculates fees on renewal amounts
  - All payment processors (Stripe, PayPal, Square) use configured prices + fees

- **Dynamic UI updates**:
  - All hardcoded prices replaced with PHP variables from centralized config
  - Meta tags, SEO descriptions, and pricing displays now use dynamic values
  - Discount calculations and credit month calculations use config values
  - Renewal amount messaging updated to reflect actual charged amounts

- **Payment validation improvements**:
  - Server-side validation of payment amounts against configured price + fee
  - Prevents discrepancies between client and server calculations

## Implementation Details

- Processing fees are only charged on actual card charges, not on credit-covered payments
- For monthly Premium with discount, the first month(s) are free (covered by $20 credit), then full price + fee applies on renewal
- All monetary calculations use `price_to_cents()` to avoid floating-point precision issues
- Environment variables are validated and cached per request for performance

https://claude.ai/code/session_01VMRmFcJ8t1hwE2apAyNSxo