### PR TITLE
Make exchange rates API authentication optional

### DIFF
--- a/api/exchange-rates.php
+++ b/api/exchange-rates.php
@@ -21,14 +21,15 @@ $dotenv->safeLoad();
 set_portal_headers();
 require_method(['GET']);
 
-// Authenticate using license key
+// Authenticate using license key (optional — exchange rates are available to all users)
 $license = authenticate_license_request();
-if (!$license) {
-    send_error_response(401, 'Invalid or missing license key.', 'UNAUTHORIZED');
-}
 
-// Rate limiting: 120 requests per 15 minutes per license (global per license, not per IP)
-$rateLimitId = substr($license['license_key_hash'], 0, 16);
+// Rate limiting: use license hash if authenticated, otherwise use IP address
+if ($license) {
+    $rateLimitId = substr($license['license_key_hash'], 0, 16);
+} else {
+    $rateLimitId = 'ip_' . substr(hash('sha256', $_SERVER['REMOTE_ADDR'] ?? 'unknown'), 0, 16);
+}
 $rateLimitKey = 'rates_' . $rateLimitId;
 if (is_rate_limited($rateLimitId, 120, 900, $rateLimitKey)) {
     send_error_response(429, 'Rate limit exceeded. Please try again later.', 'RATE_LIMITED');


### PR DESCRIPTION
## Summary
Modified the exchange rates API endpoint to make license key authentication optional while maintaining rate limiting for all users.

## Key Changes
- Removed the mandatory license key requirement for accessing exchange rates
- Updated authentication logic to allow requests without a valid license key
- Implemented dual rate limiting strategy:
  - Authenticated requests: rate limited by license key hash (120 requests per 15 minutes)
  - Unauthenticated requests: rate limited by IP address using the same threshold

## Implementation Details
- The `authenticate_license_request()` call is retained for tracking authenticated users, but no longer blocks unauthenticated access
- Rate limit ID is now conditionally determined: uses the license key hash if available, otherwise falls back to a hashed IP address prefixed with `ip_`
- Both authenticated and unauthenticated users share the same rate limit quota (120 requests per 15 minutes), ensuring fair usage across all access patterns

https://claude.ai/code/session_01GkYkNFe84MvY42L7WiogWa