### PR TITLE
Add Version History documentation and enhance Report Generator docs

### DIFF
--- a/documentation/index.php
+++ b/documentation/index.php
@@ -294,6 +294,13 @@ $isDocsLanding = true;
                     <h3>Spreadsheet Export</h3>
                     <p>Export data to Excel for backup</p>
                 </a>
+                <a href="pages/features/history-modal.php" class="doc-card">
+                    <div class="card-icon">
+                        <?= svg_icon('clock', 20) ?>
+                    </div>
+                    <h3>Version History</h3>
+                    <p>Review, undo, and redo changes</p>
+                </a>
             </div>
         </section>
 

--- a/documentation/pages/features/history-modal.php
+++ b/documentation/pages/features/history-modal.php
@@ -1,0 +1,79 @@
+<?php
+require_once __DIR__ . '/../../../resources/icons.php';
+$pageTitle = 'Version History';
+$pageDescription = 'Learn how to use the Version History modal in Argo Books to review changes, undo or redo actions, search past events, and restore previous states of your data.';
+$currentPage = 'history-modal';
+$pageCategory = 'features';
+
+include '../../docs-header.php';
+?>
+
+        <div class="docs-content">
+            <p>The Version History modal gives you a complete timeline of every change made to your company data. You can review past actions, undo or redo specific changes, and search through your history to find exactly what you're looking for.</p>
+
+            <h2>Opening Version History</h2>
+            <p>Click the clock icon (<?= svg_icon('clock', 16) ?>) in the header bar to open the Version History modal.</p>
+
+            <h2>Event Timeline</h2>
+            <p>The modal displays a chronological list of all changes. Each event shows:</p>
+            <ul>
+                <li><strong>Timestamp:</strong> When the change was made (stored in UTC for consistency across time zones)</li>
+                <li><strong>Action Type:</strong> The kind of change — Added, Modified, Deleted, Undone, or Redone</li>
+                <li><strong>Entity Details:</strong> The type and name of the item that was changed (e.g., a customer, product, or expense)</li>
+                <li><strong>Description:</strong> A human-readable summary of what happened</li>
+                <li><strong>Field-Level Changes:</strong> For modifications, a summary showing exactly which fields changed with their old and new values (e.g., "Name: 'Old Name' → 'New Name'")</li>
+            </ul>
+
+            <h3>Nested Undo/Redo Events</h3>
+            <p>When you undo or redo a change, the resulting event is displayed as a nested sub-item under the original event. This keeps your timeline organized and makes it easy to trace the relationship between an action and its reversal.</p>
+
+            <h2>Searching History</h2>
+            <p>Use the search bar at the top of the modal to find specific events. The search uses fuzzy matching, so you don't need to type an exact name — close matches will still appear in the results.</p>
+
+            <h2>Filtering Events</h2>
+            <p>Use the inline filters to narrow down the event list:</p>
+            <ul>
+                <li><strong>By Action Type:</strong> Show only Added, Modified, or Deleted events</li>
+                <li><strong>Undone:</strong> Filter to show only events that have been undone</li>
+            </ul>
+
+            <h2>Undo and Redo</h2>
+            <p>You can reverse or reapply changes directly from the history modal.</p>
+            <ul>
+                <li><strong>Undo:</strong> Revert a specific change to restore the previous state</li>
+                <li><strong>Redo:</strong> Reapply a previously undone change</li>
+                <li><strong>Selective Undo/Redo:</strong> Undo or redo individual changes without affecting other events that happened before or after</li>
+            </ul>
+
+            <div class="info-box">
+                <strong>Tip:</strong> The system automatically prevents actions that don't make sense — for example, you can't undo an "Add" if the item was later deleted. This ensures your data stays consistent.
+            </div>
+
+            <h2>First-Visit Hints</h2>
+            <p>The first time you open Version History, helpful hints will appear to guide you through the interface. You can dismiss these hints or choose "Don't show again" to hide them permanently.</p>
+
+            <h2>Backup and Restore</h2>
+            <p>Version history is included when you create backups of your company data:</p>
+            <ul>
+                <li><strong>Backup:</strong> Export your company data as an <code>.argobk</code> file — the full event history is included in the backup</li>
+                <li><strong>Restore:</strong> Restoring a backup creates a new company file with the complete history intact, without affecting your current data</li>
+                <li><strong>Attachments:</strong> You can optionally include file attachments in your backup</li>
+            </ul>
+
+            <div class="info-box">
+                <strong>Tip:</strong> For more details on creating and restoring backups, see <a class="link" href="../security/backups.php">Regular Backups</a>.
+            </div>
+
+            <div class="page-navigation">
+                <a href="spreadsheet-export.php" class="nav-button prev">
+                    <?= svg_icon('chevron-left', 16) ?>
+                    Previous: Spreadsheet Export
+                </a>
+                <a href="../reference/accepted-countries.php" class="nav-button next">
+                    Next: Accepted Countries
+                    <?= svg_icon('chevron-right', 16) ?>
+                </a>
+            </div>
+        </div>
+
+<?php include '../../docs-footer.php'; ?>

