### PR TITLE
Add automated FTP deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -20,7 +21,7 @@ jobs:
       - name: Deploy to FTP server
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
-          server: ${{ secrets.FTP_SERVER }}
+          server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           server-dir: ${{ secrets.FTP_SERVER_DIR }}
@@ -30,6 +31,8 @@ jobs:
             **/.github*
             **/.github*/**
             .gitignore
+            README.md
+            read-me/**
             composer.json
             composer.lock
             mysql_schema.sql

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to FTP Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy via FTP
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PHP dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction
+
+      - name: Deploy to FTP server
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          server-dir: ${{ secrets.FTP_SERVER_DIR }}
+          exclude: |
+            **/.git*
+            **/.git*/**
+            **/.github*
+            **/.github*/**
+            .gitignore
+            composer.json
+            composer.lock
+            mysql_schema.sql


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow to automate deployment of the application to an FTP server whenever changes are pushed to the main branch.

## Key Changes
- Added `.github/workflows/deploy.yml` workflow file that:
  - Triggers automatically on pushes to the `main` branch or manually via `workflow_dispatch`
  - Checks out the repository code
  - Installs PHP dependencies using Composer (production-only, optimized)
  - Deploys the application to the FTP server using the SamKirkland FTP-Deploy-Action

## Implementation Details
- **Excluded files/directories** from deployment:
  - Git-related files (`.git`, `.gitignore`, `.github`)
  - Development files (`README.md`, `composer.json`, `composer.lock`)
  - Database schema (`mysql_schema.sql`)
  - Documentation directory (`read-me/`)
- **Credentials** are securely managed via GitHub Secrets (`FTP_HOST`, `FTP_USERNAME`, `FTP_PASSWORD`, `FTP_SERVER_DIR`)
- Uses Composer's `--no-dev` flag to exclude development dependencies from the deployed application

https://claude.ai/code/session_01UgcytJm77rAqvBPnQZdJTX