### PR TITLE
Update location branding from Saskatoon to Canada-wide

### DIFF
--- a/about-us/index.php
+++ b/about-us/index.php
@@ -11,14 +11,14 @@
 
     <!-- SEO Meta Tags -->
     <meta name="description"
-        content="Learn about Argo, the Saskatoon-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
+        content="Learn about Argo, the Canada-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
     <meta name="keywords"
-        content="about argo books, saskatoon startup, small business software company, affordable business tools, finance management developers, canadian software company, saskatoon business, saskatchewan tech company">
+        content="about argo books, Canada startup, small business software company, affordable business tools, finance management developers, canadian software company, Canadian, saskatchewan tech company">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="About Us - Argo Books | Saskatoon Business Software Company">
+    <meta property="og:title" content="About Us - Argo Books | Canadian Software Company">
     <meta property="og:description"
-        content="Learn about Argo, the Saskatoon-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
+        content="Learn about Argo, the Canada-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
     <meta property="og:url" content="https://argorobots.com/about-us/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Argo Books">
@@ -26,13 +26,13 @@
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="About Us - Argo Books | Saskatoon Business Software Company">
+    <meta name="twitter:title" content="About Us - Argo Books | Canadian Software Company">
     <meta name="twitter:description"
-        content="Learn about Argo, the Saskatoon-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
+        content="Learn about Argo, the Canada-based startup creating affordable finance management software for small businesses. Our mission: Better tools, built by entrepreneurs who understand your challenges.">
 
     <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
-    <meta name="geo.placename" content="Saskatoon">
+    <meta name="geo.placename" content="Canada">
     <meta name="geo.position" content="52.1579;-106.6702">
     <meta name="ICBM" content="52.1579, -106.6702">
 
@@ -40,7 +40,7 @@
     <link rel="canonical" href="https://argorobots.com/about-us/">
 
     <link rel="shortcut icon" type="image/x-icon" href="../resources/images/argo-logo/A-logo.ico">
-    <title>About Us - Argo Books | Saskatoon Business Software Company</title>
+    <title>About Us - Argo Books | Canadian Software Company</title>
 
     <script src="../resources/scripts/jquery-3.6.0.js"></script>
     <script src="../resources/scripts/main.js"></script>
@@ -66,7 +66,7 @@
         <div class="container">
             <div class="hero-badge animate-fade-in">
                 <?= svg_icon('map-pin', 16) ?>
-                <span>Saskatoon, SK</span>
+                <span>Saskatoon, SK, Canada</span>
             </div>
             <h1 class="animate-fade-in">About Argo Books</h1>
             <p class="hero-subtitle animate-fade-in">Building the future of small business management, one feature at a time.</p>
@@ -162,7 +162,7 @@
                     <img src="../resources/images/saskatoon.webp" alt="Saskatoon Skyline">
                     <div class="image-badge">
                         <?= svg_icon('map-pin', 16) ?>
-                        Saskatoon, SK
+                        Saskatoon, SK, Canada
                     </div>
                 </div>
                 <div class="story-content animate-on-scroll">
@@ -233,7 +233,7 @@
             <div class="future-content animate-on-scroll">
                 <span class="section-label">What's Next</span>
                 <h2>Looking Forward</h2>
-                <p>As a growing Saskatoon-based startup, we're excited about what's ahead. Our roadmap is filled with new
+                <p>As a growing Canadian startup, we're excited about what's ahead. Our roadmap is filled with new
                     features and improvements based directly on user feedback. We're committed to expanding our offerings
                     while maintaining the simplicity and affordability that makes Argo special.</p>
                 <a href="../whats-new/" class="btn btn-secondary">

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -305,6 +305,8 @@ include '../admin_header.php';
     cursor: pointer;
     vertical-align: middle;
     transition: all 0.15s ease;