--- a/documentation/pages/features/history-modal.php
+++ b/documentation/pages/features/history-modal.php
@@ -12,56 +12,25 @@ include '../../docs-header.php';
             <p>The Version History modal gives you a complete timeline of every change made to your company data. You can review past actions, undo or redo specific changes, and search through your history to find exactly what you're looking for.</p>
 
             <h2>Opening Version History</h2>
-            <p>Click the clock icon (<?= svg_icon('clock', 16) ?>) in the header bar to open the Version History modal.</p>
+            <p>Click the clock icon in the header bar to open the Version History modal.</p>
 
             <h2>Event Timeline</h2>
             <p>The modal displays a chronological list of all changes. Each event shows:</p>
             <ul>
-                <li><strong>Timestamp:</strong> When the change was made (stored in UTC for consistency across time zones)</li>
+                <li><strong>Timestamp:</strong> When the change was made</li>
                 <li><strong>Action Type:</strong> The kind of change — Added, Modified, Deleted, Undone, or Redone</li>
                 <li><strong>Entity Details:</strong> The type and name of the item that was changed (e.g., a customer, product, or expense)</li>
-                <li><strong>Description:</strong> A human-readable summary of what happened</li>
-                <li><strong>Field-Level Changes:</strong> For modifications, a summary showing exactly which fields changed with their old and new values (e.g., "Name: 'Old Name' → 'New Name'")</li>
+                <li><strong>Description:</strong> A summary of what happened</li>
             </ul>
 
             <h3>Nested Undo/Redo Events</h3>
             <p>When you undo or redo a change, the resulting event is displayed as a nested sub-item under the original event. This keeps your timeline organized and makes it easy to trace the relationship between an action and its reversal.</p>
 
             <h2>Searching History</h2>
-            <p>Use the search bar at the top of the modal to find specific events. The search uses fuzzy matching, so you don't need to type an exact name — close matches will still appear in the results.</p>
-
-            <h2>Filtering Events</h2>
-            <p>Use the inline filters to narrow down the event list:</p>
-            <ul>
-                <li><strong>By Action Type:</strong> Show only Added, Modified, or Deleted events</li>
-                <li><strong>Undone:</strong> Filter to show only events that have been undone</li>
-            </ul>
-
-            <h2>Undo and Redo</h2>
-            <p>You can reverse or reapply changes directly from the history modal.</p>
-            <ul>
-                <li><strong>Undo:</strong> Revert a specific change to restore the previous state</li>
-                <li><strong>Redo:</strong> Reapply a previously undone change</li>
-                <li><strong>Selective Undo/Redo:</strong> Undo or redo individual changes without affecting other events that happened before or after</li>
-            </ul>
+            <p>Use the search bar or filter controls to find specific events.</p>
 
             <div class="info-box">
                 <strong>Tip:</strong> The system automatically prevents actions that don't make sense — for example, you can't undo an "Add" if the item was later deleted. This ensures your data stays consistent.
-            </div>
-
-            <h2>First-Visit Hints</h2>
-            <p>The first time you open Version History, helpful hints will appear to guide you through the interface. You can dismiss these hints or choose "Don't show again" to hide them permanently.</p>
-
-            <h2>Backup and Restore</h2>
-            <p>Version history is included when you create backups of your company data:</p>
-            <ul>
-                <li><strong>Backup:</strong> Export your company data as an <code>.argobk</code> file — the full event history is included in the backup</li>
-                <li><strong>Restore:</strong> Restoring a backup creates a new company file with the complete history intact, without affecting your current data</li>
-                <li><strong>Attachments:</strong> You can optionally include file attachments in your backup</li>
-            </ul>
-
-            <div class="info-box">
-                <strong>Tip:</strong> For more details on creating and restoring backups, see <a class="link" href="../security/backups.php">Regular Backups</a>.
             </div>
 
             <div class="page-navigation">

--- a/documentation/pages/features/report-generator.php
+++ b/documentation/pages/features/report-generator.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../resources/icons.php';
 $pageTitle = 'Report Generator';
-$pageDescription = 'Learn how to generate professional reports with charts and analytics in Argo Books using the 3-step wizard.';
+$pageDescription = 'Learn how to generate professional single and multi-page reports with charts, accounting tables, and analytics in Argo Books using the 3-step wizard.';
 $currentPage = 'report-generator';
 $pageCategory = 'features';
 
