### PR TITLE
Add dev subdomain deployment to CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,49 +69,34 @@ jobs:
             cat /tmp/deleted_files.txt
           fi
 
-      - name: Deploy to production (full mirror)
+      - name: Deploy (full mirror)
         if: steps.changes.outputs.mode == 'full'
         run: |
-          lftp -u "${{ secrets.FTP_USERNAME }}," \
-            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
-                mirror --reverse --delete --verbose --no-perms \
-                  --exclude ^\.git/$ \
-                  --exclude ^\.github/$ \
-                  --exclude ^\.gitignore$ \
-                  --exclude ^README\.md$ \
-                  --exclude ^read-me/$ \
-                  --exclude ^composer\.json$ \
-                  --exclude ^composer\.lock$ \
-                  --exclude ^mysql_schema\.sql$ \
-                  --exclude ^\.ftp-deploy-sync-state\.json$ \
-                  ./ ${{ secrets.FTP_SERVER_DIR }}; \
-                bye" \
-            sftp://${{ secrets.FTP_SERVER }}
+          DEPLOY_TARGETS="${{ secrets.FTP_SERVER_DIR }} ${{ secrets.FTP_DEV_SERVER_DIR }}"
 
-      - name: Deploy to dev subdomain (full mirror)
-        if: steps.changes.outputs.mode == 'full'
-        run: |
-          lftp -u "${{ secrets.FTP_USERNAME }}," \
-            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
-                mirror --reverse --delete --verbose --no-perms \
-                  --exclude ^\.git/$ \
-                  --exclude ^\.github/$ \
-                  --exclude ^\.gitignore$ \
-                  --exclude ^README\.md$ \
-                  --exclude ^read-me/$ \
-                  --exclude ^composer\.json$ \
-                  --exclude ^composer\.lock$ \
-                  --exclude ^mysql_schema\.sql$ \
-                  --exclude ^\.ftp-deploy-sync-state\.json$ \
-                  ./ ${{ secrets.FTP_DEV_SERVER_DIR }}; \
-                bye" \
-            sftp://${{ secrets.FTP_SERVER }}
+          for REMOTE_DIR in $DEPLOY_TARGETS; do
+            echo "=== Full mirror deploy to ${REMOTE_DIR} ==="
+            lftp -u "${{ secrets.FTP_USERNAME }}," \
+              -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts'; \
+                  mirror --reverse --delete --verbose --no-perms \
+                    --exclude ^\.git/$ \
+                    --exclude ^\.github/$ \
+                    --exclude ^\.gitignore$ \
+                    --exclude ^README\.md$ \
+                    --exclude ^read-me/$ \
+                    --exclude ^composer\.json$ \
+                    --exclude ^composer\.lock$ \
+                    --exclude ^mysql_schema\.sql$ \
+                    --exclude ^\.ftp-deploy-sync-state\.json$ \
+                    ./ ${REMOTE_DIR}; \
+                  bye" \
+              sftp://${{ secrets.FTP_SERVER }}
+          done
 
-      - name: Deploy to production (incremental)
+      - name: Deploy (incremental)
         if: steps.changes.outputs.mode == 'incremental'
         run: |
-          REMOTE_DIR="${{ secrets.FTP_SERVER_DIR }}"
-          LFTP_CMDS=""
+          DEPLOY_TARGETS="${{ secrets.FTP_SERVER_DIR }} ${{ secrets.FTP_DEV_SERVER_DIR }}"
 
           # Function to check if a file should be excluded
           is_excluded() {
@@ -121,98 +106,57 @@ jobs:
             esac
           }
 
-          # Upload changed files
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            is_excluded "$file" && continue
-            [ ! -f "$file" ] && continue
-            dir=$(dirname "$file")
-            if [ "$dir" != "." ]; then
-              LFTP_CMDS="${LFTP_CMDS}mkdir -p -f ${REMOTE_DIR}/${dir}; "
-              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
-            else
-              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
+          for REMOTE_DIR in $DEPLOY_TARGETS; do
+            echo "=== Incremental deploy to ${REMOTE_DIR} ==="
+
+            # Write lftp commands to a script file to avoid quoting/escaping issues
+            SCRIPT_FILE=$(mktemp /tmp/lftp_script.XXXXXX)
+            HAS_COMMANDS=false
+
+            # Upload changed files
+            while IFS= read -r file; do
+              [ -z "$file" ] && continue
+              is_excluded "$file" && continue
+              [ ! -f "$file" ] && continue
+              dir=$(dirname "$file")
+              if [ "$dir" != "." ]; then
+                printf 'mkdir -p -f "%s/%s"\n' "${REMOTE_DIR}" "${dir}" >> "$SCRIPT_FILE"
+              fi
+              printf 'put "./%s" -o "%s/%s"\n' "${file}" "${REMOTE_DIR}" "${file}" >> "$SCRIPT_FILE"
+              HAS_COMMANDS=true
+            done < /tmp/changed_files.txt
+
+            # Delete removed files from remote
+            while IFS= read -r file; do
+              [ -z "$file" ] && continue
+              is_excluded "$file" && continue
+              printf 'rm -f "%s/%s"\n' "${REMOTE_DIR}" "${file}" >> "$SCRIPT_FILE"
+              HAS_COMMANDS=true
+            done < /tmp/deleted_files.txt
+
+            # If composer deps changed, mirror the entire vendor/ directory
+            if [ "${{ steps.changes.outputs.composer_changed }}" = "true" ]; then
+              echo "Composer files changed, re-uploading vendor/"
+              printf 'mirror --reverse --delete --verbose --no-perms vendor/ "%s/vendor/"\n' "${REMOTE_DIR}" >> "$SCRIPT_FILE"
+              HAS_COMMANDS=true
             fi