+    min-width: 60px;
+    text-align: center;
 }
 .btn-copy:hover {
     background: #e5e7eb;
@@ -517,7 +519,7 @@ include '../admin_header.php';
                     <div class="form-group">
                         <label for="notes">Notes (optional)</label>
                         <input type="text" id="notes" name="notes" placeholder="e.g., Giveaway winner">
-                         <p style="position: absolute; margin: 5px 0 20px;">This will also appear in the recipient's email.</p>
+                         <p style="position: absolute; margin: 5px 0 20px; color: var(--gray-text);">This will also appear in the recipient's email.</p>
                     </div>
                     <div class="form-group">
                         <button type="submit" name="generate_sub_key" class="btn btn-purple" style="margin-top: 24px;">Generate Key</button>

--- a/contact-us/index.php
+++ b/contact-us/index.php
@@ -210,7 +210,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <div class="sidebar-icon">
             <?= svg_icon('map-pin', null, '', 1.5) ?>
           </div>
-          <h4>Based in Saskatoon</h4>
+          <h4>Based in Canada</h4>
           <p>We're a Canadian company proudly serving businesses worldwide.</p>
           <span class="location-badge">
             <?= svg_icon('map-pin', 14) ?>

--- a/downloads/index.php
+++ b/downloads/index.php
@@ -123,7 +123,7 @@ $systemRequirements = getSystemRequirements();
 
     <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
-    <meta name="geo.placename" content="Saskatoon">
+    <meta name="geo.placename" content="Canada">
     <meta name="geo.position" content="52.1579;-106.6702">
     <meta name="ICBM" content="52.1579, -106.6702">
 

--- a/index.php
+++ b/index.php
@@ -50,7 +50,7 @@ if (!isset($_SESSION['user_id']) && isset($_COOKIE['remember_me'])) {
 
     <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
-    <meta name="geo.placename" content="Saskatoon">
+    <meta name="geo.placename" content="Canada">
     <meta name="geo.position" content="52.1579;-106.6702">
     <meta name="ICBM" content="52.1579, -106.6702">
 

--- a/older-versions/index.php
+++ b/older-versions/index.php
@@ -118,7 +118,7 @@ foreach ($platforms as $key => $platform) {
 
     <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
-    <meta name="geo.placename" content="Saskatoon">
+    <meta name="geo.placename" content="Canada">
     <meta name="geo.position" content="52.1579;-106.6702">
     <meta name="ICBM" content="52.1579, -106.6702">
 

--- a/whats-new/index.php
+++ b/whats-new/index.php
@@ -32,7 +32,7 @@
 
     <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
-    <meta name="geo.placename" content="Saskatoon">
+    <meta name="geo.placename" content="Canada">
     <meta name="geo.position" content="52.1579;-106.6702">
     <meta name="ICBM" content="52.1579, -106.6702">
 


### PR DESCRIPTION
## Summary
This PR updates the company location branding across the website from Saskatoon-specific references to Canada-wide positioning, while maintaining the Saskatchewan geo-location metadata for SEO purposes.

## Key Changes
- **SEO Meta Tags**: Updated description and keywords across multiple pages to reference "Canada-based startup" instead of "Saskatoon-based startup"
- **Page Titles & OG Tags**: Changed from "Saskatoon Business Software Company" to "Canadian Software Company" in title tags and Open Graph metadata
- **Geo-location Metadata**: Updated `geo.placename` from "Saskatoon" to "Canada" across all pages while keeping `geo.region` as "CA-SK" for regional targeting
- **Content Updates**: 
  - About Us page: Updated hero badge and story section to show "Saskatoon, SK, Canada"
  - About Us page: Changed "Saskatoon-based startup" to "Canadian startup" in the Looking Forward section
  - Contact Us page: Updated sidebar heading from "Based in Saskatoon" to "Based in Canada"
- **UI Improvements**: 
  - Added `min-width: 60px` and `text-align: center` to `.btn-copy` class for better button styling
  - Added `color: var(--gray-text)` to notes helper text for improved text hierarchy

## Implementation Details
- Maintains Saskatchewan geo-coordinates and region metadata for local SEO while broadening the brand positioning nationally
- Consistent messaging across all pages (about-us, contact-us, downloads, older-versions, whats-new, and homepage)
- Keywords updated to include both "Canada startup" and "Canadian" for better search visibility

https://claude.ai/code/session_01Dy2o6sLjEnVkofUxSZsG8m