### PR TITLE
Add provider disconnection detection and improve error handling

### DIFF
--- a/api/portal/connect.php
+++ b/api/portal/connect.php
@@ -223,13 +223,44 @@ function disconnect_provider(array $company, string $provider): void
     }
 
     $stmt->bind_param('i', $company['id']);
-    $stmt->execute();
+    if (!$stmt->execute()) {
+        $error = $stmt->error;
+        $stmt->close();
+        $db->close();
+        send_error_response(500, 'Failed to disconnect ' . $provider . ': ' . $error, 'DISCONNECT_FAILED');
+    }
     $stmt->close();
+
+    // Re-fetch company to return the updated connected providers state
+    $stmtRefresh = $db->prepare(
+        'SELECT stripe_account_id, stripe_email, paypal_merchant_id, paypal_email,
+                square_merchant_id, square_email
+         FROM portal_companies WHERE id = ? LIMIT 1'
+    );
+    $stmtRefresh->bind_param('i', $company['id']);
+    $stmtRefresh->execute();
+    $updated = $stmtRefresh->get_result()->fetch_assoc();
+    $stmtRefresh->close();
     $db->close();
+
+    $connectedProviders = [
+        'stripeConnected' => !empty($updated['stripe_account_id']),
+        'stripeEmail' => $updated['stripe_email'] ?? null,
+        'paypalConnected' => !empty($updated['paypal_merchant_id']),
+        'paypalEmail' => $updated['paypal_email'] ?? null,
+        'squareConnected' => !empty($updated['square_merchant_id']),
+        'squareEmail' => $updated['square_email'] ?? null,
+    ];
 
     send_json_response(200, [
         'success' => true,
         'message' => ucfirst($provider) . ' has been disconnected.',
+        'connectedProviders' => $connectedProviders,
+        'payment_methods' => array_values(array_filter([
+            !empty($updated['stripe_account_id']) ? 'stripe' : null,
+            !empty($updated['paypal_merchant_id']) ? 'paypal' : null,
+            !empty($updated['square_merchant_id']) ? 'square' : null,
+        ])),
         'timestamp' => date('c')
     ]);
 }

--- a/api/portal/invoices.php
+++ b/api/portal/invoices.php
@@ -160,6 +160,9 @@ function handle_publish_invoice(): void
         }
     }
 
+    // Return currently connected payment methods so the desktop app stays in sync
+    $paymentMethods = get_available_payment_methods($company);
+
     send_json_response(200, [
         'success' => true,
         'invoiceToken' => $invoiceToken,
@@ -167,6 +170,7 @@ function handle_publish_invoice(): void
         'invoiceUrl' => $invoiceUrl,
         'portalUrl' => $portalUrl,
         'emailSent' => $emailSent,
+        'payment_methods' => $paymentMethods,
         'message' => $existing ? 'Invoice updated' : 'Invoice published',
         'timestamp' => date('c')
     ]);

