### PR TITLE
Add usage tracking and bulk email resend to license management

### DIFF
--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -11,6 +11,18 @@ if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== tru
     exit;
 }
 
+// CSRF token
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+function verify_csrf_token() {
+    if (!isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        return false;
+    }
+    return true;
+}
+
 // Set page variables for the header
 $page_title = "Subscription Administration";
 $page_description = "Manage Premium subscriptions and free subscription keys";
@@ -145,6 +157,11 @@ function get_license_usage($license_keys)
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['reset_usage'])) {
     header('Content-Type: application/json');
 
+    if (!verify_csrf_token()) {
+        echo json_encode(['success' => false, 'error' => 'Invalid request']);
+        exit;
+    }
+
     $license_keys = $_POST['license_keys'] ?? [];
     if (!is_array($license_keys)) $license_keys = [$license_keys];
     $license_keys = array_filter(array_map('trim', $license_keys));
@@ -177,6 +194,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['reset_usage'])) {
 $generated_sub_key = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf_token()) {
+        $_SESSION['message'] = "Invalid request. Please try again.";
+        $_SESSION['message_type'] = 'error';
+        header('Location: index.php');
+        exit;
+    }
+
     if (isset($_POST['generate_sub_key'])) {
         $email = !empty($_POST['sub_email']) ? filter_var($_POST['sub_email'], FILTER_VALIDATE_EMAIL) : null;
         $duration = intval($_POST['duration_months'] ?? 1);
@@ -519,6 +543,7 @@ include '../admin_header.php';
                 <p>No Premium subscriptions found.</p>
             <?php else: ?>
                 <form id="subscription-bulk-form" method="post">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <input type="hidden" name="bulk_subscription_action" id="bulk_subscription_action_input" value="give_credit">
                     <input type="hidden" name="credit_amount" id="credit_amount_input">
                     <input type="hidden" name="credit_note" id="credit_note_input">
@@ -647,6 +672,7 @@ include '../admin_header.php';
             <?php endif; ?>
 
             <form method="post">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                 <div class="generate-form-grid">
                     <div class="form-group">
                         <label for="sub_email">Recipient Email</label>
@@ -693,6 +719,7 @@ include '../admin_header.php';
                 <p>No free subscription keys generated yet.</p>
             <?php else: ?>
                 <form id="sub-key-bulk-form" method="post">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                     <input type="hidden" name="bulk_sub_key_action" id="bulk_sub_key_action_input">
                     <div class="table-responsive">
                         <table>
@@ -1028,6 +1055,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const formData = new FormData();
         formData.append('reset_usage', '1');
+        formData.append('csrf_token', '<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>');
         checked.forEach(cb => formData.append('license_keys[]', cb.dataset.licenseKey));
 
         fetch('index.php', { method: 'POST', body: formData })

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -266,6 +266,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             header('Location: index.php#premium-subscriptions');
             exit;
+        } elseif (!empty($subscription_ids) && $action === 'resend_email') {
+            $count = count($subscription_ids);
+            $placeholders = implode(',', array_fill(0, $count, '?'));
+
+            try {
+                $stmt = $pdo->prepare("
+                    SELECT email, subscription_id, billing_cycle, end_date
+                    FROM premium_subscriptions
+                    WHERE id IN ($placeholders)
+                ");
+                $stmt->execute($subscription_ids);
+                $subscriptions = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+                $sent = 0;
+                foreach ($subscriptions as $sub) {
+                    if (resend_subscription_id_email($sub['email'], $sub['subscription_id'], $sub['billing_cycle'], $sub['end_date'])) {
+                        $sent++;
+                    }
+                }
+
+                $_SESSION['message'] = "Subscription ID email resent to $sent of $count recipient(s).";
+                $_SESSION['message_type'] = $sent > 0 ? 'success' : 'error';
+            } catch (PDOException $e) {
+                error_log("Error resending subscription emails: " . $e->getMessage());
+                $_SESSION['message'] = "Error resending emails.";
+                $_SESSION['message_type'] = 'error';
+            }
+
+            header('Location: index.php#premium-subscriptions');
+            exit;
         } else {
             $_SESSION['message'] = "Please select subscriptions and enter a valid credit amount.";
             $_SESSION['message_type'] = 'error';
@@ -403,6 +433,9 @@ include '../admin_header.php';
                 <div class="bulk-buttons">
                     <button type="button" class="btn btn-bulk btn-purple" id="open-credit-modal" disabled>
                         Give Credit
+                    </button>
+                    <button type="button" class="btn btn-bulk btn-blue" id="subscription-bulk-resend" disabled>
+                        Resend Email
                     </button>
                 </div>
             </div>
@@ -738,7 +771,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const subscriptionCheckboxes = document.querySelectorAll('.subscription-checkbox');
     const subscriptionSelectedCount = document.getElementById('subscription-selected-count');
     const openCreditModalBtn = document.getElementById('open-credit-modal');
+    const subscriptionBulkResend = document.getElementById('subscription-bulk-resend');
     const subscriptionBulkForm = document.getElementById('subscription-bulk-form');
+    const bulkSubscriptionActionInput = document.getElementById('bulk_subscription_action_input');
     const creditAmountInput = document.getElementById('credit_amount_input');
     const creditNoteInput = document.getElementById('credit_note_input');
 
@@ -757,6 +792,9 @@ document.addEventListener('DOMContentLoaded', function() {
         subscriptionSelectedCount.textContent = count;
         if (openCreditModalBtn) {
             openCreditModalBtn.disabled = count === 0;
+        }
+        if (subscriptionBulkResend) {
+            subscriptionBulkResend.disabled = count === 0;
         }
     }
 
@@ -799,6 +837,19 @@ document.addEventListener('DOMContentLoaded', function() {
         openCreditModalBtn.addEventListener('click', openModal);
     }
 
+    if (subscriptionBulkResend) {
+        subscriptionBulkResend.addEventListener('click', function() {
+            const checked = document.querySelectorAll('.subscription-checkbox:checked');
+            if (checked.length === 0) return;
+
+            if (confirm(`Resend subscription ID email to ${checked.length} recipient(s)?`)) {
+                bulkSubscriptionActionInput.value = 'resend_email';
+                creditAmountInput.value = '0';
+                subscriptionBulkForm.submit();
+            }
+        });
+    }
+
     if (closeCreditModalBtn) {
         closeCreditModalBtn.addEventListener('click', closeModal);
     }
@@ -837,6 +888,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             if (confirm(`Are you sure you want to give $${amount.toFixed(2)} credit to ${checkedCount} subscription(s)?`)) {
+                bulkSubscriptionActionInput.value = 'give_credit';
                 creditAmountInput.value = amount;
                 creditNoteInput.value = note;
                 subscriptionBulkForm.submit();

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -175,6 +175,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $_SESSION['message'] = "Error deleting keys.";
                     $_SESSION['message_type'] = 'error';
                 }
+            } elseif ($action === 'resend_email') {
+                try {
+                    $stmt = $pdo->prepare("SELECT * FROM premium_subscription_keys WHERE id IN ($placeholders)");
+                    $stmt->execute($key_ids);
+                    $keys_to_resend = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+                    $sent = 0;
+                    $skipped = 0;
+                    foreach ($keys_to_resend as $k) {
+                        if (empty($k['email'])) {
+                            $skipped++;
+                            continue;
+                        }
+                        if (send_free_subscription_key_email($k['email'], $k['subscription_key'], $k['duration_months'], $k['notes'] ?? '')) {
+                            $sent++;
+                        }
+                    }
+
+                    $msg = "$sent email(s) resent successfully.";
+                    if ($skipped > 0) {
+                        $msg .= " $skipped key(s) skipped (no email address).";
+                    }
+                    $_SESSION['message'] = $msg;
+                    $_SESSION['message_type'] = $sent > 0 ? 'success' : 'error';
+                } catch (PDOException $e) {
+                    error_log("Error resending license emails: " . $e->getMessage());
+                    $_SESSION['message'] = "Error resending emails.";
+                    $_SESSION['message_type'] = 'error';
+                }
             }
 
             header('Location: index.php#free-sub-keys');
@@ -537,6 +566,7 @@ include '../admin_header.php';
                     <span id="sub-key-selected-count">0</span> selected
                 </div>
                 <div class="bulk-buttons">
+                    <button type="button" class="btn btn-bulk btn-purple" id="sub-key-bulk-resend" disabled>Resend Email</button>
                     <button type="button" class="btn btn-bulk btn-delete" id="sub-key-bulk-delete" data-action="delete" disabled>Delete Selected</button>
                 </div>
             </div>
@@ -649,6 +679,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const subKeyCheckboxes = document.querySelectorAll('.sub-key-checkbox');
     const subKeySelectedCount = document.getElementById('sub-key-selected-count');
     const subKeyBulkDelete = document.getElementById('sub-key-bulk-delete');
+    const subKeyBulkResend = document.getElementById('sub-key-bulk-resend');
     const subKeyBulkForm = document.getElementById('sub-key-bulk-form');
     const subKeyBulkActionInput = document.getElementById('bulk_sub_key_action_input');
 
@@ -657,6 +688,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const count = checked.length;
         subKeySelectedCount.textContent = count;
         subKeyBulkDelete.disabled = count === 0;
+        if (subKeyBulkResend) subKeyBulkResend.disabled = count === 0;
     }
 
     if (subKeySelectAll) {
@@ -684,6 +716,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (confirm(`Are you sure you want to delete ${checked.length} subscription key(s)?`)) {
                 subKeyBulkActionInput.value = 'delete';
+                subKeyBulkForm.submit();
+            }
+        });
+    }
+
+    if (subKeyBulkResend) {
+        subKeyBulkResend.addEventListener('click', function() {
+            const checked = document.querySelectorAll('.sub-key-checkbox:checked');
+            if (checked.length === 0) return;
+
+            if (confirm(`Resend license key email to ${checked.length} recipient(s)?`)) {
+                subKeyBulkActionInput.value = 'resend_email';
                 subKeyBulkForm.submit();
             }
         });

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -3,6 +3,7 @@ session_start();
 require_once '../../db_connect.php';
 require_once '../../email_sender.php';
 require_once '../../license_functions.php';
+require_once '../../config/pricing.php';
 
 // Check if user is logged in
 if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== true) {
@@ -108,6 +109,68 @@ function get_subscription_chart_data()
     }
 
     return $data;
