### PR TITLE
Add SMTP relay support with mail() fallback for email sending

### DIFF
--- a/api/invoice/invoice_email_sender.php
+++ b/api/invoice/invoice_email_sender.php
@@ -2,9 +2,11 @@
 /**
  * Invoice Email Sender
  *
- * Handles sending invoice emails using PHP's native mail() function.
- * No external dependencies required.
+ * Handles sending invoice emails via SMTP relay (Brevo) when configured,
+ * with fallback to PHP's native mail() function.
  */
+
+require_once __DIR__ . '/../../smtp_mailer.php';
 
 class InvoiceEmailSender
 {
@@ -44,33 +46,13 @@ class InvoiceEmailSender
             // Generate unique message ID
             $messageId = $this->generateMessageId($data['invoiceId'] ?? 'invoice');
 
-            // Build headers
-            $headers = [
-                'MIME-Version: 1.0',
-                'Content-Type: text/html; charset=UTF-8',
-                'From: ' . $this->formatAddress($fromEmail, $fromName),
-                'Message-ID: ' . $messageId,
-                'X-Mailer: ArgoBooks/1.0'
-            ];
-
-            // Add reply-to if provided
-            if (!empty($data['replyTo'])) {
-                $headers[] = 'Reply-To: ' . $data['replyTo'];
-            }
-
-            // Add BCC if provided
-            if (!empty($data['bcc'])) {
-                $headers[] = 'Bcc: ' . $data['bcc'];
-            }
-
-            // Format recipient
-            $to = $this->formatAddress($toEmail, $toName);
-
-            // Handle PDF attachment if provided
-            if (!empty($data['pdfAttachment'])) {
-                $result = $this->sendWithAttachment($to, $subject, $htmlBody, $textBody, $headers, $data['pdfAttachment'], $data['pdfFilename'] ?? 'invoice.pdf');
+            // Try SMTP relay first
+            $mailer = create_smtp_mailer();
+            if ($mailer) {
+                $result = $this->sendViaSMTP($mailer, $toEmail, $toName, $fromEmail, $fromName, $subject, $htmlBody, $data, $messageId);
             } else {
-                $result = mail($to, $subject, $htmlBody, implode("\r\n", $headers));
+                // Fall back to mail()
+                $result = $this->sendViaMail($toEmail, $toName, $fromEmail, $fromName, $subject, $htmlBody, $textBody, $data, $messageId);
             }
 
             if ($result) {
@@ -78,7 +60,8 @@ class InvoiceEmailSender
                     'to' => $toEmail,
                     'subject' => $subject,
                     'messageId' => $messageId,
-                    'invoiceId' => $data['invoiceId'] ?? 'N/A'
+                    'invoiceId' => $data['invoiceId'] ?? 'N/A',
+                    'method' => $mailer ? 'smtp' : 'mail'
                 ]);
 
                 return [
@@ -90,7 +73,7 @@ class InvoiceEmailSender
             } else {
                 $this->log('Email sending failed', [
                     'to' => $toEmail,
-                    'error' => 'mail() returned false'
+                    'error' => 'send returned false'
                 ], 'ERROR');
 
                 return [
@@ -119,7 +102,70 @@ class InvoiceEmailSender
     }
 
     /**
-     * Send email with PDF attachment using multipart MIME
+     * Send email via SMTP relay using PHPMailer
+     */
+    private function sendViaSMTP($mailer, string $toEmail, string $toName, string $fromEmail, string $fromName, string $subject, string $htmlBody, array $data, string $messageId): bool
+    {
+        $mailer->setFrom($fromEmail, $fromName);
+        $mailer->addAddress($toEmail, $toName);
+        $mailer->Subject = $subject;
+        $mailer->Body = $htmlBody;
+        $mailer->MessageID = $messageId;
+
+        if (!empty($data['replyTo'])) {
+            $mailer->addReplyTo($data['replyTo']);
+        }
+
+        if (!empty($data['bcc'])) {
+            $mailer->addBCC($data['bcc']);
+        }
+
+        // Handle PDF attachment
+        if (!empty($data['pdfAttachment'])) {
+            $pdfContent = base64_decode($data['pdfAttachment']);
+            if ($pdfContent === false) {
+                throw new \Exception('Invalid base64 PDF content');
+            }
+            $filename = $data['pdfFilename'] ?? 'invoice.pdf';
+            $mailer->addStringAttachment($pdfContent, $filename, 'base64', 'application/pdf');
+        }
+
+        $mailer->send();
+        return true;
+    }
+
+    /**
+     * Send email via PHP's native mail() function (fallback)
+     */
+    private function sendViaMail(string $toEmail, string $toName, string $fromEmail, string $fromName, string $subject, string $htmlBody, string $textBody, array $data, string $messageId): bool
+    {
+        $headers = [
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'From: ' . $this->formatAddress($fromEmail, $fromName),
+            'Message-ID: ' . $messageId,
+            'X-Mailer: ArgoBooks/1.0'
+        ];
+
+        if (!empty($data['replyTo'])) {
+            $headers[] = 'Reply-To: ' . $data['replyTo'];
+        }
+
+        if (!empty($data['bcc'])) {
+            $headers[] = 'Bcc: ' . $data['bcc'];
+        }
+
+        $to = $this->formatAddress($toEmail, $toName);
+
+        if (!empty($data['pdfAttachment'])) {
+            return $this->sendWithAttachment($to, $subject, $htmlBody, $textBody, $headers, $data['pdfAttachment'], $data['pdfFilename'] ?? 'invoice.pdf');
+        }
+
+        return mail($to, $subject, $htmlBody, implode("\r\n", $headers));
+    }
+
+    /**
+     * Send email with PDF attachment using multipart MIME (mail() fallback only)
      */
     private function sendWithAttachment(string $to, string $subject, string $htmlBody, string $textBody, array $baseHeaders, string $pdfBase64, string $filename): bool
     {

--- a/composer.lock
+++ b/composer.lock
@@ -1254,35 +1254,37 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v8.0.5",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e3422806e6f6760dbed0ddbc0a7fbfb6b5ce96bb"
+                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e3422806e6f6760dbed0ddbc0a7fbfb6b5ce96bb",
-                "reference": "e3422806e6f6760dbed0ddbc0a7fbfb6b5ce96bb",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/446d0db2b1f21575f1284b74533e425096abdfb6",
+                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
-                "doctrine/dbal": "<4.3"
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
             },
             "require-dev": {
-                "doctrine/dbal": "^4.3",
+                "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^7.4|^8.0",
-                "symfony/clock": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/expression-language": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/mime": "^7.4|^8.0",
-                "symfony/rate-limiter": "^7.4|^8.0"
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1310,7 +1312,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v8.0.5"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -1330,7 +1332,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:18:07+00:00"
+            "time": "2026-01-27T16:16:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/contact-us/contact_process.php
+++ b/contact-us/contact_process.php
@@ -1,12 +1,53 @@
 <?php
 
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../smtp_mailer.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->safeLoad();
+
 /**
  * Processes the contact form submission and sends an email
  *
  * @return array Result with 'success', 'message', and 'form_data' keys
  */
+function check_rate_limit()
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+
+    $max_submissions = 3;
+    $window_seconds = 600; // 10 minutes
+    $now = time();
+
+    if (!isset($_SESSION['contact_submissions'])) {
+        $_SESSION['contact_submissions'] = [];
+    }
+
+    // Remove entries older than the window
+    $_SESSION['contact_submissions'] = array_filter(
+        $_SESSION['contact_submissions'],
+        function ($timestamp) use ($now, $window_seconds) {
+            return ($now - $timestamp) < $window_seconds;
+        }
+    );
+
+    if (count($_SESSION['contact_submissions']) >= $max_submissions) {
+        return false;
+    }
+
+    $_SESSION['contact_submissions'][] = $now;
+    return true;
+}
+
 function process_contact_form()
 {
+    // Rate limit check
+    if (!check_rate_limit()) {
+        return ['success' => false, 'message' => 'Too many submissions. Please wait a few minutes before trying again.', 'form_data' => []];
+    }
+
     // Get form data
     $firstName = isset($_POST['firstName']) ? trim($_POST['firstName']) : '';
     $lastName = isset($_POST['lastName']) ? trim($_POST['lastName']) : '';
@@ -42,16 +83,32 @@ function process_contact_form()
     $email_subject = "Argo Books Contact: {$firstName} {$lastName}";
     $email_html = get_contact_email_template($firstName, $lastName, $email, $subject_label, $message);
 
-    $headers = [
-        'MIME-Version: 1.0',
-        'Content-Type: text/html; charset=UTF-8',
-        'From: Argo Books Website <noreply@argorobots.com>',
-        'Reply-To: ' . $email,
-        'X-Mailer: PHP/' . phpversion()
-    ];
-
     $to_email = 'contact@argorobots.com';
-    $mail_result = mail($to_email, $email_subject, $email_html, implode("\r\n", $headers));
+
+    // Use SMTP relay if configured, otherwise fall back to mail()
+    $mailer = create_smtp_mailer();
+    if ($mailer) {
+        try {
+            $mailer->addAddress($to_email);
+            $mailer->addReplyTo($email);
+            $mailer->Subject = $email_subject;
+            $mailer->Body = $email_html;
+            $mailer->send();
+            $mail_result = true;
+        } catch (\Exception $e) {
+            error_log("SMTP contact form email failed: " . $e->getMessage());
+            $mail_result = false;
+        }
+    } else {
+        $headers = [
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'From: Argo Books Website <noreply@argorobots.com>',
+            'Reply-To: ' . $email,
+            'X-Mailer: PHP/' . phpversion()
+        ];
+        $mail_result = mail($to_email, $email_subject, $email_html, implode("\r\n", $headers));
+    }
 
     if ($mail_result) {
         return ['success' => true];

--- a/contact-us/index.php
+++ b/contact-us/index.php
@@ -160,7 +160,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   </section>
 
   <!-- Contact Form Section -->
-  <section class="contact-form-section">
+  <section class="contact-form-section" id="contact">
     <div class="container">
       <div class="form-wrapper animate-on-scroll">
         <div class="form-header">
@@ -179,7 +179,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
         <?php endif; ?>
 
-        <form action="" method="POST" id="contact-form" autocomplete="off">
+        <form action="#contact" method="POST" id="contact-form" autocomplete="off">
           <div class="form-row">
             <div class="form-group">
               <label for="firstName">First Name</label>
@@ -281,6 +281,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       document.querySelectorAll('.animate-on-scroll').forEach(el => {
         observer.observe(el);
       });
+
     });
   </script>
 </body>

--- a/email_sender.php
+++ b/email_sender.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/smtp_mailer.php';
+
 /**
  * Base function to send an email with standard Argo styling
  *
@@ -51,6 +53,22 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
         </body>
         </html>
         HTML;
+
+    // Use SMTP relay if configured, otherwise fall back to mail()
+    $mailer = create_smtp_mailer();
+    if ($mailer) {
+        try {
+            $mailer->addAddress($to_email);
+            $mailer->addReplyTo('support@argorobots.com');
+            $mailer->Subject = $subject;
+            $mailer->Body = $email_html;
+            $mailer->send();
+            return true;
+        } catch (\Exception $e) {
+            error_log("SMTP email failed for {$to_email}: " . $e->getMessage());
+            return false;
+        }
+    }
 
     $headers = [
         'MIME-Version: 1.0',

--- a/smtp_mailer.php
+++ b/smtp_mailer.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+/**
+ * Create a PHPMailer instance configured with SMTP settings from environment variables.
+ * Returns null if SMTP is not configured (SMTP_HOST not set), allowing callers to
+ * fall back to PHP's mail() function.
+ *
+ * Required .env variables for SMTP:
+ *   SMTP_HOST     - SMTP server hostname (e.g. smtp-relay.brevo.com)
+ *   SMTP_PORT     - SMTP port (default: 587)
+ *   SMTP_USERNAME - SMTP login username
+ *   SMTP_PASSWORD - SMTP login password
+ *
+ * Optional:
+ *   SMTP_FROM_EMAIL - Default sender email (default: noreply@argorobots.com)
+ *   SMTP_FROM_NAME  - Default sender name (default: Argo Books)
+ */
+function create_smtp_mailer()
+{
+    $host = $_ENV['SMTP_HOST'] ?? getenv('SMTP_HOST') ?: '';
+
+    if (empty($host)) {
+        return null;
+    }
+
+    if (!class_exists('PHPMailer\PHPMailer\PHPMailer')) {
+        error_log('PHPMailer not installed — falling back to mail(). Run composer install.');
+        return null;
+    }
+
+    $mail = new PHPMailer(true);
+    $mail->isSMTP();
+    $mail->Host       = $host;
+    $mail->SMTPAuth   = true;
+    $mail->AuthType   = 'LOGIN';
+    $mail->Username   = $_ENV['SMTP_USERNAME'] ?? getenv('SMTP_USERNAME') ?: '';
+    $mail->Password   = $_ENV['SMTP_PASSWORD'] ?? getenv('SMTP_PASSWORD') ?: '';
+    $port = (int) ($_ENV['SMTP_PORT'] ?? getenv('SMTP_PORT') ?: 587);
+    $mail->Port       = $port;
+    $mail->SMTPSecure = $port === 465 ? PHPMailer::ENCRYPTION_SMTPS : PHPMailer::ENCRYPTION_STARTTLS;
+    $mail->CharSet    = 'UTF-8';
+    $mail->isHTML(true);
+
+    $fromEmail = $_ENV['SMTP_FROM_EMAIL'] ?? getenv('SMTP_FROM_EMAIL') ?: 'noreply@argorobots.com';
+    $fromName  = $_ENV['SMTP_FROM_NAME'] ?? getenv('SMTP_FROM_NAME') ?: 'Argo Books';
+    $mail->setFrom($fromEmail, $fromName);
+
+    return $mail;
+}


### PR DESCRIPTION
## Summary
This PR adds SMTP relay support (via Brevo) to the email sending infrastructure while maintaining backward compatibility with PHP's native `mail()` function as a fallback. A new `smtp_mailer.php` module provides centralized SMTP configuration, and all email-sending components have been updated to use SMTP when available.

## Key Changes

- **New SMTP Mailer Module** (`smtp_mailer.php`): Created a centralized `create_smtp_mailer()` function that:
  - Reads SMTP configuration from environment variables (SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD)
  - Returns a configured PHPMailer instance when SMTP is available
  - Returns `null` if SMTP is not configured, enabling graceful fallback to `mail()`
  - Handles missing PHPMailer dependency with appropriate logging

- **Invoice Email Sender** (`api/invoice/invoice_email_sender.php`):
  - Refactored `send()` method to attempt SMTP relay first, then fall back to `mail()`
  - Extracted email sending logic into two new methods: `sendViaSMTP()` and `sendViaMail()`
  - Updated logging to track which delivery method was used
  - Improved PDF attachment handling for SMTP (base64 decoding)

- **Contact Form Processing** (`contact-us/contact_process.php`):
  - Added rate limiting to prevent spam (3 submissions per 10 minutes per session)
  - Integrated SMTP relay with fallback to `mail()`
  - Added proper error handling and logging for SMTP failures
  - Loads environment variables via Dotenv

- **Generic Email Sender** (`email_sender.php`):
  - Updated `send_styled_email()` to use SMTP relay when available
  - Maintains `mail()` fallback for backward compatibility

- **Contact Form UI** (`contact-us/index.php`):
  - Added `id="contact"` anchor to contact form section
  - Updated form action to post to `#contact` for better UX after submission

## Implementation Details

- All SMTP configuration is environment-based, requiring no code changes for different deployments
- The fallback mechanism ensures the application continues to work even if PHPMailer is not installed or SMTP is not configured
- Rate limiting on contact form uses PHP sessions to track submission timestamps
- Error handling includes proper exception catching and logging for SMTP failures

https://claude.ai/code/session_01WkqUijy6Yub2twxStrsrZK