@@ -9,7 +9,7 @@ include '../../docs-header.php';
 ?>
 
         <div class="docs-content">
-            <p>Create professional, customized reports with charts and analytics for presentations and financial analysis. The Report Generator uses a simple 3-step wizard to guide you through the process.</p>
+            <p>Create professional, customized reports with charts, accounting tables, and analytics for presentations and financial analysis. The Report Generator uses a simple 3-step wizard to guide you through the process and supports multi-page reports for more detailed documents.</p>
 
             <h2>How to Generate a Report</h2>
             <ol class="steps-list">
@@ -20,16 +20,34 @@ include '../../docs-header.php';
             <h2>Step 1: Template & Settings</h2>
             <p>Choose a starting point for your report.</p>
             <ul>
-                <li><strong>Select a Template:</strong> Choose from pre-built templates or create your own</li>
+                <li><strong>Select a Template:</strong> Choose from pre-built templates including chart-based reports and accounting report templates, or create your own</li>
                 <li><strong>Name Your Report:</strong> Enter a name for your report</li>
                 <li><strong>Set Date Range:</strong> Use quick presets (Last Month, Last 3 Months, etc.) or choose start and end dates</li>
             </ul>
+
+            <h3>Accounting Report Templates</h3>
+            <p>The following accounting report templates are available with pre-configured layouts and structured financial tables:</p>
+            <ul>
+                <li><strong>Income Statement:</strong> Revenue, expenses, and net income over the selected period</li>
+                <li><strong>Balance Sheet:</strong> Assets, liabilities, and equity at a point in time</li>
+                <li><strong>Cash Flow Statement:</strong> Cash inflows and outflows across operating, investing, and financing activities</li>
+                <li><strong>Trial Balance:</strong> All account balances with debit and credit columns</li>
+                <li><strong>General Ledger:</strong> Detailed transaction records for all accounts</li>
+                <li><strong>Accounts Receivable Aging:</strong> Outstanding customer payments grouped by age</li>
+                <li><strong>Accounts Payable Aging:</strong> Outstanding supplier payments grouped by age</li>
+                <li><strong>Tax Summary:</strong> Tax-related totals for the selected period</li>
+            </ul>
+
+            <div class="info-box">
+                <strong>Tip:</strong> Accounting reports are generated directly from your transaction records — no Chart of Accounts setup is required. Currency formatting automatically matches your company's localization settings.
+            </div>
 
             <h2>Step 2: Layout Designer</h2>
             <p>Design your report using drag-and-drop functionality.</p>
             <ul>
                 <li><strong>Add Charts:</strong> Choose from 30+ chart types across categories like Revenue, Expenses, Financial, Geographic, Customers, Returns, and more</li>
                 <li><strong>Add Elements:</strong> Include text labels, images, date ranges, summary statistics, and tables</li>
+                <li><strong>Add Accounting Tables:</strong> Insert structured financial tables with section headers, subtotals, and grand totals — available when using accounting report templates</li>
                 <li><strong>Drag and Drop:</strong> Click and drag elements to position them on the canvas</li>
                 <li><strong>Resize:</strong> Select an element and drag the corner handles to resize</li>
                 <li><strong>Customize:</strong> Use the properties panel to adjust colors, fonts, borders, and alignment</li>
@@ -37,10 +55,24 @@ include '../../docs-header.php';
                 <li><strong>Undo/Redo:</strong> Use Ctrl+Z and Ctrl+Y to undo or redo changes</li>
             </ul>
 
+            <h3>Multi-Page Reports</h3>
+            <p>Reports can span multiple pages for more detailed documents. Pages are displayed vertically in the designer so you can see your entire report at a glance.</p>
+            <ul>
+                <li><strong>Add Page:</strong> Use the "Add Page" button in the footer toolbar to add a new page</li>
+                <li><strong>Delete Page:</strong> Use the "Delete Page" button to remove the current page</li>
+                <li><strong>Page Navigation:</strong> Scroll through pages in the designer — all pages are stacked vertically for easy editing</li>
+                <li><strong>Element Placement:</strong> Each element belongs to a specific page. Drag elements onto the page where you want them to appear</li>
+            </ul>
+
+            <div class="info-box">
+                <strong>Tip:</strong> Adding or removing pages is fully supported by undo/redo, so you can easily reverse any page changes.
+            </div>
+
             <h2>Step 3: Preview and Export</h2>
             <p>Review your report and export in your preferred format.</p>
             <ul>