+}
+
+// Get usage data for a list of license keys
+function get_license_usage($license_keys)
+{
+    global $pdo;
+    $usage = [];
+    if (empty($license_keys)) return $usage;
+
+    $usage_month = date('Y-m-01');
+    $placeholders = implode(',', array_fill(0, count($license_keys), '?'));
+
+    try {
+        $stmt = $pdo->prepare("SELECT license_key, scan_count FROM receipt_scan_usage WHERE license_key IN ($placeholders) AND usage_month = ?");
+        $stmt->execute(array_merge($license_keys, [$usage_month]));
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $usage[$row['license_key']]['receipt_scans'] = (int)$row['scan_count'];
+        }
+
+        $stmt = $pdo->prepare("SELECT license_key, scan_count FROM ai_import_usage WHERE license_key IN ($placeholders) AND usage_month = ?");
+        $stmt->execute(array_merge($license_keys, [$usage_month]));
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if (!isset($usage[$row['license_key']])) $usage[$row['license_key']] = ['receipt_scans' => 0];
+            $usage[$row['license_key']]['ai_imports'] = (int)$row['scan_count'];
+        }
+    } catch (PDOException $e) {
+        error_log("Error fetching license usage: " . $e->getMessage());
+    }
+
+    return $usage;
+}
+
+// Handle usage reset via AJAX
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['reset_usage'])) {
+    header('Content-Type: application/json');
+
+    $license_keys = $_POST['license_keys'] ?? [];
+    if (!is_array($license_keys)) $license_keys = [$license_keys];
+    $license_keys = array_filter(array_map('trim', $license_keys));
+
+    if (empty($license_keys)) {
+        echo json_encode(['success' => false, 'error' => 'No license keys provided']);
+        exit;
+    }
+
+    $usage_month = date('Y-m-01');
+    $placeholders = implode(',', array_fill(0, count($license_keys), '?'));
+    $params = array_merge($license_keys, [$usage_month]);
+
+    try {
+        $stmt = $pdo->prepare("UPDATE receipt_scan_usage SET scan_count = 0 WHERE license_key IN ($placeholders) AND usage_month = ?");
+        $stmt->execute($params);
+
+        $stmt = $pdo->prepare("UPDATE ai_import_usage SET scan_count = 0 WHERE license_key IN ($placeholders) AND usage_month = ?");
+        $stmt->execute($params);
+
+        echo json_encode(['success' => true]);
+    } catch (PDOException $e) {
+        error_log("Usage reset error: " . $e->getMessage());
+        echo json_encode(['success' => false, 'error' => 'Database error']);
+    }
+    exit;
 }
 
 // Handle form submissions
