### PR TITLE
Remove license requirement from exchange rates API

### DIFF
--- a/api/exchange-rates.php
+++ b/api/exchange-rates.php
@@ -21,12 +21,11 @@ $dotenv->safeLoad();
 set_portal_headers();
 require_method(['GET']);
 
-// Authenticate using license key (optional — exchange rates are available to all users)
-$license = authenticate_license_request();
-
-// Rate limiting: use license hash if authenticated, otherwise use IP address
-if ($license) {
-    $rateLimitId = substr($license['license_key_hash'], 0, 16);
+// Exchange rates are a free feature available to all users — no license key required.
+// Rate limiting uses device ID if provided, otherwise falls back to IP address.
+$deviceId = authenticate_device_request();
+if ($deviceId) {
+    $rateLimitId = 'dev_' . substr($deviceId, 0, 16);
 } else {
     $rateLimitId = 'ip_' . substr(hash('sha256', $_SERVER['REMOTE_ADDR'] ?? 'unknown'), 0, 16);
 }


### PR DESCRIPTION
## Summary
Refactored the exchange rates API endpoint to remove license key authentication and instead use device ID-based rate limiting, making exchange rates a freely available feature for all users.

## Key Changes
- Removed license key authentication requirement from the exchange rates endpoint
- Replaced license-based rate limiting with device ID-based rate limiting
- Updated rate limit identifier generation to use device ID when available (prefixed with `dev_`), falling back to IP address hash (prefixed with `ip_`)
- Updated code comments to reflect that exchange rates are now a free feature requiring no authentication

## Implementation Details
- The `authenticate_license_request()` call has been replaced with `authenticate_device_request()`
- Rate limit IDs now use a `dev_` prefix for device-authenticated requests and `ip_` prefix for IP-based fallback
- The rate limiting logic remains functionally similar but operates on device identity rather than license key hash
- This change maintains backward compatibility for rate limiting while opening the feature to unauthenticated users

https://claude.ai/code/session_01CLEQ5KKYr5P6w6pcnhNk2F