### PR TITLE
Update Standard pricing from $20 to $25 CAD

### DIFF
--- a/config/pricing.php
+++ b/config/pricing.php
@@ -7,10 +7,10 @@
  * identically without any env vars set.
  *
  * Environment variables:
- *   STANDARD_PRICE              - Standard one-time price (default: 20.00)
+ *   STANDARD_PRICE              - Standard one-time price (default: 25.00)
  *   PREMIUM_MONTHLY_PRICE       - Premium monthly subscription (default: 5.00)
  *   PREMIUM_YEARLY_PRICE        - Premium yearly subscription (default: 50.00)
- *   PREMIUM_STANDARD_DISCOUNT   - Discount for Standard users upgrading to Premium (default: 20.00)
+ *   PREMIUM_STANDARD_DISCOUNT   - Discount for Standard users upgrading to Premium (default: 25.00)
  *   PROCESSING_FEE_PERCENT      - Payment processing fee percentage (default: 2.90)
  *   PROCESSING_FEE_FIXED        - Payment processing fixed fee in CAD (default: 0.30)
  */
@@ -36,10 +36,10 @@ function get_pricing_config() {
     }
 
     $config = [
-        'standard_price'        => _pricing_parse_env('STANDARD_PRICE', 20.00),
+        'standard_price'        => _pricing_parse_env('STANDARD_PRICE', 25.00),
         'premium_monthly_price' => _pricing_parse_env('PREMIUM_MONTHLY_PRICE', 5.00),
         'premium_yearly_price'  => _pricing_parse_env('PREMIUM_YEARLY_PRICE', 50.00),
-        'premium_discount'      => _pricing_parse_env('PREMIUM_STANDARD_DISCOUNT', 20.00),
+        'premium_discount'      => _pricing_parse_env('PREMIUM_STANDARD_DISCOUNT', 25.00),
         'processing_fee_percent' => _pricing_parse_env('PROCESSING_FEE_PERCENT', 2.90),
         'processing_fee_fixed'   => _pricing_parse_env('PROCESSING_FEE_FIXED', 0.30),
         'currency'              => 'CAD',

--- a/documentation/pages/getting-started/version-comparison.php
+++ b/documentation/pages/getting-started/version-comparison.php
@@ -84,7 +84,7 @@ include '../../docs-header.php';
                     <div class="card-header">
                         <h3 class="version-title">Standard</h3>
                         <p class="version-subtitle">Everything you need to scale</p>
-                        <div class="version-price">$20 <span class="price-period">CAD one-time</span></div>
+                        <div class="version-price">$<?php echo number_format($pricing['standard_price'], 0); ?> <span class="price-period">CAD one-time</span></div>
                     </div>
                     <ul class="feature-list">
                         <li class="feature-item">

--- a/index.php
+++ b/index.php
@@ -1173,7 +1173,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
                         <span class="pricing-tag">Standard</span>
                         <div class="pricing-amount">
                             <span class="currency">$</span>
-                            <span class="amount">20</span>
+                            <span class="amount"><?php echo number_format($pricing['standard_price'], 0); ?></span>
                             <span class="period">CAD one-time</span>
                         </div>
                         <p class="pricing-description">Everything you need to scale</p>

--- a/upgrade/standard/thank-you/index.php
+++ b/upgrade/standard/thank-you/index.php
@@ -30,7 +30,7 @@
             if (transactionID && !sessionStorage.getItem(trackingKey)) {
                 gtag('event', 'conversion', {
                     'send_to': 'AW-17210317271/u-kiCL2u0_oaENezwo5A',
-                    'value': 20.00,
+                    'value': 25.00,
                     'currency': 'CAD',
                     'transaction_id': transactionID
                 });


### PR DESCRIPTION
## Summary
This PR updates the Standard tier pricing from $20.00 to $25.00 CAD across the application, including configuration defaults, documentation, and conversion tracking.

## Key Changes
- Updated `STANDARD_PRICE` default value from 20.00 to 25.00 in pricing configuration
- Updated `PREMIUM_STANDARD_DISCOUNT` default value from 20.00 to 25.00 to maintain consistency
- Updated hardcoded pricing display on the homepage to use dynamic pricing configuration
- Updated pricing display in version comparison documentation to use dynamic pricing configuration
- Updated Google Ads conversion tracking value from 20.00 to 25.00 for Standard tier purchases

## Implementation Details
- The pricing configuration changes ensure environment variable defaults reflect the new pricing
- Hardcoded price values in templates have been replaced with dynamic references to `$pricing['standard_price']` to prevent future inconsistencies
- All pricing-related files have been updated consistently to reflect the new $25.00 Standard tier price

https://claude.ai/code/session_01FnmTuczPUWXmsqEVdTA8Jv