### PR TITLE
Migrate exchange rates caching from file to MySQL database

### DIFF
--- a/api/exchange-rates-batch.php
+++ b/api/exchange-rates-batch.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Batch Exchange Rates Endpoint
+ *
+ * POST /api/exchange-rates-batch - Fetch exchange rates for multiple dates at once.
+ *
+ * Request body (JSON):
+ *   { "dates": ["2025-01-15", "2025-03-20", ...] }
+ *
+ * Returns all rates from MySQL cache, fetching from OpenExchangeRates only for
+ * dates not yet cached. Historical rates are stored permanently (they never change).
+ * Today's rate is refreshed if older than 1 hour.
+ */
+
+require_once __DIR__ . '/portal/portal-helper.php';
+
+// Load environment variables
+require_once __DIR__ . '/../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../');
+$dotenv->safeLoad();
+
+set_portal_headers();
+require_method(['POST']);
+
+// Batch requests may fetch many dates from OER — allow up to 2 minutes
+set_time_limit(120);
+
+// Rate limiting (counts as 1 request regardless of how many dates)
+$deviceId = authenticate_device_request();
+if ($deviceId) {
+    $rateLimitId = 'dev_' . substr($deviceId, 0, 16);
+} else {
+    $rateLimitId = 'ip_' . substr(hash('sha256', $_SERVER['REMOTE_ADDR'] ?? 'unknown'), 0, 16);
+}
+$rateLimitKey = 'rates_' . $rateLimitId;
+if (is_rate_limited($rateLimitId, 120, 900, $rateLimitKey)) {
+    send_error_response(429, 'Rate limit exceeded. Please try again later.', 'RATE_LIMITED');
+}
+record_rate_limit_attempt($rateLimitId, $rateLimitKey);
+
+// Validate server configuration
+$apiKey = $_ENV['OPENEXCHANGERATES_API_KEY'] ?? '';
+if (empty($apiKey)) {
+    send_error_response(500, 'Exchange rate service not configured on server.', 'CONFIG_ERROR');
+}
+
+// Parse request body
+$body = json_decode(file_get_contents('php://input'), true);
+if (!$body || !isset($body['dates']) || !is_array($body['dates'])) {
+    send_error_response(400, 'Request body must contain a "dates" array.', 'INVALID_REQUEST');
+}
+
+$requestedDates = $body['dates'];
+if (count($requestedDates) > 500) {
+    send_error_response(400, 'Maximum 500 dates per request.', 'TOO_MANY_DATES');
+}
+
+// Validate all dates
+$today = date('Y-m-d');
+$validDates = [];
+foreach ($requestedDates as $date) {
+    if (!is_string($date)) continue;
+    $parsed = DateTime::createFromFormat('Y-m-d', $date);
+    if (!$parsed || $parsed->format('Y-m-d') !== $date) continue;
+    if ($parsed > new DateTime()) continue; // skip future dates
+    $validDates[] = $date;
+}
+$validDates = array_unique($validDates);
+
+if (empty($validDates)) {
+    send_json_response(200, [
+        'success' => true,
+        'base' => 'USD',
+        'results' => new stdClass(),
+        'failed' => [],
+        'timestamp' => date('c'),
+    ]);
+}
+
+// Connect to database
+require_once __DIR__ . '/../db_connect.php';
+if (!$pdo) {
+    send_error_response(500, 'Database connection failed.', 'DB_ERROR');
+}
+
+// Ensure table exists
+$pdo->exec("CREATE TABLE IF NOT EXISTS exchange_rates (
+    rate_date DATE NOT NULL,
+    rates JSON NOT NULL,
+    fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (rate_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+// Fetch all cached rates from MySQL in one query
+$placeholders = implode(',', array_fill(0, count($validDates), '?'));
+$stmt = $pdo->prepare("SELECT rate_date, rates, fetched_at FROM exchange_rates WHERE rate_date IN ($placeholders)");
+$stmt->execute($validDates);
+$cachedRows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$results = [];
+$datesToFetch = [];
+$oneHourAgo = date('Y-m-d H:i:s', time() - 3600);
+
+foreach ($cachedRows as $row) {
+    $dateStr = $row['rate_date'];
+    $rates = json_decode($row['rates'], true);
+    if ($rates === null) {
+        $datesToFetch[] = $dateStr;
+        continue;
+    }
+    // Today's rate: check freshness (1hr TTL)
+    if ($dateStr === $today && $row['fetched_at'] < $oneHourAgo) {
+        $datesToFetch[] = $dateStr;
+        continue;
+    }
+    $results[$dateStr] = $rates;
+}
+
+// Find dates not in DB at all
+$cachedDateSet = array_column($cachedRows, 'rate_date');
+foreach ($validDates as $date) {
+    if (!in_array($date, $cachedDateSet) && !isset($results[$date])) {
+        $datesToFetch[] = $date;
+    }
+}
+$datesToFetch = array_unique($datesToFetch);
+
+// Cap OER calls per batch to protect API quota
+$maxOerCalls = 30;
+$failed = [];
+if (count($datesToFetch) > $maxOerCalls) {
+    // Fetch the first $maxOerCalls, mark the rest as failed
+    $overflow = array_slice($datesToFetch, $maxOerCalls);
+    $datesToFetch = array_slice($datesToFetch, 0, $maxOerCalls);
+    $failed = $overflow;
+}
+
+// Fetch missing dates from OpenExchangeRates and store in MySQL
+$insertStmt = $pdo->prepare(
+    "INSERT INTO exchange_rates (rate_date, rates, fetched_at) VALUES (?, ?, NOW())
+     ON DUPLICATE KEY UPDATE rates = VALUES(rates), fetched_at = NOW()"
+);
+
+foreach ($datesToFetch as $date) {
+    $isLatest = ($date === $today);
+    if ($isLatest) {
+        $url = "https://openexchangerates.org/api/latest.json?app_id={$apiKey}&base=USD";
+    } else {
+        $url = "https://openexchangerates.org/api/historical/{$date}.json?app_id={$apiKey}&base=USD";
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 15,
+        CURLOPT_CONNECTTIMEOUT => 5,
+    ]);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($response === false || $httpCode !== 200) {
+        $failed[] = $date;
+        continue;
+    }
+
+    $data = json_decode($response, true);
+    if ($data === null || !isset($data['rates'])) {
+        $failed[] = $date;
+        continue;
+    }
+
+    // Store in MySQL
+    $insertStmt->execute([$date, json_encode($data['rates'])]);
+
+    $results[$date] = $data['rates'];
+}
+
+send_json_response(200, [
+    'success' => true,
+    'base' => 'USD',
+    'results' => empty($results) ? new stdClass() : $results,
+    'failed' => array_values(array_unique($failed)),
+    'timestamp' => date('c'),
+]);

--- a/api/exchange-rates-batch.php
+++ b/api/exchange-rates-batch.php
@@ -65,7 +65,7 @@ foreach ($requestedDates as $date) {
     if ($parsed > new DateTime()) continue; // skip future dates
     $validDates[] = $date;
 }
-$validDates = array_unique($validDates);
+$validDates = array_values(array_unique($validDates));
 
 if (empty($validDates)) {
     send_json_response(200, [

--- a/api/exchange-rates.php
+++ b/api/exchange-rates.php
@@ -5,7 +5,8 @@
  * GET /api/exchange-rates - Proxy OpenExchangeRates API calls
  *
  * Fetches exchange rates from OpenExchangeRates using server-side API key.
- * Implements server-side file caching to reduce upstream API calls.
+ * Implements persistent MySQL caching — historical rates are stored permanently
+ * (they never change), today's rate is refreshed every hour.
  *
  * Query parameters:
  *   - date: Optional date (YYYY-MM-DD). If omitted or today, fetches latest rates.
@@ -57,27 +58,38 @@ if (!empty($date) && !$isLatest) {
     }
 }
 
-// Check server-side cache
-$cacheDir = sys_get_temp_dir() . '/argo_exchange_rates';
-if (!is_dir($cacheDir)) {
-    mkdir($cacheDir, 0755, true);
-}
+$lookupDate = $isLatest ? date('Y-m-d') : $date;
 
-$cacheKey = $isLatest ? 'latest' : $date;
-$cacheFile = $cacheDir . '/' . $cacheKey . '.json';
-$cacheTtl = $isLatest ? 3600 : 86400; // 1 hour for latest, 24 hours for historical
+// Check MySQL cache
+require_once __DIR__ . '/../db_connect.php';
+if ($pdo) {
+    // Ensure table exists
+    $pdo->exec("CREATE TABLE IF NOT EXISTS exchange_rates (
+        rate_date DATE NOT NULL,
+        rates JSON NOT NULL,
+        fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (rate_date)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
 
-if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl) {
-    $cached = json_decode(file_get_contents($cacheFile), true);
-    if ($cached !== null) {
-        send_json_response(200, [
-            'success' => true,
-            'base' => 'USD',
-            'date' => $cached['date'] ?? $date,
-            'rates' => $cached['rates'] ?? [],
-            'cached' => true,
-            'timestamp' => date('c'),
-        ]);
+    $stmt = $pdo->prepare("SELECT rates, fetched_at FROM exchange_rates WHERE rate_date = ?");
+    $stmt->execute([$lookupDate]);
+    $cached = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($cached) {
+        $rates = json_decode($cached['rates'], true);
+        // Historical rates never expire; today's rate has 1hr TTL
+        $isStale = $isLatest && (strtotime($cached['fetched_at']) < time() - 3600);
+
+        if ($rates !== null && !$isStale) {
+            send_json_response(200, [
+                'success' => true,
+                'base' => 'USD',
+                'date' => $lookupDate,
+                'rates' => $rates,
+                'cached' => true,
+                'timestamp' => date('c'),
+            ]);
+        }
     }
 }
 
@@ -85,7 +97,7 @@ if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl) {
 if ($isLatest) {
     $url = "https://openexchangerates.org/api/latest.json?app_id={$apiKey}&base=USD";
 } else {
-    $url = "https://openexchangerates.org/api/historical/{$date}.json?app_id={$apiKey}&base=USD";
+    $url = "https://openexchangerates.org/api/historical/{$lookupDate}.json?app_id={$apiKey}&base=USD";
 }
 
 $ch = curl_init($url);
@@ -115,18 +127,19 @@ if ($data === null || !isset($data['rates'])) {
     send_error_response(502, 'Invalid response from exchange rate service.', 'UPSTREAM_ERROR');
 }
 
-// Cache the response
-$cacheData = [
-    'date' => $isLatest ? date('Y-m-d') : $date,
-    'rates' => $data['rates'],
-    'fetched_at' => time(),
-];
-file_put_contents($cacheFile, json_encode($cacheData), LOCK_EX);
+// Store in MySQL cache
+if ($pdo) {
+    $stmt = $pdo->prepare(
+        "INSERT INTO exchange_rates (rate_date, rates, fetched_at) VALUES (?, ?, NOW())
+         ON DUPLICATE KEY UPDATE rates = VALUES(rates), fetched_at = NOW()"
+    );
+    $stmt->execute([$lookupDate, json_encode($data['rates'])]);
+}
 
 send_json_response(200, [
     'success' => true,
     'base' => 'USD',
-    'date' => $cacheData['date'],
+    'date' => $lookupDate,
     'rates' => $data['rates'],
     'cached' => false,
     'timestamp' => date('c'),

--- a/community/formatting/text-formatting.js
+++ b/community/formatting/text-formatting.js
@@ -29,6 +29,11 @@ document.addEventListener("DOMContentLoaded", function () {
     childList: true,
     subtree: true,
   });
+
+  // Clean up observer when navigating away
+  window.addEventListener("beforeunload", function () {
+    observer.disconnect();
+  });
 });
 
 /**

--- a/community/view-post.js
+++ b/community/view-post.js
@@ -705,12 +705,14 @@ document.addEventListener("DOMContentLoaded", function () {
                 const commentsHeading = document.querySelector(
                   ".comments-section h3"
                 );
-                // Extract just the number from the heading text
-                const currentText = commentsHeading.textContent;
-                const currentCount = parseInt(currentText);
-                if (!isNaN(currentCount)) {
-                  const newCount = currentCount - 1;
-                  commentsHeading.textContent = `${newCount} Comments`;
+                if (commentsHeading) {
+                  // Extract just the number from the heading text
+                  const currentText = commentsHeading.textContent;
+                  const currentCount = parseInt(currentText);
+                  if (!isNaN(currentCount)) {
+                    const newCount = currentCount - 1;
+                    commentsHeading.textContent = `${newCount} Comments`;
+                  }
                 }
               } else {
                 alert("Error deleting comment: " + data.message);

--- a/email_sender.php
+++ b/email_sender.php
@@ -1398,12 +1398,19 @@ function send_premium_key_redeemed_email($email, $username, $key, $subscriptionI
  */
 function send_payment_failed_email($email, $subscriptionId, $errorMessage = '')
 {
+    $errorDetail = '';
+    if (!empty($errorMessage)) {
+        $safeMessage = htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8');
+        $errorDetail = "<p><strong>Details:</strong> {$safeMessage}</p>";
+    }
+
     $body = <<<HTML
         <h1>Payment Failed</h1>
         <p>We were unable to process your subscription renewal payment.</p>
 
         <div class="info-box info-box-warning">
             <p><strong>Subscription ID:</strong> {$subscriptionId}</p>
+            {$errorDetail}
         </div>
 
         <p><strong>What to do next:</strong></p>
@@ -1423,61 +1430,6 @@ function send_payment_failed_email($email, $subscriptionId, $errorMessage = '')
         HTML;
 
     return send_styled_email($email, 'Payment Failed - Argo Premium Subscription', $body, 'purple');
-}
-
-/**
- * Send portal payment receipt email to a customer
- *
- * @param string $email Customer email address
- * @param string $companyName Business name that received the payment
- * @param string $invoiceId Invoice number
- * @param float $amount Payment amount
- * @param string $currency Currency code
- * @param string $referenceNumber Payment reference number
- * @param string $paymentMethod Payment method used
- * @return bool Success status
- */
-function send_portal_payment_receipt($email, $companyName, $invoiceId, $amount, $currency, $referenceNumber, $paymentMethod)
-{
-    $currencySymbol = $currency === 'CAD' ? 'CA$' : '$';
-    $formattedAmount = number_format($amount, 2);
-    $paymentDate = date('F j, Y');
-    $paymentMethodText = ucfirst($paymentMethod);
-
-    $body = <<<HTML
-        <h1>Payment Confirmation</h1>
-        <p>Your payment to <strong>{$companyName}</strong> has been received.</p>
-
-        <div class="payment-box">
-            <h3>Payment Details</h3>
-            <table class="details-table">
-                <tr>
-                    <td><strong>Date</strong></td>
-                    <td>{$paymentDate}</td>
-                </tr>
-                <tr>
-                    <td><strong>Invoice</strong></td>
-                    <td>{$invoiceId}</td>
-                </tr>
-                <tr>
-                    <td><strong>Amount</strong></td>
-                    <td>{$currencySymbol}{$formattedAmount} {$currency}</td>
-                </tr>
-                <tr>
-                    <td><strong>Payment Method</strong></td>
-                    <td>{$paymentMethodText}</td>
-                </tr>
-                <tr>
-                    <td><strong>Reference</strong></td>
-                    <td class="monospace">{$referenceNumber}</td>
-                </tr>
-            </table>
-        </div>
-
-        <p>Please keep this email for your records. If you have any questions about this payment, please contact {$companyName} directly.</p>
-        HTML;
-
-    return send_styled_email($email, "Payment Confirmation - Invoice {$invoiceId}", $body);
 }
 
 function send_free_credit_email($email, $creditAmount, $note = '', $subscriptionId = '')

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -536,3 +536,11 @@ CREATE TABLE IF NOT EXISTS invoice_send_usage (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     UNIQUE KEY unique_license_month (license_key, usage_month)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Exchange rates cache (persistent — historical rates never change)
+CREATE TABLE IF NOT EXISTS exchange_rates (
+    rate_date DATE NOT NULL,
+    rates JSON NOT NULL COMMENT 'All currency rates relative to USD for this date',
+    fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (rate_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
Replaces file-based caching of exchange rates with persistent MySQL storage, improving reliability and enabling batch operations. Also adds a new batch endpoint for fetching multiple dates efficiently.

## Key Changes

### Exchange Rates API (`api/exchange-rates.php`)
- **Replaced file caching with MySQL**: Migrated from `sys_get_temp_dir()` file-based cache to persistent database storage
- **Updated cache logic**: Historical rates are stored permanently (never expire), while today's rate refreshes every hour
- **Improved reliability**: Database storage is more reliable than temporary file system

### New Batch Exchange Rates Endpoint (`api/exchange-rates-batch.php`)
- **Added POST endpoint** for fetching multiple exchange rates in a single request
- **Accepts up to 500 dates** per batch request
- **Smart caching**: Fetches only missing or stale rates from OpenExchangeRates API
- **Rate limiting**: Counts as 1 request regardless of batch size
- **API quota protection**: Caps OpenExchangeRates calls to 30 per batch to prevent quota exhaustion
- **Extended timeout**: Allows up to 2 minutes for batch operations

### Database Schema (`mysql_schema.sql`)
- **Added `exchange_rates` table** with:
  - `rate_date` (primary key)
  - `rates` (JSON column storing all currency rates)
  - `fetched_at` (timestamp for TTL tracking)

### Email & UI Fixes
- **Payment failure emails**: Added optional error message details to `send_payment_failed_email()`
- **Removed unused function**: Deleted `send_portal_payment_receipt()` (no longer needed)
- **Community post comments**: Added null check before updating comment count heading
- **Observer cleanup**: Added `beforeunload` listener to disconnect MutationObserver in text formatting

## Implementation Details
- Both endpoints use the same MySQL table for consistency
- Historical rates are immutable and cached indefinitely
- Today's rate uses 1-hour TTL to balance freshness with API quota
- Batch endpoint gracefully handles partial failures, returning successful results and a list of failed dates
- All database operations use prepared statements for security

https://claude.ai/code/session_013KXWTG2HsogEjor7tWqpS1