--- a/api/portal/process-payment.php
+++ b/api/portal/process-payment.php
@@ -93,6 +93,9 @@ function process_stripe_payment(array $invoice, array $data, float $amount, stri
 
     // Verify the payment intent status with Stripe
     $stripeAccountId = $invoice['stripe_account_id'] ?? '';
+    if (empty($stripeAccountId)) {
+        send_error_response(400, 'Stripe is not configured for this business.', 'STRIPE_NOT_CONNECTED');
+    }
     $stripe_secret_key = $is_production
         ? $_ENV['STRIPE_LIVE_SECRET_KEY']
         : $_ENV['STRIPE_SANDBOX_SECRET_KEY'];
@@ -151,6 +154,11 @@ function process_stripe_payment(array $invoice, array $data, float $amount, stri
 function process_paypal_payment(array $invoice, array $data, float $amount, string $referenceNumber): void
 {
     global $is_production;
+
+    $paypalMerchantId = $invoice['paypal_merchant_id'] ?? '';
+    if (empty($paypalMerchantId)) {
+        send_error_response(400, 'PayPal is not configured for this business.', 'PAYPAL_NOT_CONNECTED');
+    }
 
     $orderId = $data['order_id'] ?? '';
     if (empty($orderId)) {

--- a/portal/main.js
+++ b/portal/main.js
@@ -195,7 +195,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
         var intentData = await response.json();
         if (!intentData.success) {
-          throw new Error(intentData.message || "Failed to create payment");
+          hideProcessing();
+          showError(intentData.message || "Failed to create payment", intentData);
+          return;
         }
 
         // Confirm the payment
@@ -233,7 +235,7 @@ document.addEventListener("DOMContentLoaded", function () {
         showConfirmation(amount, processData.reference_number, "Stripe");
       } catch (error) {
         hideProcessing();
-        showError(error.message);
+        showError(error.message, null);
       }
     });
   }
@@ -260,7 +262,11 @@ document.addEventListener("DOMContentLoaded", function () {
           return r.json();
         })
         .then(function (data) {
-          if (!data.success) throw new Error(data.message);
+          if (!data.success) {
+            var disconnected = getDisconnectedProvider(data);
+            if (disconnected) { handleProviderDisconnected(disconnected); return; }
+            throw new Error(data.message);
+          }
 
           var script = document.createElement("script");
           script.src =
@@ -281,7 +287,7 @@ document.addEventListener("DOMContentLoaded", function () {
         })
         .catch(function (err) {
           document.getElementById("portal-paypal-container").innerHTML =
-            '<div class="payment-error-box">' + err.message + "</div>";
+            '<div class="payment-error-box">' + escapeHtml(err.message) + "</div>";
         });
     } else {
       fetch(apiBase + "/checkout.php", {
@@ -297,12 +303,16 @@ document.addEventListener("DOMContentLoaded", function () {
           return r.json();
         })
         .then(function (data) {
-          if (!data.success) throw new Error(data.message);
+          if (!data.success) {
+            var disconnected = getDisconnectedProvider(data);
+            if (disconnected) { handleProviderDisconnected(disconnected); return; }
+            throw new Error(data.message);
+          }
           initializePayPalButtons(data.merchant_id);
         })
         .catch(function (err) {
           document.getElementById("portal-paypal-container").innerHTML =
-            '<div class="payment-error-box">' + err.message + "</div>";
+            '<div class="payment-error-box">' + escapeHtml(err.message) + "</div>";
         });
     }
   }
@@ -416,12 +426,16 @@ document.addEventListener("DOMContentLoaded", function () {
         return r.json();
       })
       .then(function (data) {
-        if (!data.success) throw new Error(data.message);
+        if (!data.success) {
+          var disconnected = getDisconnectedProvider(data);
+          if (disconnected) { handleProviderDisconnected(disconnected); return; }
+          throw new Error(data.message);
+        }
         loadSquareSDK(data.app_id, data.location_id);
       })
       .catch(function (err) {
         formContainer.innerHTML =
-          '<div class="payment-error-box">' + err.message + "</div>";
+          '<div class="payment-error-box">' + escapeHtml(err.message) + "</div>";
       });
   }
 
@@ -492,11 +506,13 @@ document.addEventListener("DOMContentLoaded", function () {
                   "Square"
                 );
               } else {
-                throw new Error(result.message || "Payment failed");
+                hideProcessing();
+                showError(result.message || "Payment failed", result);
+                return;
               }
             } catch (error) {
               hideProcessing();
-              showError(error.message);
+              showError(error.message, null);
             }
           });
         })