-                <li><strong>Preview:</strong> See how your finished report will look</li>
+                <li><strong>Preview:</strong> See how your finished report will look — all pages are displayed in a scrollable view</li>
+                <li><strong>Page Numbers:</strong> Multi-page reports automatically display "Page X of Y" for easy reference</li>
                 <li><strong>Export Format:</strong> Choose PNG, JPEG, or PDF</li>
                 <li><strong>Export:</strong> Select your save location and click "Export"</li>
             </ul>

--- a/documentation/pages/features/report-generator.php
+++ b/documentation/pages/features/report-generator.php
@@ -39,7 +39,7 @@ include '../../docs-header.php';
             </ul>
 
             <div class="info-box">
-                <strong>Tip:</strong> Accounting reports are generated directly from your transaction records — no Chart of Accounts setup is required. Currency formatting automatically matches your company's localization settings.
+                <strong>Tip:</strong> Accounting reports are generated directly from your transaction records — no Chart of Accounts setup is required.
             </div>
 
             <h2>Step 2: Layout Designer</h2>
@@ -56,17 +56,12 @@ include '../../docs-header.php';
             </ul>
 
             <h3>Multi-Page Reports</h3>
-            <p>Reports can span multiple pages for more detailed documents. Pages are displayed vertically in the designer so you can see your entire report at a glance.</p>
+            <p>Reports can span multiple pages for more detailed documents.</p>
             <ul>
                 <li><strong>Add Page:</strong> Use the "Add Page" button in the footer toolbar to add a new page</li>
                 <li><strong>Delete Page:</strong> Use the "Delete Page" button to remove the current page</li>
-                <li><strong>Page Navigation:</strong> Scroll through pages in the designer — all pages are stacked vertically for easy editing</li>
-                <li><strong>Element Placement:</strong> Each element belongs to a specific page. Drag elements onto the page where you want them to appear</li>
+                <li><strong>Page Navigation:</strong> Scroll through pages in the designer — all pages are stacked vertically</li>
             </ul>
-
-            <div class="info-box">
-                <strong>Tip:</strong> Adding or removing pages is fully supported by undo/redo, so you can easily reverse any page changes.
-            </div>
 
             <h2>Step 3: Preview and Export</h2>
             <p>Review your report and export in your preferred format.</p>

--- a/documentation/pages/features/spreadsheet-export.php
+++ b/documentation/pages/features/spreadsheet-export.php
@@ -46,8 +46,8 @@ include '../../docs-header.php';
                     <?= svg_icon('chevron-left', 16) ?>
                     Previous: Spreadsheet Import
                 </a>
-                <a href="../reference/accepted-countries.php" class="nav-button next">
-                    Next: Accepted Countries
+                <a href="history-modal.php" class="nav-button next">
+                    Next: Version History
                     <?= svg_icon('chevron-right', 16) ?>
                 </a>
             </div>

--- a/documentation/sidebar.php
+++ b/documentation/sidebar.php
@@ -106,6 +106,10 @@ $sidebarSections = [
             'spreadsheet-export' => [
                 'title' => 'Spreadsheet Export',
                 'icon' => svg_icon('document-download', 18)
+            ],
+            'history-modal' => [
+                'title' => 'Version History',
+                'icon' => svg_icon('clock', 18)
             ]
         ]
     ],


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Version History feature and expands the Report Generator documentation with details about accounting report templates and multi-page report support.

## Key Changes

### New Documentation
- **Added Version History modal documentation** (`history-modal.php`)
  - Explains how to open and use the Version History modal
  - Documents the event timeline with timestamps, action types, entity details, and descriptions
  - Describes nested undo/redo events functionality
  - Includes search/filter capabilities and data consistency safeguards

### Documentation Updates
- **Enhanced Report Generator documentation** with:
  - Updated description to mention accounting tables and multi-page report support
  - New "Accounting Report Templates" section detailing 8 template types:
    - Income Statement, Balance Sheet, Cash Flow Statement, Trial Balance
    - General Ledger, Accounts Receivable/Payable Aging, Tax Summary
  - Added note that accounting reports don't require Chart of Accounts setup
  - New "Multi-Page Reports" subsection explaining page management
  - Updated Step 3 preview section to mention page numbers and multi-page display

### Navigation Updates
- **Updated documentation index** to include Version History card with clock icon
- **Updated sidebar navigation** to add Version History entry under Features
- **Updated breadcrumb navigation** in Spreadsheet Export page to link to Version History instead of Accepted Countries
- **Updated page navigation** in history-modal.php to link to Accepted Countries reference

## Implementation Details
- Version History documentation follows the existing documentation structure and styling conventions
- All navigation links are properly updated to maintain documentation flow
- Documentation uses consistent formatting with info boxes for tips and structured lists for feature details

https://claude.ai/code/session_012Gxw2jhs1qXG7B7x9w9s9X