### PR TITLE
Implement device-based license key system

### DIFF
--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -290,6 +290,32 @@ include '../admin_header.php';
 <link rel="stylesheet" href="../search.css">
 <link rel="stylesheet" href="../../resources/styles/checkbox.css">
 
+<style>
+.btn-copy {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #6b7280;
+    background: #f3f4f6;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    cursor: pointer;
+    vertical-align: middle;
+    transition: all 0.15s ease;
+}
+.btn-copy:hover {
+    background: #e5e7eb;
+    color: #374151;
+}
+.btn-copy.copied {
+    background: #d1fae5;
+    color: #065f46;
+    border-color: #6ee7b7;
+}
+</style>
+
 <script>
     const subscriptionChartData = <?php echo json_encode($subscription_chart_data); ?>;
 </script>
@@ -550,7 +576,10 @@ include '../admin_header.php';
                                                 </div>
                                             <?php endif; ?>
                                         </td>
-                                        <td class="key-field"><?php echo htmlspecialchars($key['subscription_key']); ?></td>
+                                        <td class="key-field">
+                                            <?php echo htmlspecialchars($key['subscription_key']); ?>
+                                            <button type="button" class="btn-copy" onclick="copyToClipboard('<?php echo htmlspecialchars($key['subscription_key'], ENT_QUOTES); ?>', this)" title="Copy key">Copy</button>
+                                        </td>
                                         <td><?php echo $key['duration_months'] == 0 ? '<span style="color:#8b5cf6;font-weight:500;">Permanent</span>' : $key['duration_months'] . ' month' . ($key['duration_months'] > 1 ? 's' : ''); ?></td>
                                         <td><?php echo $key['email'] ? htmlspecialchars($key['email']) : '<span style="color:#9ca3af;">Any user</span>'; ?></td>
                                         <td>
@@ -574,6 +603,17 @@ include '../admin_header.php';
 </div>
 
 <script>