@@ -549,7 +565,69 @@ document.addEventListener("DOMContentLoaded", function () {
     if (overlay) overlay.remove();
   }
 
-  function showError(message) {
+  /**
+   * Check if an error response indicates a provider is no longer connected.
+   * Returns the provider name if so, or null otherwise.
+   */
+  function getDisconnectedProvider(responseData) {
+    var code = responseData.errorCode || "";
+    var disconnectedCodes = {
+      STRIPE_NOT_CONNECTED: "stripe",
+      PAYPAL_NOT_CONNECTED: "paypal",
+      SQUARE_NOT_CONNECTED: "square",
+      SQUARE_NOT_CONFIGURED: "square",
+    };
+    return disconnectedCodes[code] || null;
+  }
+
+  /**
+   * Handle a payment method that was disconnected after page load.
+   * Hides the method button and shows a helpful message.
+   */
+  function handleProviderDisconnected(provider) {
+    // Hide the button for the disconnected method
+    var btn = document.querySelector('.method-btn[data-method="' + provider + '"]');
+    if (btn) btn.style.display = "none";
+
+    // Check if there are other methods still available
+    var remainingButtons = document.querySelectorAll(".method-btn");
+    var visibleCount = 0;
+    remainingButtons.forEach(function (b) {
+      if (b.style.display !== "none") visibleCount++;
+    });
+
+    var providerName = provider.charAt(0).toUpperCase() + provider.slice(1);
+
+    if (visibleCount > 0) {
+      formContainer.innerHTML =
+        '<div class="payment-error-box">' +
+        providerName +
+        " is no longer available for this invoice. Please select another payment method." +
+        "</div>";
+      formContainer.style.display = "block";
+    } else {
+      // No methods left - hide the entire payment section and show a message
+      var paymentSection = document.getElementById("payment-section");
+      if (paymentSection) {
+        paymentSection.innerHTML =
+          '<div class="invoice-no-methods">' +
+          "<p>Online payments are not currently available for this invoice. " +
+          'Please contact the business for payment instructions, or <a href="" onclick="location.reload();return false;">refresh the page</a> to check again.</p>' +
+          "</div>";
+      }
+    }
+  }
+
+  function showError(message, responseData) {
+    // Check if this is a "provider disconnected" error
+    if (responseData) {
+      var disconnected = getDisconnectedProvider(responseData);
+      if (disconnected) {
+        handleProviderDisconnected(disconnected);
+        return;
+      }
+    }
+
     // Find or create error container
     var container = document.querySelector(".field-error:last-of-type");
     if (!container) {


### PR DESCRIPTION
## Summary
This PR enhances the payment portal to detect when payment providers (Stripe, PayPal, Square) become disconnected after page load and gracefully handle these scenarios. It also improves error handling throughout the payment flow with better user messaging and XSS protection.

## Key Changes

**Frontend (portal/main.js):**
- Added `getDisconnectedProvider()` function to detect provider disconnection error codes from API responses
- Added `handleProviderDisconnected()` function to hide unavailable payment methods and show contextual error messages
- Updated error handling in Stripe, PayPal, and Square payment flows to check for provider disconnection before throwing generic errors
- Modified `showError()` to accept response data and delegate to provider disconnection handler when applicable
- Added `escapeHtml()` calls when rendering error messages to prevent XSS vulnerabilities
- Improved error flow to call `hideProcessing()` and `showError()` instead of throwing exceptions in several places

**Backend (api/portal/connect.php):**
- Enhanced `disconnect_provider()` to validate query execution and return detailed error responses on failure
- Added re-fetch of company data after disconnection to return updated provider connection state
- Extended disconnect response to include `connectedProviders` object and `payment_methods` array so clients can stay in sync

**Backend (api/portal/process-payment.php):**
- Added validation in `process_stripe_payment()` to check if Stripe is configured before processing
- Added validation in `process_paypal_payment()` to check if PayPal is configured before processing
- Both return `STRIPE_NOT_CONNECTED` / `PAYPAL_NOT_CONNECTED` error codes when providers are missing

**Backend (api/portal/invoices.php):**
- Updated `handle_publish_invoice()` to return currently connected `payment_methods` in the response, allowing the desktop app to stay synchronized with available payment options

## Notable Implementation Details
- Provider disconnection is detected via specific error codes (`STRIPE_NOT_CONNECTED`, `PAYPAL_NOT_CONNECTED`, `SQUARE_NOT_CONNECTED`, `SQUARE_NOT_CONFIGURED`)
- When a provider disconnects, the UI hides its button and shows a message prompting users to select another method
- If all payment methods become unavailable, the entire payment section is replaced with a message suggesting users refresh or contact support
- Error messages are now properly escaped to prevent XSS attacks
- The disconnect endpoint now returns the updated provider state to keep clients in sync without requiring a full page refresh

https://claude.ai/code/session_01EAe55CmYS7Hyjxt1QqGRRC