### PR TITLE
Remove approval workflow and simplify draft-to-send process

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -809,7 +809,7 @@ Return ONLY the JSON, no other text.";
     }
 
     // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status = 'new' OR status = 'researching' OR status = 'ready_to_contact' THEN 'draft_generated' ELSE status END WHERE id = ?");
+    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','researching','ready_to_contact','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
     $stmt->execute([$parsed['subject'], $parsed['body'], $id]);
 
     log_activity($pdo, $id, 'draft_generated', 'AI draft generated');

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -67,9 +67,6 @@ switch ($action) {
         generate_draft($pdo);
         break;
     // Email workflow
-    case 'approve_draft':
-        approve_draft($pdo);
-        break;
     case 'send_email':
         send_outreach_email($pdo);
         break;
@@ -130,7 +127,6 @@ function get_leads($pdo)
 {
     $status = $_GET['status'] ?? '';
     $response_status = $_GET['response_status'] ?? '';
-    $approval_status = $_GET['approval_status'] ?? '';
     $search = $_GET['search'] ?? '';
     $sort = $_GET['sort'] ?? 'date_added_desc';
 
@@ -144,10 +140,6 @@ function get_leads($pdo)
     if ($response_status) {
         $where[] = 'response_status = ?';
         $params[] = $response_status;
-    }
-    if ($approval_status) {
-        $where[] = 'approval_status = ?';
-        $params[] = $approval_status;
     }
     if ($search) {
         $where[] = '(business_name LIKE ? OR email LIKE ? OR contact_name LIKE ? OR city LIKE ? OR category LIKE ?)';
@@ -248,7 +240,7 @@ function update_lead($pdo)
 
     $fields = [
         'business_name', 'contact_name', 'email', 'phone', 'website', 'address',
-        'category', 'city', 'source', 'status', 'response_status', 'approval_status',
+        'category', 'city', 'source', 'status', 'response_status',
         'notes', 'feedback_summary', 'offer_sent',
         'draft_subject', 'draft_body', 'contact_page_url',
         'first_contact_date', 'last_contact_date',
@@ -334,8 +326,7 @@ function get_stats($pdo)
     $rows = $pdo->query("SELECT
         COUNT(*) as total,
         SUM(status = 'new') as new_leads,
-        SUM(approval_status = 'draft_ready' OR approval_status = 'needs_review') as drafts_pending,
-        SUM(approval_status = 'approved') as approved,
+        SUM(status = 'draft_generated') as drafts_pending,
         SUM(status = 'contacted') as contacted,
         SUM(status = 'replied') as replied,
         SUM(status = 'interested') as interested
@@ -818,7 +809,7 @@ Return ONLY the JSON, no other text.";
     }
 
     // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), approval_status = 'draft_ready', status = CASE WHEN status = 'new' OR status = 'researching' OR status = 'ready_to_contact' THEN 'draft_generated' ELSE status END WHERE id = ?");
+    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status = 'new' OR status = 'researching' OR status = 'ready_to_contact' THEN 'draft_generated' ELSE status END WHERE id = ?");
     $stmt->execute([$parsed['subject'], $parsed['body'], $id]);
 
     log_activity($pdo, $id, 'draft_generated', 'AI draft generated');
@@ -827,31 +818,6 @@ Return ONLY the JSON, no other text.";
 }
 
 // ─── Email workflow ───
-
-function approve_draft($pdo)
-{
-    $data = json_decode(file_get_contents('php://input'), true);
-    $id = (int)($data['id'] ?? 0);
-
-    $stmt = $pdo->prepare("SELECT * FROM outreach_leads WHERE id = ?");
-    $stmt->execute([$id]);
-    $lead = $stmt->fetch();
-
-    if (!$lead) {
-        json_response(['success' => false, 'message' => 'Lead not found'], 404);
-    }
-
-    if (empty($lead['draft_subject']) || empty($lead['draft_body'])) {
-        json_response(['success' => false, 'message' => 'No draft to approve'], 400);
-    }
-
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET approval_status = 'approved', approved_at = NOW(), status = CASE WHEN status IN ('new','researching','ready_to_contact','draft_generated','awaiting_approval') THEN 'approved' ELSE status END WHERE id = ?");
-    $stmt->execute([$id]);
-
-    log_activity($pdo, $id, 'draft_approved', 'Draft approved for sending');
-
-    json_response(['success' => true, 'message' => 'Draft approved']);
-}
 
 function send_outreach_email($pdo)
 {
@@ -881,7 +847,6 @@ function send_outreach_email($pdo)
 
     if ($result) {
         $stmt = $pdo->prepare("UPDATE outreach_leads SET
-            approval_status = 'sent',
             sent_at = NOW(),
             status = CASE WHEN status NOT IN ('replied','interested','not_interested','onboarded') THEN 'contacted' ELSE status END,
             first_contact_date = COALESCE(first_contact_date, NOW()),
@@ -932,7 +897,7 @@ function export_csv($pdo)
     $output = fopen('php://output', 'w');
 
     $headers = ['ID', 'Business Name', 'Contact Name', 'Email', 'Phone', 'Website', 'Address',
-        'Category', 'City', 'Source', 'Status', 'Response Status', 'Approval Status',
+        'Category', 'City', 'Source', 'Status', 'Response Status',
         'Date Added', 'First Contact', 'Last Contact', 'Offer Sent',
         'Notes', 'Feedback Summary', 'Draft Subject', 'Draft Body'];
     fputcsv($output, $headers);
@@ -942,7 +907,7 @@ function export_csv($pdo)
             $lead['id'], $lead['business_name'], $lead['contact_name'], $lead['email'],
             $lead['phone'], $lead['website'], $lead['address'], $lead['category'],
             $lead['city'], $lead['source'], $lead['status'], $lead['response_status'],
-            $lead['approval_status'], $lead['date_added'], $lead['first_contact_date'],
+            $lead['date_added'], $lead['first_contact_date'],
             $lead['last_contact_date'], $lead['offer_sent'],
             $lead['notes'], $lead['feedback_summary'], $lead['draft_subject'], $lead['draft_body'],
         ]);

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -196,7 +196,7 @@ include '../admin_header.php';
     <!-- Bulk Actions -->
     <div class="bulk-actions-bar" id="bulkActionsBar" style="display:none;">
         <span><strong id="selectedCount">0</strong> selected</span>
-        <button class="btn btn-small btn-blue" onclick="bulkGenerateDrafts()">Draft Selected</button>
+        <button class="btn btn-small btn-blue" id="btnDraftSelected" onclick="bulkGenerateDrafts()">Draft Selected</button>
         <button class="btn btn-small btn-blue" onclick="openBulkSendModal()">Send Email</button>
         <button class="btn btn-small btn-blue" onclick="bulkDeleteLeads()">Delete Selected</button>
     </div>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -40,10 +40,6 @@ include '../admin_header.php';
         <div class="stat-value stat-pending" id="statDraftsPending">0</div>
     </div>
     <div class="stat-card">
-        <div class="stat-label">Approved</div>
-        <div class="stat-value stat-approved" id="statApproved">0</div>
-    </div>
-    <div class="stat-card">
         <div class="stat-label">Contacted</div>
         <div class="stat-value stat-contacted" id="statContacted">0</div>
     </div>
@@ -150,8 +146,6 @@ include '../admin_header.php';
                     <option value="researching">Researching</option>
                     <option value="ready_to_contact">Ready to Contact</option>
                     <option value="draft_generated">Draft Generated</option>
-                    <option value="awaiting_approval">Awaiting Approval</option>
-                    <option value="approved">Approved</option>
                     <option value="contacted">Contacted</option>
                     <option value="replied">Replied</option>
                     <option value="interested">Interested</option>
@@ -167,17 +161,6 @@ include '../admin_header.php';
                     <option value="positive">Positive</option>
                     <option value="neutral">Neutral</option>
                     <option value="negative">Negative</option>
-                </select>
-            </div>
-            <div class="filter-group">
-                <label for="filterApproval">Approval</label>
-                <select id="filterApproval" onchange="loadLeads()">
-                    <option value="">All</option>
-                    <option value="not_drafted">Not Drafted</option>
-                    <option value="draft_ready">Draft Ready</option>
-                    <option value="needs_review">Needs Review</option>
-                    <option value="approved">Approved</option>
-                    <option value="sent">Sent</option>
                 </select>
             </div>
             <div class="filter-group">
@@ -213,7 +196,6 @@ include '../admin_header.php';
                     <th>City</th>
                     <th>Category</th>
                     <th>Status</th>
-                    <th>Approval</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -288,8 +270,6 @@ include '../admin_header.php';
                             <option value="researching">Researching</option>
                             <option value="ready_to_contact">Ready to Contact</option>
                             <option value="draft_generated">Draft Generated</option>
-                            <option value="awaiting_approval">Awaiting Approval</option>
-                            <option value="approved">Approved</option>
                             <option value="contacted">Contacted</option>
                             <option value="replied">Replied</option>
                             <option value="interested">Interested</option>
@@ -353,7 +333,6 @@ include '../admin_header.php';
                         <button class="btn btn-blue" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
                         <button class="btn btn-blue" onclick="togglePreview()">Preview</button>
                         <button class="btn btn-blue" onclick="copyDraft()">Copy</button>
-                        <button class="btn btn-blue" onclick="approveDraft()" id="btnApprove">Approve</button>
                         <button class="btn btn-blue" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
                     </div>
                     <div class="draft-info" id="draftInfo"></div>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -199,7 +199,7 @@ async function loadLeads() {
                 <td onclick="event.stopPropagation()">
                     <div class="actions-cell">
                         <button class="btn btn-small btn-blue" onclick="openLeadDetail(${lead.id})" title="View">View</button>
-                        ${lead.approval_status !== 'sent' ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="${lead.draft_subject ? 'Regenerate Draft' : 'Generate Draft'}">${lead.draft_subject ? 'Redraft' : 'Draft'}</button>` : ''}
+                        ${!lead.draft_subject && lead.approval_status !== 'sent' ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
                     </div>
                 </td>
             </tr>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -13,13 +13,11 @@ function updateUrlParams() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
-    const approval = document.getElementById('filterApproval').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.set('search', search);
     if (status) params.set('status', status);
     if (response) params.set('response', response);
-    if (approval) params.set('approval', approval);
     if (sort && sort !== 'date_added_desc') params.set('sort', sort);
 
     const newUrl = params.toString()
@@ -33,7 +31,6 @@ function restoreFiltersFromUrl() {
     if (params.has('search')) document.getElementById('filterSearch').value = params.get('search');
     if (params.has('status')) document.getElementById('filterStatus').value = params.get('status');
     if (params.has('response')) document.getElementById('filterResponse').value = params.get('response');
-    if (params.has('approval')) document.getElementById('filterApproval').value = params.get('approval');
     if (params.has('sort')) document.getElementById('filterSort').value = params.get('sort');
 }
 
@@ -137,7 +134,6 @@ async function loadStats() {
             document.getElementById('statTotal').textContent = s.total || 0;
             document.getElementById('statNew').textContent = s.new_leads || 0;
             document.getElementById('statDraftsPending').textContent = s.drafts_pending || 0;
-            document.getElementById('statApproved').textContent = s.approved || 0;
             document.getElementById('statContacted').textContent = s.contacted || 0;
             document.getElementById('statReplied').textContent = s.replied || 0;
             document.getElementById('statInterested').textContent = s.interested || 0;
@@ -158,13 +154,11 @@ async function loadLeads() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
-    const approval = document.getElementById('filterApproval').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.search = search;
     if (status) params.status = status;
     if (response) params.response_status = response;
-    if (approval) params.approval_status = approval;
     if (sort) params.sort = sort;
 
     // Persist filters to URL
@@ -194,12 +188,11 @@ async function loadLeads() {
                 <td>${esc(lead.city || '')}</td>
                 <td>${esc(lead.category || '')}</td>
                 <td><span class="badge badge-status-${lead.status || 'new'}">${formatStatus(lead.status || 'new')}</span></td>
-                <td><span class="badge badge-approval-${lead.approval_status && lead.approval_status !== 'none' ? lead.approval_status : 'not_drafted'}">${formatApproval(lead.approval_status || 'not_drafted')}</span></td>
 
                 <td onclick="event.stopPropagation()">
                     <div class="actions-cell">
                         <button class="btn btn-small btn-blue" onclick="openLeadDetail(${lead.id})" title="View">View</button>
-                        ${!lead.draft_subject && lead.approval_status !== 'sent' ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
+                        ${!lead.draft_subject && lead.status !== 'contacted' ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
                     </div>
                 </td>
             </tr>
@@ -477,56 +470,36 @@ async function openLeadDetail(id) {
 function updateDraftStatus(lead) {
     const bar = document.getElementById('draftStatusBar');
     const sendBtn = document.getElementById('btnSend');
-    const approveBtn = document.getElementById('btnApprove');
+    const genBtn = document.getElementById('btnGenerate');
 
     let statusHtml = '';
-    if (lead.approval_status === 'sent') {
-        statusHtml = `<span class="badge badge-approval-sent">Sent</span> on ${formatDateTime(lead.sent_at)}`;
+    const isSent = lead.status === 'contacted' || lead.status === 'replied' || lead.status === 'interested';
+
+    if (isSent && lead.sent_at) {
+        statusHtml = `<span class="badge badge-status-contacted">Sent</span> on ${formatDateTime(lead.sent_at)}`;
         sendBtn.disabled = true;
-        approveBtn.disabled = true;
-        approveBtn.style.display = 'none';
-    } else if (lead.approval_status === 'approved') {
-        statusHtml = '<span class="badge badge-approval-approved">Approved</span> — Ready to send';
-        sendBtn.disabled = !lead.email;
-        approveBtn.disabled = true;
-        approveBtn.style.display = '';
-        if (!lead.email) statusHtml += ' <span class="text-muted">(no email address)</span>';
+        genBtn.style.display = 'none';
+        sendBtn.style.display = 'none';
     } else if (lead.draft_subject || lead.draft_body) {
-        statusHtml = '<span class="badge badge-approval-draft_ready">Draft Ready</span>';
+        statusHtml = '<span class="badge badge-status-draft_generated">Draft Ready</span>';
         sendBtn.disabled = !lead.email;
-        approveBtn.disabled = false;
-        approveBtn.style.display = '';
+        genBtn.style.display = '';
+        sendBtn.style.display = '';
+        genBtn.textContent = 'Regenerate Draft';
         if (!lead.email) statusHtml += ' <span class="text-muted">(no email address)</span>';
     } else {
-        statusHtml = '<span class="badge badge-approval-not_drafted">None</span>';
+        statusHtml = '<span class="badge badge-status-new">No Draft</span>';
         sendBtn.disabled = true;
-        approveBtn.disabled = true;
-        approveBtn.style.display = '';
+        genBtn.style.display = '';
+        sendBtn.style.display = '';
+        genBtn.textContent = 'Generate Draft';
     }
 
     if (lead.drafted_at) {
         statusHtml += ` | Drafted: ${formatDateTime(lead.drafted_at)}`;
     }
-    if (lead.approved_at) {
-        statusHtml += ` | Approved: ${formatDateTime(lead.approved_at)}`;
-    }
 
     bar.innerHTML = statusHtml;
-
-    // Update Generate Draft button text and visibility based on status
-    const genBtn = document.getElementById('btnGenerate');
-    if (lead.approval_status === 'sent') {
-        genBtn.style.display = 'none';
-        sendBtn.style.display = 'none';
-    } else {
-        genBtn.style.display = '';
-        sendBtn.style.display = '';
-        if (lead.draft_subject || lead.draft_body) {
-            genBtn.textContent = 'Regenerate Draft';
-        } else {
-            genBtn.textContent = 'Generate Draft';
-        }
-    }
 
     // Info section
     let info = '';
@@ -803,36 +776,9 @@ async function quickGenerateDraft(id, btn) {
 }
 
 // ─── Email Workflow ───
-async function approveDraft() {
-    if (!currentLeadId) return;
-
-    // Save any edits first
-    const subject = document.getElementById('draftSubject').value.trim();
-    const body = document.getElementById('draftBody').value.trim();
-    if (!subject || !body) { notify('Subject and body are required', 'error'); return; }
-
-    try {
-        // Save draft edits
-        await api('update_lead', {
-            method: 'POST',
-            body: { id: currentLeadId, draft_subject: subject, draft_body: body }
-        });
-
-        const result = await api('approve_draft', { method: 'POST', body: { id: currentLeadId } });
-        notify(result.message, result.success ? 'success' : 'error');
-        if (result.success) {
-            openLeadDetail(currentLeadId);
-            loadLeads();
-            loadStats();
-        }
-    } catch (e) {
-        notify(e.message, 'error');
-    }
-}
-
 async function sendEmail() {
     if (!currentLeadId) return;
-    if (!confirm('Send this approved email now?')) return;
+    if (!confirm('Send this email now?')) return;
 
     const btn = document.getElementById('btnSend');
     btn.disabled = true;
@@ -1013,10 +959,6 @@ function formatStatus(status) {
     return status.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-function formatApproval(status) {
-    if (status === 'not_drafted' || status === 'none') return 'None';
-    return status.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-}
 
 function formatActionType(type) {
     return type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -192,7 +192,7 @@ async function loadLeads() {
                 <td onclick="event.stopPropagation()">
                     <div class="actions-cell">
                         <button class="btn btn-small btn-blue" onclick="openLeadDetail(${lead.id})" title="View">View</button>
-                        ${!lead.draft_subject && lead.status !== 'contacted' ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
+                        ${!lead.draft_subject && !['contacted','replied','interested','not_interested','onboarded'].includes(lead.status) ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
                     </div>
                 </td>
             </tr>
@@ -473,7 +473,7 @@ function updateDraftStatus(lead) {
     const genBtn = document.getElementById('btnGenerate');
 
     let statusHtml = '';
-    const isSent = lead.status === 'contacted' || lead.status === 'replied' || lead.status === 'interested';
+    const isSent = ['contacted','replied','interested','not_interested','onboarded'].includes(lead.status);
 
     if (isSent && lead.sent_at) {
         statusHtml = `<span class="badge badge-status-contacted">Sent</span> on ${formatDateTime(lead.sent_at)}`;

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -183,7 +183,7 @@ async function loadLeads() {
         tbody.innerHTML = data.leads.map(lead => `
             <tr onclick="openLeadDetail(${lead.id})" class="clickable-row">
                 <td class="checkbox-column" onclick="event.stopPropagation()">
-                    <div class="checkbox"><input type="checkbox" class="lead-check" value="${lead.id}" id="lead-check-${lead.id}" onchange="updateBulkBar()"><label for="lead-check-${lead.id}"></label></div>
+                    <div class="checkbox"><input type="checkbox" class="lead-check" value="${lead.id}" id="lead-check-${lead.id}" data-has-draft="${lead.draft_subject ? '1' : ''}" onchange="updateBulkBar()"><label for="lead-check-${lead.id}"></label></div>
                 </td>
                 <td>
                     <strong>${esc(lead.business_name)}</strong>
@@ -242,6 +242,13 @@ function updateBulkBar() {
             selectAll.checked = false;
             selectAll.indeterminate = true;
         }
+    }
+
+    // Disable "Draft Selected" if any selected lead already has a draft
+    const draftBtn = document.getElementById('btnDraftSelected');
+    if (draftBtn) {
+        const anyDrafted = Array.from(checked).some(cb => cb.dataset.hasDraft === '1');
+        draftBtn.disabled = anyDrafted;
     }
 }
 

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -33,7 +33,6 @@
 
 .stat-new { color: var(--blue-500); }
 .stat-pending { color: var(--amber-500); }
-.stat-approved { color: var(--emerald-500); }
 .stat-contacted { color: var(--purple-500); }
 .stat-replied { color: var(--green-600); }
 .stat-interested { color: var(--emerald-700); }
@@ -271,8 +270,6 @@
 .badge-status-researching { background: var(--sky-100); color: var(--sky-700); }
 .badge-status-ready_to_contact { background: var(--amber-100); color: var(--amber-700); }
 .badge-status-draft_generated { background: var(--purple-100); color: var(--purple-700); }
-.badge-status-awaiting_approval { background: var(--amber-100); color: var(--amber-800); }
-.badge-status-approved { background: var(--emerald-100); color: var(--emerald-700); }
 .badge-status-contacted { background: var(--purple-100); color: var(--purple-600); }
 .badge-status-replied { background: var(--green-100); color: var(--green-700); }
 .badge-status-interested { background: var(--emerald-100); color: var(--emerald-800); }
@@ -280,12 +277,6 @@
 
 .badge-status-onboarded { background: var(--green-100); color: var(--green-800); }
 
-/* Approval badges */
-.badge-approval-not_drafted { background: var(--gray-100); color: var(--gray-600); }
-.badge-approval-draft_ready { background: var(--blue-100); color: var(--blue-700); }
-.badge-approval-needs_review { background: var(--amber-100); color: var(--amber-700); }
-.badge-approval-approved { background: var(--emerald-100); color: var(--emerald-700); }
-.badge-approval-sent { background: var(--green-100); color: var(--green-800); }
 
 /* ─── Filters ─── */
 .filters-container {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -691,6 +691,11 @@
     color: #f59e0b;
 }
 
+.btn-blue:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* ─── Dark Theme ─── */
 [data-theme="dark"] .stat-card,
 [data-theme="dark"] .panel {
@@ -774,6 +779,27 @@
 
 [data-theme="dark"] .bulk-send-item-body {
     color: #94a3b8;
+}
+
+[data-theme="dark"] .bulk-send-list::-webkit-scrollbar,
+[data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar {
+    width: 8px;
+}
+
+[data-theme="dark"] .bulk-send-list::-webkit-scrollbar-track,
+[data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-track {
+    background: #1e293b;
+}
+
+[data-theme="dark"] .bulk-send-list::-webkit-scrollbar-thumb,
+[data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-thumb {
+    background: #475569;
+    border-radius: 4px;
+}
+
+[data-theme="dark"] .bulk-send-list::-webkit-scrollbar-thumb:hover,
+[data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-thumb:hover {
+    background: #64748b;
 }
 
 [data-theme="dark"] .tabs {


### PR DESCRIPTION
## Summary
This PR removes the multi-step approval workflow from the outreach system, simplifying the draft generation and email sending process. The approval status field and related UI components have been eliminated, allowing drafts to be sent directly once generated.

## Key Changes

**Backend (api.php)**
- Removed `approve_draft()` function and its API endpoint
- Removed `approval_status` field from lead filtering and updates
- Removed `approval_status` column from CSV export
- Updated `generate_draft()` to no longer set `approval_status = 'draft_ready'`
- Updated `send_outreach_email()` to no longer set `approval_status = 'sent'`
- Updated stats query to count `status = 'draft_generated'` instead of approval statuses

**Frontend (outreach.js)**
- Removed approval filter from URL parameter handling (`updateUrlParams()`, `restoreFiltersFromUrl()`)
- Removed approval status column from leads table rendering
- Removed `formatApproval()` function
- Removed "Approve" button and related logic from draft detail view
- Simplified `updateDraftStatus()` to determine send eligibility based on lead status and email presence
- Updated draft button visibility: only shows "Draft" button when no draft exists and lead hasn't been contacted
- Added `data-has-draft` attribute to checkboxes to track draft state
- Added validation to disable "Draft Selected" button if any selected lead already has a draft
- Removed `approveDraft()` function

**UI (index.php & style.css)**
- Removed approval filter dropdown from filter panel
- Removed approval status column from leads table header
- Removed "Approved" stat card
- Removed approval-related badge styles (`.badge-approval-*`)
- Removed awaiting_approval and approved status options from status dropdowns
- Removed "Approve" button from draft detail modal
- Added disabled state styling for buttons

## Implementation Details
- The workflow now follows: Generate Draft → Send Email (no intermediate approval step)
- Draft eligibility for sending is determined by: draft exists AND lead has email AND lead hasn't been contacted yet
- Bulk draft generation is disabled if any selected lead already has a draft
- Status transitions simplified: new/researching/ready_to_contact → draft_generated → contacted (when sent)

https://claude.ai/code/session_01G7SaiDov6h2UzDwfLwAcn2