### PR TITLE
Add company logo upload and delete API endpoints

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -196,6 +196,9 @@ php_value error_log error_log.txt
     # Portal API: registration
     RewriteRule ^api/portal/register/?$ api/portal/register.php [L,QSA]
 
+    # Portal API: company logo upload/delete
+    RewriteRule ^api/portal/logo/?$ api/portal/logo.php [L,QSA]
+
     # Portal API: status check
     RewriteRule ^api/portal/status/?$ api/portal/status.php [L,QSA]
 

--- a/api/portal/logo.php
+++ b/api/portal/logo.php
@@ -28,6 +28,11 @@ if (!$company) {
 $companyId = $company['id'];
 $logosDir = __DIR__ . '/../../resources/uploads/logos';
 
+// Ensure the logos directory exists
+if (!is_dir($logosDir)) {
+    mkdir($logosDir, 0755, true);
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
     // --- Delete the current logo ---
     delete_logo_file($company['company_logo_url'], $logosDir);

--- a/api/portal/logo.php
+++ b/api/portal/logo.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Portal Company Logo API Endpoint
+ *
+ * POST   /api/portal/logo - Upload or replace the company logo
+ * DELETE /api/portal/logo - Remove the company logo
+ *
+ * Requires API key authentication (Argo Books -> Server).
+ *
+ * POST expects a multipart/form-data request with a 'logo' file field.
+ * Accepted formats: PNG, JPEG, GIF, WebP, BMP, SVG.
+ * Max file size: 2MB.
+ *
+ * On upload, any existing logo file is deleted from disk before saving the new one.
+ */
+
+require_once __DIR__ . '/portal-helper.php';
+
+set_portal_headers();
+require_method(['POST', 'DELETE']);
+
+// Authenticate the request
+$company = authenticate_portal_request();
+if (!$company) {
+    send_error_response(401, 'Invalid or missing API key.', 'UNAUTHORIZED');
+}
+
+$companyId = $company['id'];
+$logosDir = __DIR__ . '/../../resources/uploads/logos';
+
+if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
+    // --- Delete the current logo ---
+    delete_logo_file($company['company_logo_url'], $logosDir);
+
+    $db = get_db_connection();
+    $stmt = $db->prepare('UPDATE portal_companies SET company_logo_url = NULL WHERE id = ?');
+    $stmt->bind_param('i', $companyId);
+    $stmt->execute();
+    $stmt->close();
+    $db->close();
+
+    send_json_response(200, [
+        'success' => true,
+        'message' => 'Logo removed successfully',
+        'timestamp' => date('c')
+    ]);
+}
+
+// --- POST: Upload / replace logo ---
+
+// Validate file presence
+if (!isset($_FILES['logo']) || $_FILES['logo']['error'] !== UPLOAD_ERR_OK) {
+    $errorCode = isset($_FILES['logo']) ? $_FILES['logo']['error'] : 'no_file';
+    send_error_response(400, 'No logo file uploaded or upload error (code: ' . $errorCode . ').', 'UPLOAD_ERROR');
+}
+
+$file = $_FILES['logo'];
+
+// Validate file size (2MB max)
+$maxSize = 2 * 1024 * 1024;
+if ($file['size'] > $maxSize) {
+    send_error_response(400, 'Logo file too large. Maximum size is 2MB.', 'FILE_TOO_LARGE');
+}
+
+// Validate MIME type
+$allowedMimes = [
+    'image/png'     => 'png',
+    'image/jpeg'    => 'jpg',
+    'image/gif'     => 'gif',
+    'image/webp'    => 'webp',
+    'image/bmp'     => 'bmp',
+    'image/svg+xml' => 'svg',
+];
+
+$finfo = new finfo(FILEINFO_MIME_TYPE);
+$detectedMime = $finfo->file($file['tmp_name']);
+
+if (!isset($allowedMimes[$detectedMime])) {
+    send_error_response(400, 'Invalid file type: ' . $detectedMime . '. Allowed: PNG, JPEG, GIF, WebP, BMP, SVG.', 'INVALID_FILE_TYPE');
+}
+
+$extension = $allowedMimes[$detectedMime];
+
+// For SVG files, do a basic safety check (no script tags)
+if ($extension === 'svg') {
+    $svgContent = file_get_contents($file['tmp_name']);
+    if (preg_match('/<script/i', $svgContent) || preg_match('/on\w+\s*=/i', $svgContent)) {
+        send_error_response(400, 'SVG file contains potentially unsafe content.', 'UNSAFE_SVG');
+    }
+}
+
+// Delete the old logo file if one exists
+delete_logo_file($company['company_logo_url'], $logosDir);
+
+// Generate a unique filename: {companyId}_{random}.{ext}
+$randomHash = bin2hex(random_bytes(8));
+$filename = $companyId . '_' . $randomHash . '.' . $extension;
+$destPath = $logosDir . '/' . $filename;
+
+// Save the file
+if (!move_uploaded_file($file['tmp_name'], $destPath)) {
+    send_error_response(500, 'Failed to save logo file.', 'SAVE_ERROR');
+}
+
+// Build the public URL path
+$baseUrl = rtrim($_ENV['APP_URL'] ?? 'https://argorobots.com', '/');
+$logoUrl = $baseUrl . '/resources/uploads/logos/' . $filename;
+
+// Update the database
+$db = get_db_connection();
+$stmt = $db->prepare('UPDATE portal_companies SET company_logo_url = ? WHERE id = ?');
+$stmt->bind_param('si', $logoUrl, $companyId);
+$stmt->execute();
+$stmt->close();
+$db->close();
+
+send_json_response(200, [
+    'success' => true,
+    'message' => 'Logo uploaded successfully',
+    'logo_url' => $logoUrl,
+    'timestamp' => date('c')
+]);
+
+/**
+ * Delete a logo file from disk given its URL.
+ *
+ * @param string|null $logoUrl The full URL or path stored in the database
+ * @param string $logosDir Absolute path to the logos directory
+ */
+function delete_logo_file(?string $logoUrl, string $logosDir): void
+{
+    if (empty($logoUrl)) {
+        return;
+    }
+
+    // Extract the filename from the URL
+    // URL format: https://argorobots.com/resources/uploads/logos/5_a1b2c3d4.png
+    $basename = basename(parse_url($logoUrl, PHP_URL_PATH));
+
+    // Safety: only delete files that match our expected naming pattern
+    if (!preg_match('/^\d+_[a-f0-9]+\.\w+$/', $basename)) {
+        return;
+    }
+
+    $filePath = $logosDir . '/' . $basename;
+    if (file_exists($filePath)) {
+        unlink($filePath);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a new Portal API endpoint for managing company logos, allowing authenticated users to upload, replace, and delete company logos with comprehensive validation and security checks.

## Key Changes
- **New API endpoint** (`/api/portal/logo`):
  - `POST` - Upload or replace a company logo
  - `DELETE` - Remove the company logo
  - Requires API key authentication via the existing portal authentication system

- **File validation**:
  - Accepts PNG, JPEG, GIF, WebP, BMP, and SVG formats
  - Enforces 2MB maximum file size
  - Uses `finfo` for MIME type detection to prevent spoofed file types
  - Includes SVG safety checks to prevent script injection attacks

- **File management**:
  - Generates unique filenames using company ID and random hash to prevent collisions
  - Automatically deletes old logo files when uploading a replacement
  - Stores files in `resources/uploads/logos/` directory
  - Constructs public URLs using the `APP_URL` environment variable

- **Database integration**:
  - Updates `portal_companies.company_logo_url` with the public logo URL on upload
  - Sets `company_logo_url` to NULL on deletion

- **Infrastructure**:
  - Added `.htaccess` rewrite rule to route logo API requests
  - Created `.gitkeep` in logos directory to ensure directory structure is tracked

## Notable Implementation Details
- The `delete_logo_file()` helper function safely extracts filenames from URLs and validates them against an expected naming pattern before deletion
- Proper error handling with specific error codes for different failure scenarios (upload errors, file size, invalid type, unsafe SVG)
- Comprehensive response messages with timestamps for audit trail purposes

https://claude.ai/code/session_01HNA1YeftzrkA3EtCunHDWR