@@ -323,6 +386,15 @@ $premium_subscriptions = get_premium_subscriptions($sub_search);
 $premium_subscription_keys = get_premium_subscription_keys();
 $subscription_chart_data = get_subscription_chart_data();
 
+// Get usage data and limits
+$pricing_config = get_pricing_config();
+$receipt_limit = $pricing_config['receipt_scan_monthly_limit'];
+$ai_import_limit = $pricing_config['ai_import_monthly_limit'];
+
+$all_sub_ids = array_column($premium_subscriptions, 'subscription_id');
+$all_key_ids = array_column($premium_subscription_keys, 'subscription_key');
+$usage_data = get_license_usage(array_merge($all_sub_ids, $all_key_ids));
+
 $active_ai_subs = 0;
 foreach ($premium_subscriptions as $sub) {
     if ($sub['status'] === 'active') $active_ai_subs++;
@@ -437,6 +509,9 @@ include '../admin_header.php';
                     <button type="button" class="btn btn-bulk btn-blue" id="subscription-bulk-resend" disabled>
                         Resend Email
                     </button>
+                    <button type="button" class="btn btn-bulk btn-reset-usage" id="subscription-bulk-reset-usage" disabled>
+                        Reset Usage
+                    </button>
                 </div>
             </div>
 
@@ -465,6 +540,8 @@ include '../admin_header.php';
                                     <th>Status</th>
                                     <th>Start Date</th>
                                     <th>End Date</th>
+                                    <th>Receipt Scans</th>
+                                    <th>AI Imports</th>
                                     <th>Credit</th>
                                 </tr>
                             </thead>
@@ -473,7 +550,7 @@ include '../admin_header.php';
                                     <tr>
                                         <td class="checkbox-column">
                                             <div class="checkbox">
-                                                <input type="checkbox" name="selected_subscriptions[]" value="<?php echo $sub['id']; ?>" class="subscription-checkbox" id="sub-<?php echo $sub['id']; ?>">
+                                                <input type="checkbox" name="selected_subscriptions[]" value="<?php echo $sub['id']; ?>" class="subscription-checkbox" id="sub-<?php echo $sub['id']; ?>" data-license-key="<?php echo htmlspecialchars($sub['subscription_id']); ?>">
                                                 <label for="sub-<?php echo $sub['id']; ?>"></label>
                                             </div>
                                         </td>
@@ -498,6 +575,13 @@ include '../admin_header.php';
                                         </td>
                                         <td><?php echo date('M j, Y', strtotime($sub['start_date'])); ?></td>
                                         <td><?php echo date('M j, Y', strtotime($sub['end_date'])); ?></td>
+                                        <?php
+                                            $sub_key = $sub['subscription_id'];
+                                            $scans = $usage_data[$sub_key]['receipt_scans'] ?? 0;
+                                            $imports = $usage_data[$sub_key]['ai_imports'] ?? 0;
+                                        ?>
+                                        <td><span class="usage-count <?php echo $scans >= $receipt_limit ? 'usage-maxed' : ''; ?>"><?php echo $scans; ?> / <?php echo $receipt_limit; ?></span></td>
+                                        <td><span class="usage-count <?php echo $imports >= $ai_import_limit ? 'usage-maxed' : ''; ?>"><?php echo $imports; ?> / <?php echo $ai_import_limit; ?></span></td>
                                         <td>$<?php echo number_format($sub['credit_balance'] ?? 0, 2); ?></td>
                                     </tr>
                                 <?php endforeach; ?>
@@ -600,6 +684,7 @@ include '../admin_header.php';
                 </div>
                 <div class="bulk-buttons">
                     <button type="button" class="btn btn-bulk btn-purple" id="sub-key-bulk-resend" disabled>Resend Email</button>
+                    <button type="button" class="btn btn-bulk btn-reset-usage" id="sub-key-bulk-reset-usage" disabled>Reset Usage</button>
                     <button type="button" class="btn btn-bulk btn-delete" id="sub-key-bulk-delete" data-action="delete" disabled>Delete Selected</button>
                 </div>
             </div>
@@ -623,6 +708,8 @@ include '../admin_header.php';
                                     <th>Duration</th>
                                     <th>Email</th>
                                     <th>Status</th>
+                                    <th>Receipt Scans</th>
+                                    <th>AI Imports</th>
                                     <th>Created</th>
                                     <th>Notes</th>
                                 </tr>
@@ -632,7 +719,7 @@ include '../admin_header.php';
                                     <tr class="<?php echo $key['redeemed_at'] ? 'redeemed-row' : ''; ?>">
                                         <td class="checkbox-column">
                                             <div class="checkbox">
-                                                <input type="checkbox" name="selected_sub_keys[]" value="<?php echo $key['id']; ?>" class="sub-key-checkbox" id="sub-key-<?php echo $key['id']; ?>">
+                                                <input type="checkbox" name="selected_sub_keys[]" value="<?php echo $key['id']; ?>" class="sub-key-checkbox" id="sub-key-<?php echo $key['id']; ?>" data-license-key="<?php echo htmlspecialchars($key['subscription_key']); ?>">
                                                 <label for="sub-key-<?php echo $key['id']; ?>"></label>
                                             </div>
                                         </td>
@@ -647,6 +734,26 @@ include '../admin_header.php';
                                                 <span class="badge badge-redeemed">Redeemed</span>
                                             <?php else: ?>
                                                 <span class="badge badge-free">Available</span>
+                                            <?php endif; ?>
+                                        </td>
+                                        <?php
+                                            $fk = $key['subscription_key'];
+                                            $fk_scans = $usage_data[$fk]['receipt_scans'] ?? 0;
+                                            $fk_imports = $usage_data[$fk]['ai_imports'] ?? 0;
+                                            $fk_redeemed = !empty($key['redeemed_at']);
+                                        ?>
+                                        <td>
+                                            <?php if ($fk_redeemed): ?>
+                                                <span class="usage-count <?php echo $fk_scans >= $receipt_limit ? 'usage-maxed' : ''; ?>"><?php echo $fk_scans; ?> / <?php echo $receipt_limit; ?></span>
+                                            <?php else: ?>
+                                                <span class="usage-na">&mdash;</span>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td>
+                                            <?php if ($fk_redeemed): ?>
+                                                <span class="usage-count <?php echo $fk_imports >= $ai_import_limit ? 'usage-maxed' : ''; ?>"><?php echo $fk_imports; ?> / <?php echo $ai_import_limit; ?></span>
+                                            <?php else: ?>
+                                                <span class="usage-na">&mdash;</span>
                                             <?php endif; ?>
                                         </td>
                                         <td><?php echo date('M j, Y', strtotime($key['created_at'])); ?></td>
@@ -713,6 +820,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const subKeySelectedCount = document.getElementById('sub-key-selected-count');
     const subKeyBulkDelete = document.getElementById('sub-key-bulk-delete');
     const subKeyBulkResend = document.getElementById('sub-key-bulk-resend');
+    const subKeyBulkResetUsage = document.getElementById('sub-key-bulk-reset-usage');
     const subKeyBulkForm = document.getElementById('sub-key-bulk-form');
     const subKeyBulkActionInput = document.getElementById('bulk_sub_key_action_input');
 
@@ -722,6 +830,7 @@ document.addEventListener('DOMContentLoaded', function() {
         subKeySelectedCount.textContent = count;
         subKeyBulkDelete.disabled = count === 0;
         if (subKeyBulkResend) subKeyBulkResend.disabled = count === 0;
+        if (subKeyBulkResetUsage) subKeyBulkResetUsage.disabled = count === 0;
     }
 
     if (subKeySelectAll) {
@@ -772,6 +881,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const subscriptionSelectedCount = document.getElementById('subscription-selected-count');
     const openCreditModalBtn = document.getElementById('open-credit-modal');
     const subscriptionBulkResend = document.getElementById('subscription-bulk-resend');
+    const subscriptionBulkResetUsage = document.getElementById('subscription-bulk-reset-usage');
     const subscriptionBulkForm = document.getElementById('subscription-bulk-form');
     const bulkSubscriptionActionInput = document.getElementById('bulk_subscription_action_input');
     const creditAmountInput = document.getElementById('credit_amount_input');
@@ -795,6 +905,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         if (subscriptionBulkResend) {
             subscriptionBulkResend.disabled = count === 0;
+        }
+        if (subscriptionBulkResetUsage) {
+            subscriptionBulkResetUsage.disabled = count === 0;
         }
     }
 
@@ -904,6 +1017,37 @@ document.addEventListener('DOMContentLoaded', function() {
                 confirmGiveCreditBtn.click();
             }
         });
+    }
+
+    // Reset Usage helper
+    function resetUsage(checkboxSelector) {
+        const checked = document.querySelectorAll(checkboxSelector + ':checked');
+        if (checked.length === 0) return;
+
+        if (!confirm(`Reset usage for ${checked.length} selected license(s)? This resets the current month's receipt scan and AI import counts to 0.`)) return;
+
+        const formData = new FormData();
+        formData.append('reset_usage', '1');
+        checked.forEach(cb => formData.append('license_keys[]', cb.dataset.licenseKey));
+
+        fetch('index.php', { method: 'POST', body: formData })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + (data.error || 'Unknown error'));
+                }
+            })
+            .catch(() => alert('Network error resetting usage.'));
+    }
+
+    if (subscriptionBulkResetUsage) {
+        subscriptionBulkResetUsage.addEventListener('click', () => resetUsage('.subscription-checkbox'));
+    }
+
+    if (subKeyBulkResetUsage) {
+        subKeyBulkResetUsage.addEventListener('click', () => resetUsage('.sub-key-checkbox'));
     }
 });
 </script>

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -199,3 +199,29 @@ table th {
 .modal-footer .btn {
     padding: 10px 20px;
 }
+/* Usage display */
+.usage-count {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--gray-700, #374151);
+    white-space: nowrap;
+}
+.usage-maxed {
+    color: var(--red-500, #ef4444);
+    font-weight: 600;
+}
+.usage-na {
+    color: var(--gray-400, #9ca3af);
+}
+.btn-reset-usage {
+    background-color: var(--primary-blue, #3b82f6);
+    color: white;
+    border: none;
+}
+.btn-reset-usage:not(:disabled):hover {
+    background-color: var(--blue-600, #2563eb);
+}
+.btn-reset-usage:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -5,7 +5,6 @@ require_once '../../email_sender.php';
 require_once '../../community/report/ban_check.php';
 
 require_once __DIR__ . '/../../resources/icons.php';
-require_once __DIR__ . '/../../config/pricing.php';
 
 // Check if user is already logged in
 if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== true) {
@@ -108,149 +107,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_action'])) {
         header('Location: ' . $redirect_url);
         exit;
     }
-}
-
-// Handle usage reset via AJAX
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['reset_usage'])) {
-    header('Content-Type: application/json');
-
-    // Verify CSRF token
-    if (!isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
-        echo json_encode(['success' => false, 'error' => 'Invalid request']);
-        exit;
-    }
-
-    $user_ids = $_POST['user_ids'] ?? [];
-    if (!is_array($user_ids)) $user_ids = [$user_ids];
-    $user_ids = array_filter(array_map('intval', $user_ids), function($id) { return $id > 0; });
-
-    if (empty($user_ids)) {
-        echo json_encode(['success' => false, 'error' => 'No valid user IDs']);
-        exit;
-    }
-
-    global $pdo;
-    $usage_month = date('Y-m-01');
-
-    try {
-        $all_keys = [];
-        foreach ($user_ids as $user_id) {
-            // Get all license keys for this user (direct + free key via email)
-            $stmt = $pdo->prepare("
-                SELECT subscription_id FROM premium_subscriptions WHERE user_id = ?
-                UNION
-                SELECT psk.subscription_key
-                FROM premium_subscription_keys psk
-                JOIN community_users u ON u.email = psk.email
-                WHERE u.id = ? AND psk.email IS NOT NULL AND psk.redeemed_at IS NOT NULL
-            ");
-            $stmt->execute([$user_id, $user_id]);
-            $all_keys = array_merge($all_keys, $stmt->fetchAll(PDO::FETCH_COLUMN));
-        }
-
-        $all_keys = array_unique($all_keys);
-
-        if (empty($all_keys)) {
-            echo json_encode(['success' => true, 'message' => 'No subscriptions found']);
-            exit;
-        }
-
-        $placeholders = implode(',', array_fill(0, count($all_keys), '?'));
-        $params = array_merge($all_keys, [$usage_month]);
-
-        $stmt = $pdo->prepare("UPDATE receipt_scan_usage SET scan_count = 0 WHERE license_key IN ($placeholders) AND usage_month = ?");
-        $stmt->execute($params);
-
-        $stmt = $pdo->prepare("UPDATE ai_import_usage SET scan_count = 0 WHERE license_key IN ($placeholders) AND usage_month = ?");
-        $stmt->execute($params);
-
-        echo json_encode(['success' => true]);
-    } catch (PDOException $e) {
-        error_log("Usage reset error: " . $e->getMessage());
-        echo json_encode(['success' => false, 'error' => 'Database error']);
-    }
-    exit;
-}
-
-// Function to get all license keys (as used in usage tables) linked to a user.
-// For paid subscriptions: license_key = premium_subscriptions.subscription_id
-// For free keys: license_key = premium_subscription_keys.subscription_key (the original key)
-// because the app sends the original key to the usage API.
-function _get_user_license_keys_query() {
-    return "
-        SELECT ps.subscription_id as license_key, u.id as user_id
-        FROM premium_subscriptions ps
-        JOIN community_users u ON ps.user_id = u.id
-        WHERE ps.user_id IS NOT NULL
-        UNION
-        SELECT psk.subscription_key as license_key, u.id as user_id
-        FROM premium_subscription_keys psk
-        JOIN community_users u ON u.email = psk.email
-        WHERE psk.email IS NOT NULL AND psk.redeemed_at IS NOT NULL
-    ";
-}
-
-// Function to get usage data for all users
-function get_user_usage_data() {
-    global $pdo;
-    $usage_month = date('Y-m-01');
-    $data = [];
-    $user_keys_query = _get_user_license_keys_query();
-
-    try {
-        // Receipt scan usage per user
-        $stmt = $pdo->prepare("
-            SELECT uk.user_id, COALESCE(SUM(rsu.scan_count), 0) as receipt_scans
-            FROM ($user_keys_query) uk
-            LEFT JOIN receipt_scan_usage rsu ON rsu.license_key = uk.license_key AND rsu.usage_month = ?
-            GROUP BY uk.user_id
-        ");
-        $stmt->execute([$usage_month]);
-        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            $data[$row['user_id']]['receipt_scans'] = (int)$row['receipt_scans'];
-        }
-
-        // AI import usage per user
-        $stmt = $pdo->prepare("
-            SELECT uk.user_id, COALESCE(SUM(aiu.scan_count), 0) as ai_imports
-            FROM ($user_keys_query) uk
-            LEFT JOIN ai_import_usage aiu ON aiu.license_key = uk.license_key AND aiu.usage_month = ?
-            GROUP BY uk.user_id
-        ");
-        $stmt->execute([$usage_month]);
-        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            if (!isset($data[$row['user_id']])) {
-                $data[$row['user_id']] = ['receipt_scans' => 0];
-            }
-            $data[$row['user_id']]['ai_imports'] = (int)$row['ai_imports'];
-        }
-
-        // Track which users have active premium subscriptions (direct or via free key)
-        $stmt = $pdo->prepare("
-            SELECT DISTINCT user_id FROM (
-                SELECT user_id FROM premium_subscriptions
-                WHERE user_id IS NOT NULL AND status IN ('active', 'cancelled') AND end_date > NOW()
-                UNION
-                SELECT u.id as user_id
-                FROM premium_subscription_keys psk
-                JOIN community_users u ON u.email = psk.email
-                JOIN premium_subscriptions ps ON ps.subscription_id = psk.subscription_id
-                WHERE psk.email IS NOT NULL AND psk.subscription_id IS NOT NULL
-                AND ps.status IN ('active', 'cancelled') AND ps.end_date > NOW()
-            ) combined
-        ");
-        $stmt->execute();
-        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $uid) {
-            if (!isset($data[$uid])) {
-                $data[$uid] = ['receipt_scans' => 0, 'ai_imports' => 0];
-            }
-            $data[$uid]['has_premium'] = true;
-        }
-    } catch (PDOException $e) {
-        error_log("Error fetching usage data: " . $e->getMessage());
-    }
-
-    return $data;
 }
 
 // Function to get all users with optional filters
@@ -379,12 +235,6 @@ foreach ($users as $user) {
         $banned_count++;
     }
 }
-
-// Get usage data and limits
-$usage_data = get_user_usage_data();
-$pricing_config = get_pricing_config();
-$receipt_limit = $pricing_config['receipt_scan_monthly_limit'];
-$ai_import_limit = $pricing_config['ai_import_monthly_limit'];
 
 // Check for flash messages
 $message = '';
@@ -519,11 +369,7 @@ include '../admin_header.php';
                             <?= svg_icon('shield-check') ?>
                             Unban Selected
                         </button>
-                        <button type="button" class="btn btn-bulk btn-reset-usage" data-action="reset_usage" disabled>
-                            <?= svg_icon('refresh') ?>
-                            Reset Usage
-                        </button>
-                        <button type="button" class="btn btn-bulk btn-delete" data-action="delete" disabled>
+<button type="button" class="btn btn-bulk btn-delete" data-action="delete" disabled>
                             <?= svg_icon('trash') ?>
                             Delete Selected
                         </button>
@@ -547,8 +393,6 @@ include '../admin_header.php';
                                 <th>Role</th>
                                 <th>Verified</th>
                                 <th>Banned</th>
-                                <th>Receipt Scans</th>
-                                <th>AI Imports</th>
                                 <th>Created</th>
                                 <th>Last Login</th>
                             </tr>
@@ -588,27 +432,6 @@ include '../admin_header.php';
                                             <span class="badge badge-active">Active</span>
                                         <?php endif; ?>
                                     </td>
-                                    <?php
-                                        $uid = $user['id'];
-                                        $has_usage = isset($usage_data[$uid]);
-                                        $scans = $has_usage ? ($usage_data[$uid]['receipt_scans'] ?? 0) : 0;
-                                        $imports = $has_usage ? ($usage_data[$uid]['ai_imports'] ?? 0) : 0;
-                                        $has_premium = $has_usage && !empty($usage_data[$uid]['has_premium']);
-                                    ?>
-                                    <td>
-                                        <?php if ($has_premium): ?>
-                                            <span class="usage-count <?php echo $scans >= $receipt_limit ? 'usage-maxed' : ''; ?>"><?php echo $scans; ?> / <?php echo $receipt_limit; ?></span>
-                                        <?php else: ?>
-                                            <span class="usage-na">&mdash;</span>
-                                        <?php endif; ?>
-                                    </td>
-                                    <td>
-                                        <?php if ($has_premium): ?>
-                                            <span class="usage-count <?php echo $imports >= $ai_import_limit ? 'usage-maxed' : ''; ?>"><?php echo $imports; ?> / <?php echo $ai_import_limit; ?></span>
-                                        <?php else: ?>
-                                            <span class="usage-na">&mdash;</span>
-                                        <?php endif; ?>
-                                    </td>
                                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($user['created_at']))); ?></td>
                                     <td><?php echo $user['last_login'] ? htmlspecialchars(date('Y-m-d', strtotime($user['last_login']))) : 'Never'; ?></td>
                                 </tr>