+function copyToClipboard(text, btn) {
+    navigator.clipboard.writeText(text).then(function() {
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(function() {
+            btn.textContent = 'Copy';
+            btn.classList.remove('copied');
+        }, 1500);
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     // Tab switching
     const tabs = document.querySelectorAll('.section-tab');

--- a/api/license/redeem.php
+++ b/api/license/redeem.php
@@ -4,12 +4,12 @@ header('Content-Type: application/json');
 
 require_once __DIR__ . '/../../license_functions.php';
 require_once __DIR__ . '/../../db_connect.php';
-require_once __DIR__ . '/../../email_sender.php';
 
 // Initialize response array
 $response = [
     'success' => false,
-    'message' => 'Invalid request method'
+    'status' => 'error',
+    'message' => 'Invalid request method.'
 ];
 
 // Only allow POST requests
@@ -18,59 +18,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
 
     $premium_key = trim($data['premium_key'] ?? '');
-    $user_id = intval($data['user_id'] ?? 0);
-    $email = trim($data['email'] ?? '');
+    $device_id = trim($data['device_id'] ?? '');
 
     if (empty($premium_key)) {
         $response = [
             'success' => false,
+            'status' => 'error',
             'message' => 'Premium key is required.'
         ];
-    } elseif ($user_id <= 0) {
+    } elseif (empty($device_id)) {
         $response = [
             'success' => false,
-            'message' => 'Valid user ID is required.'
-        ];
-    } elseif (empty($email)) {
-        $response = [
-            'success' => false,
-            'message' => 'Email is required.'
+            'status' => 'error',
+            'message' => 'Device ID is required.'
         ];
     } else {
-        // Verify user exists
-        try {
-            $stmt = $pdo->prepare("SELECT id, email, username FROM community_users WHERE id = ?");
-            $stmt->execute([$user_id]);
-            $user = $stmt->fetch(PDO::FETCH_ASSOC);
-
-            if (!$user) {
-                $response = [
-                    'success' => false,
-                    'message' => 'Invalid user.'
-                ];
-            } else {
-                $response = redeem_premium_key($premium_key, $user_id, $email);
-
-                // Send redemption confirmation email on success
-                if ($response['success']) {
-                    send_premium_key_redeemed_email(
-                        $email,
-                        $user['username'],
-                        $premium_key,
-                        $response['subscription_id'],
-                        $response['duration_months'],
-                        date('Y-m-d H:i:s'),
-                        $response['end_date']
-                    );
-                }
-            }
-        } catch (PDOException $e) {
-            error_log("Redeem endpoint error: " . $e->getMessage());
-            $response = [
-                'success' => false,
-                'message' => 'Error processing request. Please try again.'
-            ];
-        }
+        $response = redeem_premium_key($premium_key, $device_id);
     }
 }
 

--- a/api/license/validate.php
+++ b/api/license/validate.php
@@ -8,43 +8,26 @@ require_once __DIR__ . '/../../db_connect.php';
 // Initialize response array
 $response = [
     'success' => false,
-    'message' => 'Invalid request method'
+    'status' => 'error',
+    'message' => 'Invalid request method.'
 ];
 
 // Only allow POST requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Get the license key from the request
+    // Get the request data
     $data = json_decode(file_get_contents('php://input'), true);
 
-    // Check for Premium subscription key validation (active subscriptions)
-    if (isset($data['subscription_id'])) {
-        $subscription_id = trim($data['subscription_id']);
-        $response = validate_premium_subscription_key($subscription_id);
-    }
-    // Check for free/promo premium key validation
-    elseif (isset($data['premium_key'])) {
-        $premium_key = trim($data['premium_key']);
-        $response = validate_premium_key($premium_key);
-    }
-    // Check for license key validation (auto-detect type by prefix)
-    elseif (isset($data['license_key'])) {
-        $license_key = trim($data['license_key']);
-        $ip_address = $_SERVER['REMOTE_ADDR'];
+    $license_key = trim($data['license_key'] ?? '');
+    $device_id = trim($data['device_id'] ?? '');
 
-        // Validate key type based on prefix
-        if (str_starts_with($license_key, 'PREM-')) {
-            $response = validate_premium_key($license_key);
-        } else {
-            $response = [
-                'success' => false,
-                'message' => 'Invalid license key format.'
-            ];
-        }
-    } else {
+    if (empty($license_key) || empty($device_id)) {
         $response = [
             'success' => false,
-            'message' => 'License key, subscription ID, or premium key is required.'
+            'status' => 'error',
+            'message' => 'License key and device ID are required.'
         ];
+    } else {
+        $response = validate_license($license_key, $device_id);
     }
 }
 

--- a/license_functions.php
+++ b/license_functions.php
@@ -113,7 +113,7 @@ function validate_premium_key($key) {
     try {
         $stmt = $pdo->prepare("
             SELECT subscription_key, email, duration_months, created_at,
-                redeemed_at, redeemed_by_user_id, subscription_id, notes
+                redeemed_at, redeemed_by_user_id, device_id, subscription_id, notes
             FROM premium_subscription_keys
             WHERE subscription_key = ?
         ");
@@ -160,40 +160,34 @@ function validate_premium_key($key) {
 }
 
 /**
- * Redeem a free/promo premium subscription key
- * Validates the key, creates a premium subscription, and marks the key as redeemed.
+ * Redeem a free/promo premium subscription key (device-based).
+ * On first redemption: validates the key, creates a premium subscription, and marks the key as redeemed.
+ * On re-redemption: allows transferring the key to a new device by updating device_id.
  *
  * @param string $key The premium subscription key to redeem
- * @param int $user_id The user ID redeeming the key
- * @param string $email The user's email address
+ * @param string $device_id The hashed machine identifier of the redeeming device
  * @return array Response array with redemption result
  */
-function redeem_premium_key($key, $user_id, $email) {
+function redeem_premium_key($key, $device_id) {
     global $pdo;
 
     // First validate the key
     $validation = validate_premium_key($key);
 
     if (!$validation['success']) {
-        return $validation;
+        return [
+            'success' => false,
+            'status' => 'invalid_key',
+            'message' => 'Invalid license key.'
+        ];
     }
 
+    // Key already redeemed — handle re-redemption (device transfer)
     if ($validation['status'] === 'redeemed') {
-        return [
-            'success' => false,
-            'message' => 'This premium key has already been redeemed.',
-            'redeemed_at' => $validation['redeemed_at']
-        ];
+        return _handle_re_redemption($key, $device_id, $validation['subscription_id']);
     }
 
-    // Check email restriction if set
-    if (!empty($validation['restricted_email']) && strtolower($validation['restricted_email']) !== strtolower($email)) {
-        return [
-            'success' => false,
-            'message' => 'This premium key is restricted to a different email address.'
-        ];
-    }
-
+    // First-time redemption
     $duration_months = $validation['duration_months'];
 
     try {
@@ -216,45 +210,43 @@ function redeem_premium_key($key, $user_id, $email) {
             $billingCycle = 'monthly';
         }
 
-        // Create the premium subscription
+        // Create the premium subscription (no user account — user_id and email are NULL)
         $stmt = $pdo->prepare("
             INSERT INTO premium_subscriptions (
-                subscription_id, user_id, email, billing_cycle, amount, currency,
+                subscription_id, billing_cycle, amount, currency,
                 start_date, end_date, status, payment_method, transaction_id,
                 auto_renew, created_at
             ) VALUES (
-                ?, ?, ?, ?, 0.00, 'CAD',
+                ?, ?, 0.00, 'CAD',
                 ?, ?, 'active', 'free_key', ?,
                 0, NOW()
             )
         ");
         $stmt->execute([
             $subscriptionId,
-            $user_id,
-            $email,
             $billingCycle,
             $startDate,
             $endDate,
             $key
         ]);
 
-        // Mark the key as redeemed
+        // Mark the key as redeemed with device_id
         $stmt = $pdo->prepare("
             UPDATE premium_subscription_keys
             SET redeemed_at = NOW(),
-                redeemed_by_user_id = ?,
+                device_id = ?,
                 subscription_id = ?
             WHERE subscription_key = ?
         ");
-        $stmt->execute([$user_id, $subscriptionId, $key]);
+        $stmt->execute([$device_id, $subscriptionId, $key]);
 
         $pdo->commit();
 
         return [
             'success' => true,
-            'type' => 'premium_key',
-            'status' => 'redeemed',
-            'message' => 'Premium key redeemed successfully.',
+            'type' => 'premium',
+            'status' => 'active',
+            'message' => 'License activated successfully!',
             'subscription_id' => $subscriptionId,
             'end_date' => $endDate,
             'duration_months' => $duration_months
@@ -265,7 +257,173 @@ function redeem_premium_key($key, $user_id, $email) {
         error_log("Premium key redemption error: " . $e->getMessage());
         return [
             'success' => false,
+            'status' => 'error',
             'message' => 'Error redeeming premium key. Please try again.'
+        ];
+    }
+}
+
+/**
+ * Handle re-redemption of an already-redeemed key (device transfer).
+ * If the subscription is still active, updates the device_id on the key.
+ * If the subscription is expired, returns an error.
+ *
+ * @param string $key The premium subscription key
+ * @param string $device_id The new device's hashed machine identifier
+ * @param string $subscription_id The subscription ID linked to this key
+ * @return array Response array
+ */
+function _handle_re_redemption($key, $device_id, $subscription_id) {
+    global $pdo;
+
+    try {
+        // Look up the linked subscription to check status/expiry
+        $stmt = $pdo->prepare("
+            SELECT subscription_id, status, end_date
+            FROM premium_subscriptions
+            WHERE subscription_id = ?
+        ");
+        $stmt->execute([$subscription_id]);
+        $subscription = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$subscription) {
+            return [
+                'success' => false,
+                'status' => 'error',
+                'message' => 'Linked subscription not found.'
+            ];
+        }
+
+        // Check if subscription has expired
+        $now = new DateTime();
+        $end_date = new DateTime($subscription['end_date']);
+
+        if ($subscription['status'] === 'expired' || $end_date <= $now) {
+            // Mark as expired if not already
+            if ($subscription['status'] !== 'expired') {
+                $stmt = $pdo->prepare("UPDATE premium_subscriptions SET status = 'expired' WHERE subscription_id = ?");
+                $stmt->execute([$subscription_id]);
+            }
+            return [
+                'success' => false,
+                'status' => 'expired',
+                'message' => "This license key's subscription has expired."
+            ];
+        }
+
+        // Subscription is still active — transfer to new device
+        $stmt = $pdo->prepare("
+            UPDATE premium_subscription_keys
+            SET device_id = ?
+            WHERE subscription_key = ?
+        ");
+        $stmt->execute([$device_id, $key]);
+
+        return [
+            'success' => true,
+            'type' => 'premium',
+            'status' => 'active',
+            'message' => 'License activated successfully!',
+            'subscription_id' => $subscription['subscription_id'],
+            'end_date' => $subscription['end_date'],
+        ];
+
+    } catch (PDOException $e) {
+        error_log("Premium key re-redemption error: " . $e->getMessage());
+        return [
+            'success' => false,
+            'status' => 'error',
+            'message' => 'Error redeeming premium key. Please try again.'
+        ];
+    }
+}
+
+/**
+ * Validate a license key against a device.
+ * Checks that the key exists, is redeemed, matches the device, and the subscription is active.
+ *
+ * @param string $key The premium subscription key to validate
+ * @param string $device_id The hashed machine identifier to check against
+ * @return array Response array with validation result
+ */
+function validate_license($key, $device_id) {
+    global $pdo;
+
+    try {
+        // Look up the key
+        $stmt = $pdo->prepare("
+            SELECT subscription_key, device_id, subscription_id, redeemed_at
+            FROM premium_subscription_keys
+            WHERE subscription_key = ?
+        ");
+        $stmt->execute([$key]);
+        $premium_key = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        // Key not found or not yet redeemed
+        if (!$premium_key || $premium_key['redeemed_at'] === null) {
+            return [
+                'success' => false,
+                'status' => 'invalid_key',
+                'message' => 'License key is not valid.'
+            ];
+        }
+
+        // Check device_id matches
+        if ($premium_key['device_id'] !== $device_id) {
+            return [
+                'success' => false,
+                'status' => 'wrong_device',
+                'message' => 'This license key is active on a different device.'
+            ];
+        }
+
+        // Look up the linked subscription
+        $stmt = $pdo->prepare("
+            SELECT subscription_id, status, end_date
+            FROM premium_subscriptions
+            WHERE subscription_id = ?
+        ");
+        $stmt->execute([$premium_key['subscription_id']]);
+        $subscription = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$subscription) {
+            return [
+                'success' => false,
+                'status' => 'invalid_key',
+                'message' => 'License key is not valid.'
+            ];
+        }
+
+        // Check if subscription has expired
+        $now = new DateTime();
+        $end_date = new DateTime($subscription['end_date']);
+
+        if ($subscription['status'] === 'expired' || $end_date <= $now) {
+            // Mark as expired if not already
+            if ($subscription['status'] !== 'expired') {
+                $stmt = $pdo->prepare("UPDATE premium_subscriptions SET status = 'expired' WHERE subscription_id = ?");
+                $stmt->execute([$premium_key['subscription_id']]);
+            }
+            return [
+                'success' => false,
+                'status' => 'expired',
+                'message' => 'Your premium subscription has expired.'
+            ];
+        }
+
+        // Key is valid, device matches, subscription active
+        return [
+            'success' => true,
+            'status' => 'valid',
+            'message' => 'License is valid.'
+        ];
+
+    } catch (PDOException $e) {
+        error_log("License validation error: " . $e->getMessage());
+        return [
+            'success' => false,
+            'status' => 'error',
+            'message' => 'Error validating license. Please try again.'
         ];
     }
 }

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -294,8 +294,8 @@ CREATE TABLE IF NOT EXISTS user_bans (
 CREATE TABLE IF NOT EXISTS premium_subscriptions (
     id INT PRIMARY KEY AUTO_INCREMENT,
     subscription_id VARCHAR(50) NOT NULL UNIQUE,
-    user_id INT NOT NULL,
-    email VARCHAR(100) NOT NULL,
+    user_id INT DEFAULT NULL,
+    email VARCHAR(100) DEFAULT NULL,
     billing_cycle ENUM('monthly', 'yearly') NOT NULL DEFAULT 'monthly',
     amount DECIMAL(10,2) NOT NULL,
     currency VARCHAR(3) NOT NULL DEFAULT 'CAD',
@@ -322,7 +322,6 @@ CREATE TABLE IF NOT EXISTS premium_subscriptions (
     INDEX idx_end_date (end_date),
     INDEX idx_premium_license (standard_license_key),
     INDEX idx_renewal (status, end_date, auto_renew),
-    FOREIGN KEY (user_id) REFERENCES community_users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Premium Subscription Payments table
@@ -352,6 +351,7 @@ CREATE TABLE IF NOT EXISTS premium_subscription_keys (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     redeemed_at DATETIME DEFAULT NULL,
     redeemed_by_user_id INT DEFAULT NULL,
+    device_id VARCHAR(255) DEFAULT NULL COMMENT 'Hashed machine identifier of redeeming device',
     subscription_id VARCHAR(50) DEFAULT NULL COMMENT 'Link to created subscription',
     notes TEXT DEFAULT NULL COMMENT 'Admin notes about this key',
     INDEX idx_subscription_key (subscription_key),
@@ -500,3 +500,22 @@ CREATE TABLE IF NOT EXISTS portal_payments (
     INDEX idx_created_at (created_at),
     FOREIGN KEY (company_id) REFERENCES portal_companies(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- Migration: Device-based license key system
+-- Run these statements on an existing database to apply the schema changes.
+-- ============================================================================
+
+-- Add device_id column to premium_subscription_keys
+-- ALTER TABLE premium_subscription_keys
+--   ADD COLUMN device_id VARCHAR(255) DEFAULT NULL COMMENT 'Hashed machine identifier of redeeming device'
+--   AFTER redeemed_by_user_id;
+
+-- Make user_id and email nullable for device-based subscriptions (no user account)
+-- ALTER TABLE premium_subscriptions
+--   MODIFY user_id INT DEFAULT NULL,
+--   MODIFY email VARCHAR(100) DEFAULT NULL;
+
+-- Drop the foreign key constraint on user_id
+-- (constraint name may vary — run SHOW CREATE TABLE premium_subscriptions to find the actual name)
+-- ALTER TABLE premium_subscriptions DROP FOREIGN KEY premium_subscriptions_ibfk_1;


### PR DESCRIPTION
## Summary
Refactored the premium license key system from user-account-based to device-based activation. License keys can now be redeemed on any device using a hashed machine identifier, with support for transferring keys between devices as long as the subscription remains active.

## Key Changes

- **Device-based redemption**: Changed `redeem_premium_key()` to accept `device_id` instead of `user_id` and `email`. Keys are now tied to devices rather than user accounts.

- **Re-redemption support**: Added `_handle_re_redemption()` function to allow transferring an already-redeemed key to a new device if the subscription is still active. Expired subscriptions cannot be transferred.

- **New license validation**: Added `validate_license()` function that checks:
  - Key exists and has been redeemed
  - Device ID matches the registered device
  - Subscription is active and not expired

- **Database schema updates**:
  - Added `device_id` column to `premium_subscription_keys` table
  - Made `user_id` and `email` nullable in `premium_subscriptions` table (device-based keys don't require user accounts)
  - Removed foreign key constraint on `user_id` in `premium_subscriptions`

- **API endpoint changes**:
  - `/api/license/redeem.php`: Now accepts `device_id` instead of `user_id` and `email`. Removed user verification and email confirmation logic.
  - `/api/license/validate.php`: Simplified to require both `license_key` and `device_id`. Removed subscription ID and auto-detection logic.

- **Admin UI enhancement**: Added "Copy" button to license key display in admin panel for easier key distribution.

- **Removed dependencies**: Removed email sender integration from redemption flow since keys are no longer tied to user accounts.

## Implementation Details

- License keys can be redeemed on any device by providing the hashed machine identifier
- Once redeemed, a key is locked to that device unless transferred to a new device
- Device transfer is only allowed if the subscription hasn't expired
- Subscriptions created from device-based keys have no associated user account (user_id and email are NULL)
- All validation checks automatically mark expired subscriptions as such

https://claude.ai/code/session_01QctiWke4iT4iYmT18nPLUL