-          done < /tmp/changed_files.txt
 
-          # Delete removed files from remote
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            is_excluded "$file" && continue
-            LFTP_CMDS="${LFTP_CMDS}rm -f ${REMOTE_DIR}/${file}; "
-          done < /tmp/deleted_files.txt
-
-          # If composer deps changed, mirror the entire vendor/ directory
-          if [ "${{ steps.changes.outputs.composer_changed }}" = "true" ]; then
-            echo "Composer files changed, re-uploading vendor/"
-            LFTP_CMDS="${LFTP_CMDS}mirror --reverse --delete --verbose --no-perms vendor/ ${REMOTE_DIR}/vendor/; "
-          fi
-
-          if [ -z "$LFTP_CMDS" ]; then
-            echo "No files to deploy to production"
-            exit 0
-          fi
-
-          echo "Deploying changed files to production..."
-          echo "Commands: $LFTP_CMDS"
-
-          lftp -u "${{ secrets.FTP_USERNAME }}," \
-            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
-                ${LFTP_CMDS} \
-                bye" \
-            sftp://${{ secrets.FTP_SERVER }}
-
-      - name: Deploy to dev subdomain (incremental)
-        if: steps.changes.outputs.mode == 'incremental'
-        run: |
-          REMOTE_DIR="${{ secrets.FTP_DEV_SERVER_DIR }}"
-          LFTP_CMDS=""
-
-          # Function to check if a file should be excluded
-          is_excluded() {
-            case "$1" in
-              .git/*|.github/*|.gitignore|README.md|read-me/*|composer.json|composer.lock|mysql_schema.sql|.ftp-deploy-sync-state.json) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          # Upload changed files
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            is_excluded "$file" && continue
-            [ ! -f "$file" ] && continue
-            dir=$(dirname "$file")
-            if [ "$dir" != "." ]; then
-              LFTP_CMDS="${LFTP_CMDS}mkdir -p -f ${REMOTE_DIR}/${dir}; "
-              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
-            else
-              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
+            if [ "$HAS_COMMANDS" = "false" ]; then
+              echo "No files to deploy to ${REMOTE_DIR}"
+              rm -f "$SCRIPT_FILE"
+              continue
             fi
-          done < /tmp/changed_files.txt
 
-          # Delete removed files from remote
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            is_excluded "$file" && continue
-            LFTP_CMDS="${LFTP_CMDS}rm -f ${REMOTE_DIR}/${file}; "
-          done < /tmp/deleted_files.txt
+            echo "Deploying changed files to ${REMOTE_DIR}..."
+            echo "=== lftp script ==="
+            cat "$SCRIPT_FILE"
+            echo "==================="
 
-          # If composer deps changed, mirror the entire vendor/ directory
-          if [ "${{ steps.changes.outputs.composer_changed }}" = "true" ]; then
-            echo "Composer files changed, re-uploading vendor/"
-            LFTP_CMDS="${LFTP_CMDS}mirror --reverse --delete --verbose --no-perms vendor/ ${REMOTE_DIR}/vendor/; "
-          fi
+            lftp -u "${{ secrets.FTP_USERNAME }}," \
+              -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts'; \
+                  source ${SCRIPT_FILE}; \
+                  bye" \
+              sftp://${{ secrets.FTP_SERVER }}
 
-          if [ -z "$LFTP_CMDS" ]; then
-            echo "No files to deploy to dev subdomain"
-            exit 0
-          fi
-
-          echo "Deploying changed files to dev subdomain..."
-          echo "Commands: $LFTP_CMDS"
-
-          lftp -u "${{ secrets.FTP_USERNAME }}," \
-            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
-                ${LFTP_CMDS} \
-                bye" \
-            sftp://${{ secrets.FTP_SERVER }}
+            rm -f "$SCRIPT_FILE"
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
             cat /tmp/deleted_files.txt
           fi
 
-      - name: Deploy (full mirror)
+      - name: Deploy to production (full mirror)
         if: steps.changes.outputs.mode == 'full'
         run: |
           lftp -u "${{ secrets.FTP_USERNAME }}," \
@@ -88,7 +88,26 @@ jobs:
                 bye" \
             sftp://${{ secrets.FTP_SERVER }}
 
-      - name: Deploy (incremental)
+      - name: Deploy to dev subdomain (full mirror)
+        if: steps.changes.outputs.mode == 'full'
+        run: |
+          lftp -u "${{ secrets.FTP_USERNAME }}," \
+            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
+                mirror --reverse --delete --verbose --no-perms \
+                  --exclude ^\.git/$ \
+                  --exclude ^\.github/$ \
+                  --exclude ^\.gitignore$ \
+                  --exclude ^README\.md$ \
+                  --exclude ^read-me/$ \
+                  --exclude ^composer\.json$ \
+                  --exclude ^composer\.lock$ \
+                  --exclude ^mysql_schema\.sql$ \
+                  --exclude ^\.ftp-deploy-sync-state\.json$ \
+                  ./ ${{ secrets.FTP_DEV_SERVER_DIR }}; \
+                bye" \
+            sftp://${{ secrets.FTP_SERVER }}
+
+      - name: Deploy to production (incremental)
         if: steps.changes.outputs.mode == 'incremental'
         run: |
           REMOTE_DIR="${{ secrets.FTP_SERVER_DIR }}"
@@ -130,11 +149,66 @@ jobs:
           fi
 
           if [ -z "$LFTP_CMDS" ]; then
-            echo "No files to deploy"
+            echo "No files to deploy to production"
             exit 0
           fi
 
-          echo "Deploying changed files..."
+          echo "Deploying changed files to production..."
+          echo "Commands: $LFTP_CMDS"
+
+          lftp -u "${{ secrets.FTP_USERNAME }}," \
+            -e "set sftp:connect-program 'ssh -a -x -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no'; \
+                ${LFTP_CMDS} \
+                bye" \
+            sftp://${{ secrets.FTP_SERVER }}
+
+      - name: Deploy to dev subdomain (incremental)
+        if: steps.changes.outputs.mode == 'incremental'
+        run: |
+          REMOTE_DIR="${{ secrets.FTP_DEV_SERVER_DIR }}"
+          LFTP_CMDS=""
+
+          # Function to check if a file should be excluded
+          is_excluded() {
+            case "$1" in
+              .git/*|.github/*|.gitignore|README.md|read-me/*|composer.json|composer.lock|mysql_schema.sql|.ftp-deploy-sync-state.json) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # Upload changed files
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            is_excluded "$file" && continue
+            [ ! -f "$file" ] && continue
+            dir=$(dirname "$file")
+            if [ "$dir" != "." ]; then
+              LFTP_CMDS="${LFTP_CMDS}mkdir -p -f ${REMOTE_DIR}/${dir}; "
+              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
+            else
+              LFTP_CMDS="${LFTP_CMDS}put ./${file} -o ${REMOTE_DIR}/${file}; "
+            fi
+          done < /tmp/changed_files.txt
+
+          # Delete removed files from remote
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            is_excluded "$file" && continue
+            LFTP_CMDS="${LFTP_CMDS}rm -f ${REMOTE_DIR}/${file}; "
+          done < /tmp/deleted_files.txt
+
+          # If composer deps changed, mirror the entire vendor/ directory
+          if [ "${{ steps.changes.outputs.composer_changed }}" = "true" ]; then
+            echo "Composer files changed, re-uploading vendor/"
+            LFTP_CMDS="${LFTP_CMDS}mirror --reverse --delete --verbose --no-perms vendor/ ${REMOTE_DIR}/vendor/; "
+          fi
+
+          if [ -z "$LFTP_CMDS" ]; then
+            echo "No files to deploy to dev subdomain"
+            exit 0
+          fi
+
+          echo "Deploying changed files to dev subdomain..."
           echo "Commands: $LFTP_CMDS"
 
           lftp -u "${{ secrets.FTP_USERNAME }}," \


### PR DESCRIPTION
## Summary
This PR extends the deployment workflow to support deploying to a development subdomain in addition to the production environment. Both full mirror and incremental deployment modes are now available for the dev subdomain.

## Key Changes
- **Renamed deployment steps** for clarity: "Deploy (full mirror)" → "Deploy to production (full mirror)" and "Deploy (incremental)" → "Deploy to production (incremental)"
- **Added full mirror deployment to dev subdomain**: New step that mirrors the entire codebase to `FTP_DEV_SERVER_DIR` with the same exclusion rules as production
- **Added incremental deployment to dev subdomain**: New step that handles file-by-file uploads/deletions and vendor directory syncing for the dev environment
- **Updated status messages**: Changed generic "No files to deploy" messages to specify the target environment (production vs. dev subdomain)

## Implementation Details
- Both dev subdomain deployment steps use the same exclusion patterns as production (`.git/`, `.github/`, `.gitignore`, `README.md`, `read-me/`, `composer.json`, `composer.lock`, `mysql_schema.sql`, `.ftp-deploy-sync-state.json`)
- The incremental dev deployment includes the same composer dependency handling as production
- Dev deployments use the `FTP_DEV_SERVER_DIR` secret for the remote directory path
- All deployment steps maintain the same SFTP connection configuration and security settings

https://claude.ai/code/session_016KKDk2spqLzasv3hJcet7z