@@ -628,7 +451,6 @@ include '../admin_header.php';
         const rowCheckboxes = document.querySelectorAll('.row-checkbox');
         const bulkButtons = document.querySelectorAll('.btn-bulk');
         const unbanButton = document.querySelector('.btn-unban');
-        const resetUsageButton = document.querySelector('.btn-reset-usage');
         const deleteButton = document.querySelector('.btn-delete');
         const selectedCountSpan = document.getElementById('selected-count');
         const bulkForm = document.getElementById('bulk-form');
@@ -650,12 +472,10 @@ include '../admin_header.php';
             // Enable/disable buttons based on selection
             if (count === 0) {
                 unbanButton.disabled = true;
-                resetUsageButton.disabled = true;
                 deleteButton.disabled = true;
             } else {
                 // Only enable unban if at least one banned user is selected
                 unbanButton.disabled = bannedUsersSelected === 0;
-                resetUsageButton.disabled = false;
                 deleteButton.disabled = false;
             }
 
@@ -700,42 +520,9 @@ include '../admin_header.php';
                     confirmMessage = `Are you sure you want to delete ${count} user${count > 1 ? 's' : ''}? This action cannot be undone.`;
                 } else if (action === 'unban') {
                     confirmMessage = `Are you sure you want to unban ${count} user${count > 1 ? 's' : ''}? They will be able to post again.`;
-                } else if (action === 'reset_usage') {
-                    confirmMessage = `Are you sure you want to reset all usage counts for ${count} user${count > 1 ? 's' : ''}?`;
                 }
 
                 if (confirm(confirmMessage)) {
-                    if (action === 'reset_usage') {
-                        // Handle reset usage via AJAX
-                        const userIds = Array.from(checkedBoxes).map(cb => cb.value);
-                        const formData = new FormData();
-                        formData.append('reset_usage', '1');
-                        formData.append('csrf_token', document.querySelector('input[name="csrf_token"]').value);
-                        userIds.forEach(id => formData.append('user_ids[]', id));
-
-                        resetUsageButton.disabled = true;
-                        resetUsageButton.textContent = 'Resetting...';
-
-                        fetch('index.php', { method: 'POST', body: formData })
-                            .then(r => r.json())
-                            .then(data => {
-                                if (data.success) {
-                                    sessionStorage.setItem('scrollPosition', window.scrollY);
-                                    window.location.reload();
-                                } else {
-                                    alert('Reset failed: ' + (data.error || 'Unknown error'));
-                                    resetUsageButton.disabled = false;
-                                    resetUsageButton.textContent = 'Reset Usage';
-                                }
-                            })
-                            .catch(() => {
-                                alert('Network error');
-                                resetUsageButton.disabled = false;
-                                resetUsageButton.textContent = 'Reset Usage';
-                            });
-                        return;
-                    }
-
                     bulkActionInput.value = action;
                     sessionStorage.setItem('scrollPosition', window.scrollY);
                     bulkForm.submit();

--- a/admin/users/style.css
+++ b/admin/users/style.css
@@ -245,15 +245,6 @@
   background-color: var(--emerald-600);
 }
 
