### PR TITLE
Add AI Spreadsheet Import usage tracking API

### DIFF
--- a/api/ai-import/usage.php
+++ b/api/ai-import/usage.php
@@ -41,14 +41,15 @@ if (!isset($input['action']) || !in_array($input['action'], ['check', 'increment
 $license_key = trim($input['license_key']);
 $action = $input['action'];
 
-// Load database connection
+// Load database connection and pricing config
 require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/../../config/pricing.php';
 
 /**
  * Determine tier and validate license key
  * @param PDO $pdo
  * @param string $license_key
- * @return array|null Returns ['tier' => 'premium', 'limit' => 10] for valid premium keys,
+ * @return array|null Returns ['tier' => 'premium', 'limit' => N] for valid premium keys,
  *                    or null if invalid
  */
 function validateAndGetTier($pdo, $license_key) {
@@ -58,7 +59,8 @@ function validateAndGetTier($pdo, $license_key) {
         $stmt = $pdo->prepare("SELECT id FROM premium_subscription_keys WHERE subscription_key = ?");
         $stmt->execute([$license_key]);
         if ($stmt->fetch()) {
-            return ['tier' => 'premium', 'limit' => 10];
+            $config = get_pricing_config();
+            return ['tier' => 'premium', 'limit' => $config['ai_import_monthly_limit']];
         }
 
         // Check premium_subscriptions table for active subscriptions
@@ -70,7 +72,8 @@ function validateAndGetTier($pdo, $license_key) {
         ");
         $stmt->execute([$license_key]);
         if ($stmt->fetch()) {
-            return ['tier' => 'premium', 'limit' => 10];
+            $config = get_pricing_config();
+            return ['tier' => 'premium', 'limit' => $config['ai_import_monthly_limit']];
         }
 
         return null;

--- a/api/ai-import/usage.php
+++ b/api/ai-import/usage.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * AI Spreadsheet Import Usage Tracking API
+ * Tracks and enforces monthly import limits for Premium tier subscribers.
+ * AI Spreadsheet Import is only available on the Premium plan with 10 imports/month.
+ */
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+// Handle preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit();
+}
+
+// Only allow POST requests
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit();
+}
+
+// Get JSON input
+$input = json_decode(file_get_contents('php://input'), true);
+
+if (!isset($input['license_key']) || empty($input['license_key'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'License key is required']);
+    exit();
+}
+
+if (!isset($input['action']) || !in_array($input['action'], ['check', 'increment'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Valid action (check or increment) is required']);
+    exit();
+}
+
+$license_key = trim($input['license_key']);
+$action = $input['action'];
+
+// Load database connection
+require_once __DIR__ . '/../../db_connect.php';
+
+/**
+ * Determine tier and validate license key
+ * @param PDO $pdo
+ * @param string $license_key
+ * @return array|null Returns ['tier' => 'premium', 'limit' => 10] for valid premium keys,
+ *                    or null if invalid
+ */
+function validateAndGetTier($pdo, $license_key) {
+    // Check if it's a Premium key (starts with PREM-)
+    if (strpos($license_key, 'PREM-') === 0) {
+        // Check premium_subscription_keys table (unredeemed promo keys)
+        $stmt = $pdo->prepare("SELECT id FROM premium_subscription_keys WHERE subscription_key = ?");
+        $stmt->execute([$license_key]);
+        if ($stmt->fetch()) {
+            return ['tier' => 'premium', 'limit' => 10];
+        }
+
+        // Check premium_subscriptions table for active subscriptions
+        $stmt = $pdo->prepare("
+            SELECT id FROM premium_subscriptions
+            WHERE subscription_id = ?
+            AND status IN ('active', 'cancelled')
+            AND end_date > NOW()
+        ");
+        $stmt->execute([$license_key]);
+        if ($stmt->fetch()) {
+            return ['tier' => 'premium', 'limit' => 10];
+        }
+
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Get or create usage record for current month
+ * @param PDO $pdo
+ * @param string $license_key
+ * @param int $monthly_limit
+ * @return array
+ */
+function getOrCreateUsageRecord($pdo, $license_key, $monthly_limit) {
+    $usage_month = date('Y-m-01');
+
+    // Try to get existing record
+    $stmt = $pdo->prepare("
+        SELECT id, scan_count, monthly_limit
+        FROM ai_import_usage
+        WHERE license_key = ? AND usage_month = ?
+    ");
+    $stmt->execute([$license_key, $usage_month]);
+    $record = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($record) {
+        return $record;
+    }
+
+    // Create new record for this month
+    $stmt = $pdo->prepare("
+        INSERT INTO ai_import_usage (license_key, usage_month, scan_count, monthly_limit)
+        VALUES (?, ?, 0, ?)
+    ");
+    $stmt->execute([$license_key, $usage_month, $monthly_limit]);
+
+    return [
+        'id' => $pdo->lastInsertId(),
+        'scan_count' => 0,
+        'monthly_limit' => $monthly_limit
+    ];
+}
+
+/**
+ * Build response array
+ * @param int $import_count
+ * @param int $monthly_limit
+ * @param string $tier
+ * @param bool $can_import
+ * @return array
+ */
+function buildResponse($import_count, $monthly_limit, $tier, $can_import = null) {
+    $remaining = max(0, $monthly_limit - $import_count);
+    if ($can_import === null) {
+        $can_import = $remaining > 0;
+    }
+
+    $usage_month = date('Y-m-01');
+    $resets_at = date('Y-m-01', strtotime('first day of next month'));
+
+    return [
+        'success' => true,
+        'can_import' => $can_import,
+        'import_count' => (int)$import_count,
+        'monthly_limit' => (int)$monthly_limit,
+        'remaining' => (int)$remaining,
+        'tier' => $tier,
+        'usage_month' => $usage_month,
+        'resets_at' => $resets_at
+    ];
+}
+
+try {
+    // Validate license key and get tier
+    $tierInfo = validateAndGetTier($pdo, $license_key);
+
+    if (!$tierInfo) {
+        http_response_code(401);
+        echo json_encode(['success' => false, 'error' => 'Invalid or expired license key']);
+        exit();
+    }
+
+    $tier = $tierInfo['tier'];
+    $monthly_limit = $tierInfo['limit'];
+
+    // Get or create usage record
+    $usage = getOrCreateUsageRecord($pdo, $license_key, $monthly_limit);
+    $import_count = $usage['scan_count'];
+    // Use the limit from the tier info (in case it changed)
+    $monthly_limit = $tierInfo['limit'];
+
+    if ($action === 'check') {
+        // Just return current status
+        echo json_encode(buildResponse($import_count, $monthly_limit, $tier));
+        exit();
+    }
+
+    if ($action === 'increment') {
+        // Check if limit reached before incrementing
+        if ($import_count >= $monthly_limit) {
+            $response = buildResponse($import_count, $monthly_limit, $tier, false);
+            $response['success'] = false;
+            $response['error'] = 'Monthly import limit reached';
+            http_response_code(429);
+            echo json_encode($response);
+            exit();
+        }
+
+        // Increment the import count
+        $usage_month = date('Y-m-01');
+        $stmt = $pdo->prepare("
+            UPDATE ai_import_usage
+            SET scan_count = scan_count + 1
+            WHERE license_key = ? AND usage_month = ?
+        ");
+        $stmt->execute([$license_key, $usage_month]);
+
+        // Return updated status
+        $new_import_count = $import_count + 1;
+        echo json_encode(buildResponse($new_import_count, $monthly_limit, $tier));
+        exit();
+    }
+
+} catch (PDOException $e) {
+    error_log("AI import usage API error: " . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error']);
+    exit();
+}

--- a/api/receipt/usage.php
+++ b/api/receipt/usage.php
@@ -41,14 +41,15 @@ if (!isset($input['action']) || !in_array($input['action'], ['check', 'increment
 $license_key = trim($input['license_key']);
 $action = $input['action'];
 
-// Load database connection
+// Load database connection and pricing config
 require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/../../config/pricing.php';
 
 /**
  * Determine tier and validate license key
  * @param PDO $pdo
  * @param string $license_key
- * @return array|null Returns ['tier' => 'premium', 'limit' => 500] for valid premium keys,
+ * @return array|null Returns ['tier' => 'premium', 'limit' => N] for valid premium keys,
  *                    or null if invalid
  */
 function validateAndGetTier($pdo, $license_key) {
@@ -58,7 +59,8 @@ function validateAndGetTier($pdo, $license_key) {
         $stmt = $pdo->prepare("SELECT id FROM premium_subscription_keys WHERE subscription_key = ?");
         $stmt->execute([$license_key]);
         if ($stmt->fetch()) {
-            return ['tier' => 'premium', 'limit' => 500];
+            $config = get_pricing_config();
+            return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit']];
         }
 
         // Check premium_subscriptions table for active subscriptions
@@ -70,7 +72,8 @@ function validateAndGetTier($pdo, $license_key) {
         ");
         $stmt->execute([$license_key]);
         if ($stmt->fetch()) {
-            return ['tier' => 'premium', 'limit' => 500];
+            $config = get_pricing_config();
+            return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit']];
         }
 
         return null;

--- a/config/pricing.php
+++ b/config/pricing.php
@@ -11,6 +11,8 @@
  *   PREMIUM_YEARLY_PRICE        - Premium yearly subscription (default: 100.00)
  *   PROCESSING_FEE_PERCENT      - Payment processing fee percentage (default: 2.90)
  *   PROCESSING_FEE_FIXED        - Payment processing fixed fee in CAD (default: 0.30)
+ *   RECEIPT_SCAN_MONTHLY_LIMIT  - Monthly receipt scan limit for premium tier (default: 500)
+ *   AI_IMPORT_MONTHLY_LIMIT     - Monthly AI import limit for premium tier (default: 10)
  */
 
 /**
@@ -36,6 +38,8 @@ function get_pricing_config() {
         'premium_yearly_price'  => _pricing_parse_env('PREMIUM_YEARLY_PRICE', 100.00),
         'processing_fee_percent' => _pricing_parse_env('PROCESSING_FEE_PERCENT', 2.90),
         'processing_fee_fixed'   => _pricing_parse_env('PROCESSING_FEE_FIXED', 0.30),
+        'receipt_scan_monthly_limit' => _pricing_parse_int_env('RECEIPT_SCAN_MONTHLY_LIMIT', 500),
+        'ai_import_monthly_limit'    => _pricing_parse_int_env('AI_IMPORT_MONTHLY_LIMIT', 10),
         'currency'              => 'CAD',
     ];
 
@@ -58,6 +62,28 @@ function _pricing_parse_env($key, $default) {
     $value = round(floatval($_ENV[$key]), 2);
 
     if ($value < 0) {
+        return $default;
+    }
+
+    return $value;
+}
+
+/**
+ * Parse an integer value from an environment variable.
+ * Returns the default if the env var is missing, empty, non-numeric, or less than 1.
+ *
+ * @param string $key     Environment variable name
+ * @param int    $default Default value if env var is invalid
+ * @return int Validated integer value
+ */
+function _pricing_parse_int_env($key, $default) {
+    if (!isset($_ENV[$key]) || $_ENV[$key] === '' || !is_numeric($_ENV[$key])) {
+        return $default;
+    }
+
+    $value = intval($_ENV[$key]);
+
+    if ($value < 1) {
         return $default;
     }
 


### PR DESCRIPTION
## Summary
This PR introduces usage tracking and monthly limits for the AI Spreadsheet Import feature, available exclusively to Premium tier subscribers. It also refactors the pricing configuration to support configurable monthly limits for both receipt scanning and AI imports.

## Key Changes

- **New API Endpoint**: Added `api/ai-import/usage.php` to track and enforce monthly import limits (10 imports/month for Premium tier)
  - Supports `check` action to retrieve current usage status
  - Supports `increment` action to record a new import and validate against monthly limits
  - Validates license keys against both unredeemed promo keys and active subscriptions
  - Returns detailed usage information including remaining imports and reset date

- **Enhanced Pricing Configuration**: Updated `config/pricing.php` to support configurable monthly limits
  - Added `RECEIPT_SCAN_MONTHLY_LIMIT` environment variable (default: 500)
  - Added `AI_IMPORT_MONTHLY_LIMIT` environment variable (default: 10)
  - Introduced `_pricing_parse_int_env()` helper function for parsing integer environment variables with validation

- **Refactored Receipt Usage API**: Updated `api/receipt/usage.php` to use the new pricing configuration
  - Changed hardcoded limit of 500 to use `receipt_scan_monthly_limit` from pricing config
  - Maintains backward compatibility while allowing dynamic configuration

## Implementation Details

- The AI import usage API creates monthly usage records in the `ai_import_usage` table, resetting counts on the first day of each month
- License key validation checks both `premium_subscription_keys` (unredeemed promo keys) and `premium_subscriptions` (active subscriptions) tables
- HTTP status codes follow REST conventions (401 for invalid keys, 429 for rate limiting)
- All responses include usage metadata (current month, reset date, remaining imports)

https://claude.ai/code/session_014TYYUmB8D7aDYAkGvfvL8J