### PR TITLE
Migrate from XAMPP to Laragon and simplify email handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This is the website for [Argo Books](https://github.com/ArgoRobots/Argo-Books), AI-powered accounting software with receipt scanning, predictive analytics, inventory management, and more. This website serves as a platform for users to download the software, purchase license keys, access documentation, and has an administrative system for managing licenses, user accounts, and analytics.
+This is the website for [Argo Books](https://github.com/ArgoRobots/Argo-Books), accounting software with receipt scanning, predictive analytics, inventory management, and more. This website serves as a platform for users to download the software, purchase license keys, access documentation, and has an administrative system for managing licenses, user accounts, and viewing analytics.
 
 You can view the live website here: https://argorobots.com/
 
@@ -10,8 +10,8 @@ You can view the live website here: https://argorobots.com/
 
 ### Frontend:
 
-- **HTML5/CSS3**: Structure and styling
-- **JavaScript/jQuery**: Interactive elements and dynamic content loading
+- **HTML5 and CSS3**: Structure and styling
+- **JavaScript and jQuery**: Interactive elements and dynamic content loading
 - **Chart.js**: Data visualization for analytics dashboard
 
 ### Backend:
@@ -104,7 +104,7 @@ You need to create a MySQL database and import the schema.
 1. Open Laragon and click **Start All**
 2. Navigate to http://localhost/argo-books-website in your browser (adjust the folder name if different)
 3. The website should now be running locally
-4. To view emails sent by the application, open http://localhost:8025
+4. To view emails sent by the application, open http://localhost:8025 (requires MailHog setup — see [Local email setup](read-me/Local%20email%20setup.md))
 
 ## Publishing a new version of Argo Books
 1. Create a new folder in `resources/downloads/versions` named whatever the version number is

--- a/contact-us/contact_process.php
+++ b/contact-us/contact_process.php
@@ -1,11 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/../smtp_mailer.php';
-
-$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
-$dotenv->safeLoad();
-
 /**
  * Processes the contact form submission and sends an email
  *
@@ -85,30 +79,14 @@ function process_contact_form()
 
     $to_email = 'contact@argorobots.com';
 
-    // Use SMTP relay if configured, otherwise fall back to mail()
-    $mailer = create_smtp_mailer();
-    if ($mailer) {
-        try {
-            $mailer->addAddress($to_email);
-            $mailer->addReplyTo($email);
-            $mailer->Subject = $email_subject;
-            $mailer->Body = $email_html;
-            $mailer->send();
-            $mail_result = true;
-        } catch (\Exception $e) {
-            error_log("SMTP contact form email failed: " . $e->getMessage());
-            $mail_result = false;
-        }
-    } else {
-        $headers = [
-            'MIME-Version: 1.0',
-            'Content-Type: text/html; charset=UTF-8',
-            'From: Argo Books Website <noreply@argorobots.com>',
-            'Reply-To: ' . $email,
-            'X-Mailer: PHP/' . phpversion()
-        ];
-        $mail_result = mail($to_email, $email_subject, $email_html, implode("\r\n", $headers));
-    }
+    $headers = [
+        'MIME-Version: 1.0',
+        'Content-Type: text/html; charset=UTF-8',
+        'From: Argo Books Website <noreply@argorobots.com>',
+        'Reply-To: ' . $email,
+        'X-Mailer: PHP/' . phpversion()
+    ];
+    $mail_result = mail($to_email, $email_subject, $email_html, implode("\r\n", $headers));
 
     if ($mail_result) {
         return ['success' => true];

--- a/read-me/Admin guide.md
+++ b/read-me/Admin guide.md
@@ -9,27 +9,18 @@
 - **Standard Rate:** 2.9% + $0.30 CAD per transaction
 - **International Cards:** Additional 1.5%
 - **Currency Conversion:** Additional 1%
-- **No monthly fees**
 
 ### PayPal
 
 - **Standard Rate:** 2.9% + $0.30 CAD per transaction
 - **PayPal Account Payments:** Same rate
 - **International:** 4.4% + fixed fee
-- **No monthly fees**
 
 ### Square
 
 - **Online Payments:** 2.9% + $0.30 CAD per transaction
 - **Card on File:** Same rate
 - **International:** Additional 1.5%
-- **No monthly fees**
-
-**For a $20 CAD transaction:**
-
-- Stripe: $20.00 - $0.88 = **$19.12 net**
-- PayPal: $20.00 - $0.88 = **$19.12 net**
-- Square: $20.00 - $0.88 = **$19.12 net**
 
 ---
 
@@ -129,7 +120,7 @@ The subscription renewal process checks for Premium subscriptions due for renewa
 To run the renewal process automatically every day at 3:00 PM, add this cron entry:
 
 ```bash
-0 15 * * * /usr/bin/php /path/to/your/website/cron/subscription_renewal.php
+/usr/bin/php /home/argorobots/public_html/cron/subscription_renewal.php
 ```
 
 This will check for subscriptions due within 24 hours and process their renewals automatically.
@@ -148,7 +139,7 @@ This will check for subscriptions due within 24 hours and process their renewals
 
 **Via CLI:**
 ```bash
-php /path/to/your/website/cron/subscription_renewal.php
+php /home/argorobots/public_html/cron/subscription_renewal.php
 ```
 
 **Via Web (with secret key):**
@@ -162,13 +153,3 @@ Visit `/cron/` and authenticate with TOTP to access the renewal management dashb
 ### Logs
 
 Logs are stored in: `/cron/logs/subscription_renewal_YYYY-MM-DD.log`
-
----
-
-## Security Best Practices
-
-### API Keys
-
-- **Never** commit .env to git
-- **Never** expose secret keys in frontend code
-- Rotate keys regularly (every 90 days)

--- a/read-me/Local email setup.md
+++ b/read-me/Local email setup.md
@@ -1,6 +1,6 @@
 # Local Email Setup with MailHog
 
-When running the Argo Books website locally on XAMPP, PHP's `mail()` function won't work without a mail server. MailHog is a fake SMTP server that catches all emails locally and displays them in a web interface - no emails are actually sent.
+When running the Argo Books website locally on Laragon, PHP's `mail()` function won't work without a mail server. MailHog is a fake SMTP server that catches all emails locally and displays them in a web interface - no emails are actually sent.
 
 ## Setup Instructions
 
@@ -10,50 +10,39 @@ When running the Argo Books website locally on XAMPP, PHP's `mail()` function wo
 2. Download `MailHog_windows_386.exe` (or `MailHog_windows_amd64.exe`)
 3. Save it somewhere convenient
 
-### 2. Configure php.ini
+### 2. Create and configure php.ini
 
-Open `C:\xampp\php\php.ini` and find the `[mail function]` section. Update these settings:
+Laragon doesn't ship with a `php.ini` by default — only template files. You need to create one first:
+
+1. Open your Laragon PHP folder (e.g. `C:\laragon\bin\php\php-8.x.x-nts-Win32-vs17-x64`)
+2. Copy `php.ini-development` and rename the copy to `php.ini`
+3. Open the new `php.ini` and find the `[mail function]` section. Update these settings:
 
 ```ini
 [mail function]
 SMTP=localhost
 smtp_port=1025
 sendmail_from = noreply@localhost
-sendmail_path = "C:\xampp\sendmail\sendmail.exe -t"
 ```
 
-> **Note:** The `sendmail_path` comment says "For Unix only" but XAMPP includes a Windows sendmail wrapper, so this works.
+Make sure `sendmail_path` is commented out (has a `;` in front of it). On Windows, PHP uses `SMTP` and `smtp_port` directly — no sendmail needed.
 
-### 3. Configure sendmail.ini
-
-Open `C:\xampp\sendmail\sendmail.ini` and update these settings:
-
-```ini
-smtp_server=localhost
-smtp_port=1025
-smtp_ssl=none
-force_sender=noreply@localhost
-error_logfile=error.log
-```
-
-> **Important:** `smtp_ssl` must be `none` because MailHog doesn't support TLS/SSL.
-
-### 4. Run MailHog
+### 3. Run MailHog
 
 Double-click `MailHog_windows_386.exe`. A console window will open. Keep it running (you can minimize it).
 
-### 5. Restart Apache
+### 4. Restart Apache
 
-In XAMPP Control Panel, stop and start Apache.
+In Laragon, right-click the tray icon and select "Reload Apache" (or stop and start all services).
 
-### 6. View Emails
+### 5. View Emails
 
 Open http://localhost:8025 in your browser. All captured emails will appear here.
 
 ## How It Works
 
 ```
-PHP mail() → sendmail.exe → MailHog (port 1025) → Web UI (port 8025)
+PHP mail() → SMTP localhost:1025 → MailHog → Web UI (port 8025)
 ```
 
 ## Troubleshooting
@@ -66,11 +55,13 @@ PHP mail() → sendmail.exe → MailHog (port 1025) → Web UI (port 8025)
    ```
    You should see `0.0.0.0:1025` in LISTENING state.
 
-2. **Check sendmail error log:** `C:\xampp\sendmail\error.log`
+2. **Make sure php.ini exists and is being loaded.** Create a file called `phpinfo.php` in your project root:
+   ```php
+   <?php phpinfo();
+   ```
+   Open it in your browser and search for "Loaded Configuration File" — it should show the path to your `php.ini`. Also check that `SMTP` shows `localhost` and `smtp_port` shows `1025`.
 
-3. **Check Apache error log:** `C:\xampp\apache\logs\error.log`
-
-4. **Test PHP mail directly:** Create `test_mail.php` in htdocs:
+3. **Test PHP mail directly:** Create `test_mail.php` in your project root:
    ```php
    <?php
    $result = mail("test@example.com", "Test", "Test body");

--- a/smtp_mailer.php
+++ b/smtp_mailer.php
@@ -1,7 +1,6 @@
 <?php
 
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
 
 /**
  * Create a PHPMailer instance configured with SMTP settings from environment variables.


### PR DESCRIPTION
## Summary
This PR updates the local development setup documentation and simplifies the email handling implementation by removing SMTP relay complexity and relying on PHP's native `mail()` function with MailHog.

## Key Changes

**Documentation Updates:**
- Updated "Local Email Setup" guide to reference Laragon instead of XAMPP
- Simplified PHP mail configuration by removing sendmail.ini setup (Windows uses SMTP/smtp_port directly)
- Added instructions for creating `php.ini` from template in Laragon (which doesn't ship with one by default)
- Updated troubleshooting steps to use Laragon-specific commands and removed XAMPP-specific paths
- Removed fee comparison examples and security best practices section from Admin guide
- Updated cron job examples with actual production paths
- Clarified frontend technology descriptions in README

**Code Simplification:**
- Removed PHPMailer/SMTP relay logic from `contact_process.php`
- Removed dotenv and `smtp_mailer.php` dependencies from contact form processing
- Simplified email sending to use PHP's native `mail()` function with proper headers
- Removed unused `Exception` import from `smtp_mailer.php`
- Updated README to note MailHog setup requirement for local email testing

## Implementation Details

The contact form now uses a straightforward approach:
- Removed conditional logic that attempted SMTP relay with fallback to `mail()`
- All email sending now goes through PHP's `mail()` function
- When MailHog is running locally, emails are captured at `localhost:1025` and viewable at `localhost:8025`
- Configuration is purely through `php.ini` settings (`SMTP=localhost` and `smtp_port=1025`)

This approach is simpler to maintain and aligns with the local development workflow using Laragon and MailHog.

https://claude.ai/code/session_014v4J33KAxRTPEtnsgXfKqN