-.btn-reset-usage {
-  background-color: var(--primary-blue);
-  color: var(--white);
-}
-
-.btn-reset-usage:not(:disabled):hover {
-  background-color: var(--blue-600, #2563eb);
-}
-
 .btn-delete {
   background: var(--red-500);
   color: var(--white);
@@ -281,25 +272,6 @@
   margin: 0;
   font-size: 1rem;
 }
-
-/* Usage Cells */
-
-.usage-count {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--gray-700);
-  white-space: nowrap;
-}
-
-.usage-maxed {
-  color: var(--red-500);
-  font-weight: 600;
-}
-
-.usage-na {
-  color: var(--gray-400);
-}
-
 
 /* Responsive adjustments */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
This PR enhances the license management admin panel by adding usage tracking visibility and bulk email resend functionality for both premium subscriptions and free subscription keys. It also refactors usage reset functionality to be license-key based rather than user-based.

## Key Changes

- **Usage Tracking Display**: Added receipt scan and AI import usage columns to both premium subscriptions and free subscription keys tables, showing current month usage against configured limits
- **Bulk Email Resend**: Implemented "Resend Email" buttons for both premium subscriptions and free subscription keys, allowing admins to resend subscription/license key emails to multiple recipients at once
- **Usage Reset by License Key**: Moved usage reset functionality from user management to license management, now operating on individual license keys (subscription IDs and subscription keys) rather than aggregating by user
- **New Helper Function**: Added `get_license_usage()` function to fetch usage data for a list of license keys from receipt_scan_usage and ai_import_usage tables
- **AJAX Usage Reset**: Implemented AJAX-based usage reset endpoint in license management that resets both receipt scan and AI import counts for selected licenses
- **Pricing Config Integration**: Added pricing configuration import to license management to display usage limits alongside actual usage
- **UI Improvements**: 
  - Added data attributes to checkboxes to track license keys for reset operations
  - Added visual indicators (usage-maxed class) when usage reaches limits
  - Added "N/A" display for unredeemed free keys with no usage data
  - Styled new reset usage buttons consistently with existing UI

## Implementation Details

- Usage data is fetched for the current calendar month (Y-m-01)
- Reset usage operations accept multiple license keys via AJAX POST request
- Free subscription keys show usage only if they have been redeemed
- Bulk operations include confirmation dialogs to prevent accidental actions
- Removed duplicate usage reset code and user-level usage tracking from admin/users/index.php
- Styling for usage display and reset buttons added to admin/license/style.css

https://claude.ai/code/session_011YqA4PzHetq2GNC94pRcDB