### PR TITLE
Replace hardcoded colors with CSS custom properties

### DIFF
--- a/about-us/style.css
+++ b/about-us/style.css
@@ -246,7 +246,7 @@ body {
 
 .mission-image img {
   width: 100%;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 25px 50px -12px var(--shadow-lg);
 }
 
 /* ========================================
@@ -288,13 +288,13 @@ body {
   padding: 28px;
   border-radius: 16px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .feature-item:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 32px var(--shadow-default);
 }
 
 .feature-icon {
@@ -373,7 +373,7 @@ body {
 .story-image img {
   width: 100%;
   border-radius: 16px;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 25px 50px -12px var(--shadow-lg);
 }
 
 .image-badge {
@@ -389,7 +389,7 @@ body {
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--gray-600);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
 }
 
 .image-badge svg {
@@ -466,13 +466,13 @@ body {
   padding: 32px;
   border-radius: 16px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .value-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 32px var(--shadow-default);
 }
 
 .value-icon {
@@ -623,7 +623,7 @@ body {
 
 .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 8px 20px var(--blue-alpha-30);
 }
 
 .btn-secondary {

--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -28,7 +28,7 @@ body.menu-open::after {
   left: 0;
   width: 100%;
   height: calc(100% - 50px);
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--overlay-light);
   z-index: 90;
   opacity: 1;
   visibility: visible;
@@ -63,9 +63,9 @@ body.menu-open::after {
 
 /* Header */
 .admin-header {
-  background: #ffffff;
-  border-bottom: 1px solid #ddd;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: var(--white);
+  border-bottom: 1px solid var(--neutral-ddd);
+  box-shadow: 0 1px 3px var(--shadow-default);
   position: relative;
   height: 50px;
   z-index: 1000;
@@ -135,7 +135,7 @@ body.menu-open::after {
 
 /* Mobile Dropdown Menu */
 .hamburger-nav-menu {
-  background: #fff;
+  background: var(--white);
   overflow: hidden;
   position: absolute;
   top: 50px;
@@ -157,7 +157,7 @@ body.menu-open::after {
 }
 
 .hamburger-nav-menu ul li {
-  border-top: 1px solid rgb(225, 225, 225);
+  border-top: 1px solid var(--gray-rgb-border);
   transform: translateY(-20px);
   opacity: 0;
   transition: all 0.3s ease-in-out;
@@ -169,24 +169,24 @@ body.menu-open::after {
 }
 
 .hamburger-nav-menu ul li:last-of-type {
-  border-bottom: 1px solid rgb(225, 225, 225);
+  border-bottom: 1px solid var(--gray-rgb-border);
 }
 
 .hamburger-nav-menu ul li a {
   text-decoration: none;
-  color: #000;
+  color: var(--black);
   padding: 20px 30px;
   display: block;
   transition: background-color 0.2s ease;
 }
 
 .hamburger-nav-menu ul li a:hover {
-  background-color: #f8f9fa;
+  background-color: var(--neutral-f8f9fa);
 }
 
 .hamburger-nav-menu ul li a.active {
-  background-color: #e6f3ff;
-  color: #0066cc;
+  background-color: var(--blue-e6f3ff);
+  color: var(--blue-link);
   font-weight: 500;
 }
 
@@ -263,7 +263,7 @@ body.menu-open::after {
 .header-link {
   padding: 0.5rem 0.75rem;
   text-decoration: none;
-  color: #666;
+  color: var(--neutral-666);
   font-weight: 500;
   font-size: 0.9rem;
   border-radius: 4px;
@@ -273,12 +273,12 @@ body.menu-open::after {
 
 .header-link:hover {
   color: var(--dark-gray);
-  background: #f0f0f0;
+  background: var(--neutral-f0f0f0);
 }
 
 .header-link.active {
-  color: #0066cc;
-  background: #e6f3ff;
+  color: var(--blue-link);
+  background: var(--blue-e6f3ff);
 }
 
 .desktop-actions {
@@ -294,7 +294,7 @@ body.menu-open::after {
 
 .user-name {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--neutral-666);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -304,23 +304,23 @@ body.menu-open::after {
   display: block;
   align-items: center;
   gap: 0.5rem;
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--gray-bg-light);
+  color: var(--gray-text);
   text-decoration: none;
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
   font-size: 0.875rem;
   transition: all 0.2s ease;
-  border: 1px solid #cccfd5;
+  border: 1px solid var(--neutral-cccfd5);
   cursor: pointer;
   font-weight: bold;
   text-align: center;
 }
 
 .btn-home:hover {
-  background: #e5e7eb;
-  color: #374151;
-  border-color: #d1d5db;
+  background: var(--gray-border);
+  color: var(--gray-text-dark);
+  border-color: var(--gray-input-border);
 }
 
 .btn-home svg {
@@ -334,12 +334,12 @@ body.menu-open::after {
 .admin-content {
   margin: 0 auto;
   padding: 1.5rem;
-  background: white;
+  background: var(--white);
 }
 
 .page-header {
   margin-bottom: 1.5rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--neutral-eee);
   padding-bottom: 1rem;
   text-align: center;
 }
@@ -352,7 +352,7 @@ body.menu-open::after {
 }
 
 .page-description {
-  color: #666;
+  color: var(--neutral-666);
   font-size: 0.95rem;
   margin: 0;
   line-height: 1.5;
@@ -365,14 +365,14 @@ h1 {
 }
 
 h2 {
-  color: #374151;
+  color: var(--gray-text-dark);
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0 0 1rem 0;
 }
 
 h3 {
-  color: #4b5563;
+  color: var(--gray-text-light);
   font-size: 1rem;
   font-weight: 500;
   margin: 0 0 0.5rem 0;
@@ -380,7 +380,7 @@ h3 {
 
 /* Button Variants */
 .btn-green {
-  background: #10b981;
+  background: var(--emerald-500);
 }
 
 .btn-green:hover {
@@ -405,7 +405,7 @@ input[type="password"],
 input[type="number"] {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--gray-input-border);
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 16px;
@@ -430,12 +430,12 @@ input[type="number"]::-webkit-inner-spin-button {
 
 /* Tables */
 .table-container {
-  background: white;
+  background: var(--white);
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 30px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px var(--shadow-default);
+  border: 1px solid var(--gray-border);
 }
 
 .table-header {
@@ -453,14 +453,14 @@ th,
 td {
   padding: 12px 15px;
   text-align: left;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-border);
   box-sizing: border-box;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 th {
-  background-color: #f8fafc;
+  background-color: var(--gray-50);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -470,7 +470,7 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background-color: var(--whiteBackground, rgba(243, 244, 246, 0.8)) !important;
+  background-color: var(--whiteBackground, var(--gray-bg-light-alpha-80)) !important;
 }
 
 .key-field {
@@ -488,33 +488,33 @@ tbody tr:hover {
 }
 
 .badge-success {
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .badge-pending {
   background-color: var(--yellow-50);
-  color: #92400e;
+  color: var(--amber-800);
 }
 
 .badge-admin {
-  background-color: #dbeafe;
-  color: #1e40af;
+  background-color: var(--blue-100);
+  color: var(--blue-800);
 }
 
 .badge-user {
-  background-color: #e5e7eb;
-  color: #4b5563;
+  background-color: var(--gray-border);
+  color: var(--gray-text-light);
 }
 
 .badge-banned {
-  background-color: #fee2e2;
-  color: #991b1b;
+  background-color: var(--red-100);
+  color: var(--red-800);
 }
 
 .badge-active {
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: var(--gray-bg-light);
+  color: var(--gray-text);
 }
 
 /* Action Buttons */
@@ -528,16 +528,16 @@ tbody tr:hover {
 /* Statistics Cards */
 .stat-card {
   flex: 1;
-  background: white;
+  background: var(--white);
   border-radius: 8px;
   padding: 15px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
   text-align: center;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
 }
 
 .stat-card h3 {
-  color: #6b7280;
+  color: var(--gray-text);
   font-size: 0.8rem;
   font-weight: 500;
   text-transform: uppercase;
@@ -550,13 +550,13 @@ tbody tr:hover {
 .stat-card .value {
   font-size: 1.75rem;
   font-weight: bold;
-  color: var(--blueText, #1f2937);
+  color: var(--blueText, var(--gray-text-darker));
   margin: 0;
   line-height: 1.2;
 }
 
 .stat-card .subtext {
-  color: #9ca3af;
+  color: var(--gray-placeholder);
   font-size: 0.75rem;
   margin-top: 0.25rem;
   line-height: 1.2;
@@ -567,8 +567,8 @@ tbody tr:hover {
   border-radius: 8px;
   padding: 20px 20px 60px 20px;
   margin-bottom: 30px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px var(--shadow-default);
+  border: 1px solid var(--gray-border);
   position: relative;
   height: 300px;
   display: flex;
@@ -594,7 +594,7 @@ tbody tr:hover {
   align-items: center;
   justify-content: center;
   height: 300px;
-  color: #6b7280;
+  color: var(--gray-text);
   flex-direction: column;
   text-align: center;
 }
@@ -610,17 +610,17 @@ tbody tr:hover {
 
 .alert-success,
 .success-message {
-  background: #d1fae5;
-  color: #065f46;
-  border-color: #10b981;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
+  border-color: var(--emerald-500);
 }
 
 .alert-error,
 .error-message {
   text-align: center;
-  background: #fee2e2;
-  color: #b91c1c;
-  border-color: #ef4444;
+  background: var(--red-100);
+  color: var(--red-700);
+  border-color: var(--red-500);
 }
 
 .alert-close {
@@ -650,10 +650,10 @@ tbody tr:hover {
   display: flex;
   align-items: center;
   margin-bottom: 20px;
-  background: white;
+  background: var(--white);
   padding: 15px 20px;
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
 }
 
 .period-selection span {
@@ -668,9 +668,9 @@ tbody tr:hover {
 
 .period-btn {
   padding: 8px 15px;
-  background: #f3f4f6;
+  background: var(--gray-bg-light);
   border-radius: 4px;
-  color: #4b5563;
+  color: var(--gray-text-light);
   text-decoration: none;
   font-size: 14px;
   transition: all 0.2s ease;
@@ -678,13 +678,13 @@ tbody tr:hover {
 }
 
 .period-btn:hover {
-  background: #e5e7eb;
+  background: var(--gray-border);
 }
 
 .period-btn.active {
   background: var(--primary-blue);
-  color: white;
-  border: 2px solid #1e40af;
+  color: var(--white);
+  border: 2px solid var(--blue-800);
   font-weight: bold;
 }
 
@@ -697,9 +697,9 @@ tbody tr:hover {
   width: 100%;
   max-width: 400px;
   padding: 40px;
-  background: white;
+  background: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--shadow-default);
 }
 
 .login-header {
@@ -736,7 +736,7 @@ tbody tr:hover {
   font-size: 18px;
   padding: 10px;
   border-radius: 4px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--gray-input-border);
   width: 100%;
   max-width: 200px;
   margin: 0 auto 20px;
@@ -753,8 +753,8 @@ tbody tr:hover {
 .secret-key {
   font-family: monospace;
   font-size: 20px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
   border-radius: 4px;
   padding: 10px 15px;
   margin: 15px 0;
@@ -771,7 +771,7 @@ tbody tr:hover {
 .verification-heading {
   margin-bottom: 15px;
   font-size: 18px;
-  color: #374151;
+  color: var(--gray-text-dark);
 }
 
 .steps {
@@ -782,7 +782,7 @@ tbody tr:hover {
 
 .manual-entry {
   margin-top: 25px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--gray-200);
   padding-top: 25px;
 }
 
@@ -795,13 +795,13 @@ tbody tr:hover {
 }
 
 .data-info {
-  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-  border: 1px solid #cbd5e1;
+  background: linear-gradient(135deg, var(--gray-50) 0%, var(--gray-200) 100%);
+  border: 1px solid var(--gray-300);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1.5rem;
   text-align: center;
-  color: #475569;
+  color: var(--gray-600);
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -809,17 +809,17 @@ tbody tr:hover {
 .no-data {
   text-align: center;
   padding: 3rem 2rem;
-  color: #6b7280;
-  background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+  color: var(--gray-text);
+  background: linear-gradient(135deg, var(--whiteBackground) 0%, var(--gray-bg-light) 100%);
   border-radius: 12px;
-  border: 2px dashed #d1d5db;
+  border: 2px dashed var(--gray-input-border);
   margin: 2rem 0;
 }
 
 .no-data h3 {
   margin: 0 0 1rem 0;
   font-size: 1.5rem;
-  color: #374151;
+  color: var(--gray-text-dark);
   font-weight: 600;
 }
 
@@ -829,12 +829,12 @@ tbody tr:hover {
 }
 
 .no-data code {
-  background: #e5e7eb;
+  background: var(--gray-border);
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
   font-family: "Monaco", "Consolas", monospace;
   font-size: 0.875rem;
-  color: #374151;
+  color: var(--gray-text-dark);
 }
 
 /* Table Responsive Wrapper */
@@ -851,17 +851,17 @@ tbody tr:hover {
 }
 
 .table-responsive::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--neutral-f1f1f1);
   border-radius: 4px;
 }
 
 .table-responsive::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
+  background: var(--gray-300);
   border-radius: 4px;
 }
 
 .table-responsive::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
+  background: var(--gray-400);
 }
 
 /* Responsive Design */
@@ -1052,7 +1052,7 @@ tbody tr:hover {
    ============================================================ */
 .theme-toggle {
   background: none;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--gray-input-border);
   border-radius: 6px;
   cursor: pointer;
   padding: 4px 8px;
@@ -1060,13 +1060,13 @@ tbody tr:hover {
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
-  color: #6b7280;
+  color: var(--gray-text);
 }
 
 .theme-toggle:hover {
-  background: #f3f4f6;
-  border-color: #9ca3af;
-  color: #374151;
+  background: var(--gray-bg-light);
+  border-color: var(--gray-placeholder);
+  color: var(--gray-text-dark);
 }
 
 .theme-toggle svg {
@@ -1086,14 +1086,14 @@ tbody tr:hover {
    Dark Theme
    ============================================================ */
 [data-theme="dark"] .theme-toggle {
-  border-color: #4b5563;
-  color: #d1d5db;
+  border-color: var(--gray-text-light);
+  color: var(--gray-input-border);
 }
 
 [data-theme="dark"] .theme-toggle:hover {
-  background: #374151;
-  border-color: #6b7280;
-  color: #f9fafb;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text);
+  color: var(--whiteBackground);
 }
 
 [data-theme="dark"] .theme-toggle .icon-moon {
@@ -1106,43 +1106,43 @@ tbody tr:hover {
 
 /* Dark theme - Base */
 [data-theme="dark"] body {
-  background: #111827;
-  color: #e2e8f0;
+  background: var(--neutral-111827);
+  color: var(--gray-200);
 }
 
 /* Dark theme - Header */
 [data-theme="dark"] .admin-header {
-  background: #1e293b;
-  border-bottom-color: #334155;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-800);
+  border-bottom-color: var(--gray-700);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .header-title {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .header-link {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .header-link:hover {
-  color: #e2e8f0;
-  background: #334155;
+  color: var(--gray-200);
+  background: var(--gray-700);
 }
 
 [data-theme="dark"] .header-link.active {
-  color: #60a5fa;
-  background: rgba(59, 130, 246, 0.15);
+  color: var(--blue-400);
+  background: var(--blue-alpha-15);
 }
 
 [data-theme="dark"] .user-name {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .menu-icon .nav-icon,
 [data-theme="dark"] .menu-icon .nav-icon:before,
 [data-theme="dark"] .menu-icon .nav-icon:after {
-  background: #e2e8f0;
+  background: var(--gray-200);
 }
 
 [data-theme="dark"] .menu-btn:checked~.menu-icon .nav-icon {
@@ -1151,124 +1151,124 @@ tbody tr:hover {
 
 /* Dark theme - Home button */
 [data-theme="dark"] .btn-home {
-  background: #334155;
-  color: #94a3b8;
-  border-color: #475569;
+  background: var(--gray-700);
+  color: var(--gray-400);
+  border-color: var(--gray-600);
 }
 
 [data-theme="dark"] .btn-home:hover {
-  background: #3f4f63;
-  color: #e2e8f0;
-  border-color: #64748b;
+  background: var(--slate-3f4f63);
+  color: var(--gray-200);
+  border-color: var(--gray-500);
 }
 
 /* Dark theme - Mobile menu */
 [data-theme="dark"] .hamburger-nav-menu {
-  background: #1e293b;
+  background: var(--gray-800);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li {
-  border-top-color: #334155;
+  border-top-color: var(--gray-700);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li:last-of-type {
-  border-bottom-color: #334155;
+  border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li a {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li a:hover {
-  background-color: #334155;
+  background-color: var(--gray-700);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li a.active {
-  background-color: rgba(59, 130, 246, 0.15);
-  color: #60a5fa;
+  background-color: var(--blue-alpha-15);
+  color: var(--blue-400);
 }
 
 /* Dark theme - Main content */
 [data-theme="dark"] .admin-content {
-  background: #111827;
+  background: var(--neutral-111827);
 }
 
 [data-theme="dark"] .page-header {
-  border-bottom-color: #334155;
+  border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .page-title {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .page-description {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - Typography */
 [data-theme="dark"] h1 {
-  color: #93c5fd;
+  color: var(--blue-300);
 }
 
 [data-theme="dark"] h2 {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] h3 {
-  color: #cbd5e1;
+  color: var(--gray-300);
 }
 
 /* Dark theme - Tables */
 [data-theme="dark"] .table-container {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] th {
-  background-color: #1e293b;
-  color: #94a3b8;
+  background-color: var(--gray-800);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] th,
 [data-theme="dark"] td {
-  border-bottom-color: #374151;
-  color: #e2e8f0;
+  border-bottom-color: var(--gray-text-dark);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] tbody tr:hover {
-  background-color: rgba(55, 65, 81, 0.5) !important;
+  background-color: var(--gray-text-alpha-50) !important;
 }
 
 /* Dark theme - Stat cards */
 [data-theme="dark"] .stat-card {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .stat-card h3 {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .stat-card .stat-value,
 [data-theme="dark"] .stat-card .value {
-  color: #93c5fd;
+  color: var(--blue-300);
 }
 
 [data-theme="dark"] .stat-card .subtext {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 /* Dark theme - Charts */
 [data-theme="dark"] .chart-container {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .chart-no-data {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - Forms & Inputs */
@@ -1278,663 +1278,663 @@ tbody tr:hover {
 [data-theme="dark"] input[type="number"],
 [data-theme="dark"] select,
 [data-theme="dark"] textarea {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] input::placeholder,
 [data-theme="dark"] textarea::placeholder {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 [data-theme="dark"] label {
-  color: #cbd5e1;
+  color: var(--gray-300);
 }
 
 /* Dark theme - Badges */
 [data-theme="dark"] .badge-success {
-  background-color: rgba(16, 185, 129, 0.2);
-  color: #34d399;
+  background-color: var(--green-alpha-20);
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .badge-pending {
-  background-color: rgba(245, 158, 11, 0.2);
-  color: #fbbf24;
+  background-color: var(--amber-alpha-20);
+  color: var(--amber-400);
 }
 
 [data-theme="dark"] .badge-admin {
-  background-color: rgba(59, 130, 246, 0.2);
-  color: #60a5fa;
+  background-color: var(--blue-alpha-20);
+  color: var(--blue-400);
 }
 
 [data-theme="dark"] .badge-user {
-  background-color: rgba(107, 114, 128, 0.3);
-  color: #94a3b8;
+  background-color: var(--gray-alpha-30);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .badge-banned {
-  background-color: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  background-color: var(--red-alpha-20);
+  color: var(--red-400);
 }
 
 [data-theme="dark"] .badge-active {
-  background-color: rgba(107, 114, 128, 0.2);
-  color: #94a3b8;
+  background-color: var(--gray-alpha-20);
+  color: var(--gray-400);
 }
 
 /* Dark theme - Alerts */
 [data-theme="dark"] .alert-success,
 [data-theme="dark"] .success-message {
-  background: rgba(16, 185, 129, 0.15);
-  color: #34d399;
-  border-color: rgba(16, 185, 129, 0.3);
+  background: var(--green-alpha-15);
+  color: var(--emerald-400);
+  border-color: var(--green-alpha-30);
 }
 
 [data-theme="dark"] .alert-error,
 [data-theme="dark"] .error-message {
-  background: rgba(239, 68, 68, 0.15);
-  color: #f87171;
-  border-color: rgba(239, 68, 68, 0.3);
+  background: var(--red-alpha-15);
+  color: var(--red-400);
+  border-color: var(--red-alpha-30);
 }
 
 /* Dark theme - Period selection */
 [data-theme="dark"] .period-selection {
-  background: #1f2937;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .period-selection span {
-  color: #cbd5e1;
+  color: var(--gray-300);
 }
 
 [data-theme="dark"] .period-btn {
-  background: #374151;
-  color: #94a3b8;
+  background: var(--gray-text-dark);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .period-btn:hover {
-  background: #4b5563;
+  background: var(--gray-text-light);
 }
 
 [data-theme="dark"] .period-btn.active {
-  background: #4b5563;
-  color: #f1f5f9;
-  border-color: #6b7280;
+  background: var(--gray-text-light);
+  color: var(--gray-100);
+  border-color: var(--gray-text);
 }
 
 /* Dark theme - Login */
 [data-theme="dark"] .login-container {
-  background: #1f2937;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  box-shadow: 0 4px 6px var(--overlay-light);
 }
 
 /* Dark theme - 2FA */
 [data-theme="dark"] .secret-key {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .verification-heading {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .verification-code,
 [data-theme="dark"] .verification-input {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 /* Dark theme - Data info / No data */
 [data-theme="dark"] .data-info {
-  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-  border-color: #475569;
-  color: #94a3b8;
+  background: linear-gradient(135deg, var(--gray-800) 0%, var(--gray-700) 100%);
+  border-color: var(--gray-600);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .no-data {
-  color: #94a3b8;
-  background: linear-gradient(135deg, #1f2937 0%, #1e293b 100%);
-  border-color: #475569;
+  color: var(--gray-400);
+  background: linear-gradient(135deg, var(--gray-text-darker) 0%, var(--gray-800) 100%);
+  border-color: var(--gray-600);
 }
 
 [data-theme="dark"] .no-data h3 {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .no-data code {
-  background: #374151;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  color: var(--gray-200);
 }
 
 /* Dark theme - Scrollbar */
 [data-theme="dark"] .table-responsive::-webkit-scrollbar-track {
-  background: #1e293b;
+  background: var(--gray-800);
 }
 
 [data-theme="dark"] .table-responsive::-webkit-scrollbar-thumb {
-  background: #475569;
+  background: var(--gray-600);
 }
 
 [data-theme="dark"] .table-responsive::-webkit-scrollbar-thumb:hover {
-  background: #64748b;
+  background: var(--gray-500);
 }
 
 /* Dark theme - Filters bar (payments) */
 [data-theme="dark"] .filters-bar {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 /* Dark theme - Env toggle (payments) */
 [data-theme="dark"] .env-toggle-bar {
-  background: #374151;
+  background: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .env-toggle-btn {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .env-toggle-btn:hover {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .env-toggle-btn.active {
-  background: #1f2937;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 /* Dark theme - Tab buttons (payments, license) */
 [data-theme="dark"] .tab-buttons {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .tab-button {
-  background: #1e293b;
-  border-color: #374151;
-  color: #94a3b8;
+  background: var(--gray-800);
+  border-color: var(--gray-text-dark);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .tab-button:hover {
-  background: #334155;
-  color: #e2e8f0;
+  background: var(--gray-700);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .tab-button.active {
-  background: #1f2937;
-  color: #f1f5f9;
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  color: var(--gray-100);
+  box-shadow: 0 -2px 8px var(--overlay-light);
 }
 
 [data-theme="dark"] .section-tabs {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .section-tab {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .section-tab:hover {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 /* Dark theme - Payment status badges */
 [data-theme="dark"] .status-completed,
 [data-theme="dark"] .badge-completed {
-  background: rgba(16, 185, 129, 0.2);
-  color: #34d399;
+  background: var(--green-alpha-20);
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .status-failed,
 [data-theme="dark"] .badge-failed {
-  background: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  background: var(--red-alpha-20);
+  color: var(--red-400);
 }
 
 [data-theme="dark"] .status-pending,
 [data-theme="dark"] .badge-refunded {
-  background: rgba(99, 102, 241, 0.2);
-  color: #818cf8;
+  background: var(--indigo-alpha-20);
+  color: var(--indigo-400);
 }
 
 /* Dark theme - Invoice badges */
 [data-theme="dark"] .badge-invoice-draft,
 [data-theme="dark"] .badge-invoice-cancelled {
-  background: rgba(107, 114, 128, 0.2);
-  color: #94a3b8;
+  background: var(--gray-alpha-20);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .badge-invoice-sent {
-  background: rgba(59, 130, 246, 0.2);
-  color: #60a5fa;
+  background: var(--blue-alpha-20);
+  color: var(--blue-400);
 }
 
 [data-theme="dark"] .badge-invoice-viewed {
-  background: rgba(14, 165, 233, 0.2);
-  color: #38bdf8;
+  background: var(--sky-alpha-20);
+  color: var(--sky-400);
 }
 
 [data-theme="dark"] .badge-invoice-pending {
-  background: rgba(245, 158, 11, 0.2);
-  color: #fbbf24;
+  background: var(--amber-alpha-20);
+  color: var(--amber-400);
 }
 
 [data-theme="dark"] .badge-invoice-partial {
-  background: rgba(139, 92, 246, 0.2);
-  color: #a78bfa;
+  background: var(--purple-alpha-20);
+  color: var(--purple-400);
 }
 
 [data-theme="dark"] .badge-invoice-paid {
-  background: rgba(16, 185, 129, 0.2);
-  color: #34d399;
+  background: var(--green-alpha-20);
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .badge-invoice-overdue {
-  background: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  background: var(--red-alpha-20);
+  color: var(--red-400);
 }
 
 /* Dark theme - Overdue row */
 [data-theme="dark"] .row-overdue {
-  background-color: rgba(239, 68, 68, 0.1) !important;
+  background-color: var(--red-alpha-10) !important;
 }
 
 [data-theme="dark"] .row-overdue:hover {
-  background-color: rgba(239, 68, 68, 0.15) !important;
+  background-color: var(--red-alpha-15) !important;
 }
 
 /* Dark theme - Company detail (payments) */
 [data-theme="dark"] .company-detail {
-  background: #1e293b;
-  border-top-color: #374151;
+  background: var(--gray-800);
+  border-top-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .detail-section-title {
-  color: #cbd5e1;
-  border-bottom-color: #374151;
+  color: var(--gray-300);
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .detail-label {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .detail-value {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .provider-card {
-  border-color: #374151;
+  border-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .provider-card.provider-connected {
-  background: rgba(16, 185, 129, 0.1);
-  border-color: rgba(16, 185, 129, 0.3);
+  background: var(--green-alpha-10);
+  border-color: var(--green-alpha-30);
 }
 
 [data-theme="dark"] .provider-card.provider-disconnected {
-  background: #1e293b;
-  border-color: #374151;
+  background: var(--gray-800);
+  border-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .provider-card-name {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .provider-card-status {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .expandable-row:hover {
-  background-color: #1e293b !important;
+  background-color: var(--gray-800) !important;
 }
 
 [data-theme="dark"] .detail-row td {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .provider-badge.connected {
-  background-color: rgba(16, 185, 129, 0.2);
-  color: #34d399;
+  background-color: var(--green-alpha-20);
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .provider-badge.disconnected {
-  background-color: rgba(107, 114, 128, 0.2);
-  color: #64748b;
+  background-color: var(--gray-alpha-20);
+  color: var(--gray-500);
 }
 
 /* Dark theme - Result count */
 [data-theme="dark"] .result-count {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - Btn outline */
 [data-theme="dark"] .btn-outline {
-  background: #374151;
-  color: #94a3b8;
-  border-color: #4b5563;
+  background: var(--gray-text-dark);
+  color: var(--gray-400);
+  border-color: var(--gray-text-light);
 }
 
 [data-theme="dark"] .btn-outline:hover {
-  background: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 /* Dark theme - Badge method */
 [data-theme="dark"] .badge-method {
-  background-color: rgba(99, 102, 241, 0.2);
-  color: #818cf8;
+  background-color: var(--indigo-alpha-20);
+  color: var(--indigo-400);
 }
 
 /* Dark theme - License page */
 [data-theme="dark"] .form-group label {
-  color: #cbd5e1;
+  color: var(--gray-300);
 }
 
 [data-theme="dark"] .form-group input,
 [data-theme="dark"] .form-group select,
 [data-theme="dark"] .form-group textarea {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .key-display {
-  background: rgba(16, 185, 129, 0.1);
-  border-color: rgba(16, 185, 129, 0.3);
+  background: var(--green-alpha-10);
+  border-color: var(--green-alpha-30);
 }
 
 [data-theme="dark"] .key-display code {
-  color: #34d399;
+  color: var(--emerald-400);
   background: transparent;
 }
 
 [data-theme="dark"] .badge-free {
-  background: rgba(139, 92, 246, 0.2);
-  color: #a78bfa;
+  background: var(--purple-alpha-20);
+  color: var(--purple-400);
 }
 
 [data-theme="dark"] .badge-redeemed {
-  background: rgba(59, 130, 246, 0.2);
-  color: #60a5fa;
+  background: var(--blue-alpha-20);
+  color: var(--blue-400);
 }
 
 [data-theme="dark"] .badge-cancelled {
-  background: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  background: var(--red-alpha-20);
+  color: var(--red-400);
 }
 
 [data-theme="dark"] .badge-expired {
-  background: rgba(107, 114, 128, 0.2);
-  color: #94a3b8;
+  background: var(--gray-alpha-20);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .usage-count {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .usage-na {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 [data-theme="dark"] .btn-secondary {
-  background: #374151;
-  color: #e2e8f0;
-  border-color: #4b5563;
+  background: var(--gray-text-dark);
+  color: var(--gray-200);
+  border-color: var(--gray-text-light);
 }
 
 [data-theme="dark"] .btn-secondary:hover {
-  background: #4b5563;
+  background: var(--gray-text-light);
 }
 
 /* Dark theme - Modals */
 [data-theme="dark"] .modal-content {
-  background: #1f2937;
+  background: var(--gray-text-darker);
 }
 
 [data-theme="dark"] .modal-header {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .modal-header h3 {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .modal-close {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 [data-theme="dark"] .modal-close:hover {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .modal-body p {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .modal-note {
-  background: #374151;
-  color: #94a3b8;
+  background: var(--gray-text-dark);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .modal-footer {
-  border-top-color: #374151;
-  background: #1e293b;
+  border-top-color: var(--gray-text-dark);
+  background: var(--gray-800);
 }
 
 [data-theme="dark"] #modalTitle {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 /* Dark theme - Referral links page */
 [data-theme="dark"] table thead {
-  background: #1e293b;
+  background: var(--gray-800);
 }
 
 [data-theme="dark"] table td {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] table tbody tr:hover {
-  background: rgba(55, 65, 81, 0.5);
+  background: var(--gray-text-alpha-50);
 }
 
 [data-theme="dark"] code {
-  background: #374151;
-  color: #f87171;
+  background: var(--gray-text-dark);
+  color: var(--red-400);
 }
 
 [data-theme="dark"] .status-active {
-  background: rgba(16, 185, 129, 0.2);
-  color: #34d399;
+  background: var(--green-alpha-20);
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .status-inactive {
-  background: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  background: var(--red-alpha-20);
+  color: var(--red-400);
 }
 
 /* Dark theme - Reports page */
 [data-theme="dark"] .reports-table {
-  background: #1f2937;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .report-row {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .report-title {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .report-id {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 [data-theme="dark"] .report-meta-row {
-  color: #64748b;
+  color: var(--gray-500);
 }
 
 [data-theme="dark"] .content-preview {
-  background: #1e293b;
-  color: #94a3b8;
-  border-left-color: #475569;
+  background: var(--gray-800);
+  color: var(--gray-400);
+  border-left-color: var(--gray-600);
 }
 
 [data-theme="dark"] .content-preview:after {
-  background: linear-gradient(transparent, #1e293b);
+  background: linear-gradient(transparent, var(--gray-800));
 }
 
 [data-theme="dark"] .status-badges .status-badge {
-  background: #1f2937;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-text-darker);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .status-badge-label {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .status-badge-count {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 /* Dark theme - Filter groups */
 [data-theme="dark"] .filter-group select {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .filter-group label {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 
 /* Dark theme - Card (users) */
 [data-theme="dark"] .card {
-  background: #1f2937;
-  border-color: #374151;
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .card-header {
-  border-bottom-color: #374151;
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .card-header h2 {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .search-input {
-  background: #374151;
-  border-color: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-dark);
+  border-color: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .clear-button {
-  background: #374151;
-  color: #94a3b8;
+  background: var(--gray-text-dark);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .clear-button:hover {
-  background: #4b5563;
-  color: #e2e8f0;
+  background: var(--gray-text-light);
+  color: var(--gray-200);
 }
 
 /* Dark theme - Bulk actions (users) */
 [data-theme="dark"] .bulk-actions-bar {
-  background: #1e293b;
-  border-bottom-color: #374151;
+  background: var(--gray-800);
+  border-bottom-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .selection-info {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - Dashboard chart cards */
 [data-theme="dark"] .chart-card {
-  background: #1f2937;
-  border-color: #374151;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
+  box-shadow: 0 4px 6px var(--shadow-xl);
 }
 
 [data-theme="dark"] .chart-card-title {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 /* Dark theme - Search results */
 [data-theme="dark"] .search-results {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - Checkboxes */
 [data-theme="dark"] .checkbox input[type="checkbox"] {
-  background-color: #1f2937;
-  border-color: #6366f1;
+  background-color: var(--gray-text-darker);
+  border-color: var(--indigo-500);
 }
 
 [data-theme="dark"] .checkbox input[type="checkbox"]:checked {
-  background-color: #6366f1;
+  background-color: var(--indigo-500);
 }
 
 [data-theme="dark"] .checkbox input[type="checkbox"]:hover {
-  border-color: #818cf8;
+  border-color: var(--indigo-400);
 }
 
 /* Dark theme - Dashboard hero */
 [data-theme="dark"] .hero-section h1 {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 /* Dark theme - Env toggle production/sandbox */
 [data-theme="dark"] .env-toggle-production.active {
-  color: #34d399;
+  color: var(--emerald-400);
 }
 
 [data-theme="dark"] .env-toggle-sandbox.active {
-  color: #fbbf24;
+  color: var(--amber-400);
 }
 
 /* Dark theme - Bulk actions container (license, search) */
 [data-theme="dark"] .bulk-actions-container {
-  background: #1e293b;
-  border-color: #374151;
+  background: var(--gray-800);
+  border-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .bulk-actions-container .selection-info {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 /* Dark theme - App stats inline styles */
 [data-theme="dark"] .section-title {
-  color: #e2e8f0;
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .error-details-table {
-  background: #1f2937;
-  border-color: #374151;
+  background: var(--gray-text-darker);
+  border-color: var(--gray-text-dark);
 }
 
 [data-theme="dark"] .error-details-table th {
-  background: #1e293b;
-  color: #94a3b8;
+  background: var(--gray-800);
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .error-details-table td {
-  border-bottom-color: #374151;
-  color: #e2e8f0;
+  border-bottom-color: var(--gray-text-dark);
+  color: var(--gray-200);
 }
 
 [data-theme="dark"] .error-details-table tr:hover {
-  background: #1e293b;
+  background: var(--gray-800);
 }
 
 [data-theme="dark"] .error-details-table td.error-code {
-  color: #f87171;
+  color: var(--red-400);
 }
 
 [data-theme="dark"] .error-details-table td.error-source {
-  color: #94a3b8;
+  color: var(--gray-400);
 }

--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -470,7 +470,7 @@ tbody tr {
 }
 
 tbody tr:hover {
-  background-color: var(--whiteBackground, var(--gray-bg-light-alpha-80)) !important;
+  background-color: var(--whiteBackground) !important;
 }
 
 .key-field {
@@ -550,7 +550,7 @@ tbody tr:hover {
 .stat-card .value {
   font-size: 1.75rem;
   font-weight: bold;
-  color: var(--blueText, var(--gray-text-darker));
+  color: var(--blueText);
   margin: 0;
   line-height: 1.2;
 }

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -2,7 +2,7 @@
     display: flex;
     gap: 10px;
     margin-bottom: 30px;
-    border-bottom: 2px solid #e5e7eb;
+    border-bottom: 2px solid var(--gray-border);
     padding-bottom: 0;
 }
 .section-tab {
@@ -12,13 +12,13 @@
     cursor: pointer;
     font-size: 1rem;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--gray-text);
     border-bottom: 3px solid transparent;
     margin-bottom: -2px;
     transition: all 0.2s;
 }
 .section-tab:hover {
-    color: #374151;
+    color: var(--gray-text-dark);
 }
 .section-tab.active {
     color: var(--primary-blue);
@@ -48,12 +48,12 @@ table th {
     display: block;
     margin-bottom: 5px;
     font-weight: 500;
-    color: #374151;
+    color: var(--gray-text-dark);
 }
 .form-group input, .form-group select, .form-group textarea {
     width: 100%;
     padding: 10px 12px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--gray-input-border);
     border-radius: 6px;
     font-size: 0.95rem;
 }
@@ -63,8 +63,8 @@ table th {
     box-sizing: border-box;
 }
 .key-display {
-    background: #f0fdf4;
-    border: 1px solid #86efac;
+    background: var(--green-50);
+    border: 1px solid var(--green-300);
     border-radius: 8px;
     padding: 15px;
     margin: 15px 0;
@@ -72,53 +72,53 @@ table th {
 .key-display code {
     font-size: 1.1rem;
     font-weight: bold;
-    color: #166534;
+    color: var(--green-800);
 }
 .badge-free {
-    background: #ede9fe;
-    color: #7c3aed;
+    background: var(--ede9fe);
+    color: var(--purple-600);
 }
 .badge-redeemed {
-    background: #dbeafe;
-    color: #1e40af;
+    background: var(--blue-100);
+    color: var(--blue-800);
 }
 .badge-active {
-    background: #d1fae5;
-    color: #065f46;
+    background: var(--emerald-100);
+    color: var(--emerald-800);
 }
 .badge-cancelled {
-    background: #fee2e2;
-    color: #991b1b;
+    background: var(--red-100);
+    color: var(--red-800);
 }
 .badge-expired {
-    background: #f3f4f6;
-    color: #6b7280;
+    background: var(--gray-bg-light);
+    color: var(--gray-text);
 }
 .btn-purple {
-    background: #8b5cf6;
-    color: white;
+    background: var(--purple-500);
+    color: var(--white);
     border: none;
 }
 .btn-purple:hover {
-    background: #7c3aed;
+    background: var(--purple-600);
 }
 .btn-purple:disabled {
-    background: #c4b5fd;
+    background: var(--purple-300);
     cursor: not-allowed;
 }
 .btn-secondary {
-    background: #f3f4f6;
-    color: #374151;
-    border: 1px solid #d1d5db;
+    background: var(--gray-bg-light);
+    color: var(--gray-text-dark);
+    border: 1px solid var(--gray-input-border);
 }
 .btn-secondary:hover {
-    background: #e5e7eb;
+    background: var(--gray-border);
 }
 /* Modal Styles */
 .modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay-dark);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -130,12 +130,12 @@ table th {
     to { opacity: 1; }
 }
 .modal-content {
-    background: white;
+    background: var(--white);
     border-radius: 12px;
     width: 100%;
     max-width: 450px;
     margin: 20px;
-    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    box-shadow: 0 20px 25px -5px var(--shadow-default), 0 10px 10px -5px var(--shadow-xs);
     animation: slideUp 0.3s ease;
 }
 @keyframes slideUp {
@@ -147,31 +147,31 @@ table th {
     justify-content: space-between;
     align-items: center;
     padding: 20px 24px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--gray-border);
 }
 .modal-header h3 {
     margin: 0;
     font-size: 1.25rem;
-    color: #111827;
+    color: var(--neutral-111827);
 }
 .modal-close {
     background: none;
     border: none;
     font-size: 1.5rem;
-    color: #9ca3af;
+    color: var(--gray-placeholder);
     cursor: pointer;
     padding: 0;
     line-height: 1;
 }
 .modal-close:hover {
-    color: #374151;
+    color: var(--gray-text-dark);
 }
 .modal-body {
     padding: 24px;
 }
 .modal-body p {
     margin: 0 0 20px 0;
-    color: #4b5563;
+    color: var(--gray-text-light);
 }
 .modal-body .form-group {
     margin-bottom: 20px;
@@ -181,8 +181,8 @@ table th {
 }
 .modal-note {
     font-size: 0.875rem;
-    color: #6b7280;
-    background: #f3f4f6;
+    color: var(--gray-text);
+    background: var(--gray-bg-light);
     padding: 12px;
     border-radius: 6px;
     margin-bottom: 0 !important;
@@ -192,8 +192,8 @@ table th {
     justify-content: flex-end;
     gap: 12px;
     padding: 16px 24px;
-    border-top: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-top: 1px solid var(--gray-border);
+    background: var(--whiteBackground);
     border-radius: 0 0 12px 12px;
 }
 .modal-footer .btn {
@@ -203,23 +203,23 @@ table th {
 .usage-count {
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--gray-700, #374151);
+    color: var(--gray-700, var(--gray-text-dark));
     white-space: nowrap;
 }
 .usage-maxed {
-    color: var(--red-500, #ef4444);
+    color: var(--red-500, var(--red-500));
     font-weight: 600;
 }
 .usage-na {
-    color: var(--gray-400, #9ca3af);
+    color: var(--gray-400, var(--gray-placeholder));
 }
 .btn-reset-usage {
-    background-color: var(--primary-blue, #3b82f6);
-    color: white;
+    background-color: var(--primary-blue, var(--blue-500));
+    color: var(--white);
     border: none;
 }
 .btn-reset-usage:not(:disabled):hover {
-    background-color: var(--blue-600, #2563eb);
+    background-color: var(--blue-600, var(--blue-600));
 }
 .btn-reset-usage:disabled {
     opacity: 0.5;

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -75,7 +75,7 @@ table th {
     color: var(--green-800);
 }
 .badge-free {
-    background: var(--ede9fe);
+    background: var(--violet-100);
     color: var(--purple-600);
 }
 .badge-redeemed {

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -203,23 +203,23 @@ table th {
 .usage-count {
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--gray-700, var(--gray-text-dark));
+    color: var(--gray-700);
     white-space: nowrap;
 }
 .usage-maxed {
-    color: var(--red-500, var(--red-500));
+    color: var(--red-500);
     font-weight: 600;
 }
 .usage-na {
-    color: var(--gray-400, var(--gray-placeholder));
+    color: var(--gray-400);
 }
 .btn-reset-usage {
-    background-color: var(--primary-blue, var(--blue-500));
+    background-color: var(--primary-blue);
     color: var(--white);
     border: none;
 }
 .btn-reset-usage:not(:disabled):hover {
-    background-color: var(--blue-600, var(--blue-600));
+    background-color: var(--blue-600);
 }
 .btn-reset-usage:disabled {
     opacity: 0.5;

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -10,7 +10,7 @@
     background: var(--white);
     padding: 14px 18px;
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px var(--shadow-default);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -42,7 +42,7 @@
 .panel {
     background: var(--white);
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px var(--shadow-default);
     margin-bottom: 20px;
     overflow: hidden;
 }
@@ -129,7 +129,7 @@
 .form-group textarea:focus {
     outline: none;
     border-color: var(--primary-blue);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    box-shadow: 0 0 0 2px var(--blue-alpha-15);
 }
 
 .form-group textarea {
@@ -151,13 +151,13 @@
     align-items: center;
     gap: 12px;
     padding: 10px 20px;
-    background: var(--blue-50, #eff6ff);
+    background: var(--blue-50, var(--blue-50));
     border-bottom: 1px solid var(--gray-border);
     font-size: 14px;
 }
 
 [data-theme="dark"] .bulk-actions-bar {
-    background: #1e3a5f;
+    background: var(--navy-1e3a5f);
 }
 
 .checkbox-column {
@@ -323,7 +323,7 @@
 .modal {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay-dark);
     z-index: 2000;
     display: flex;
     align-items: center;
@@ -337,7 +337,7 @@
     width: 100%;
     height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 20px 60px var(--overlay-light);
 }
 
 .modal-large {
@@ -617,8 +617,8 @@
 .bulk-send-status {
     padding: 12px 20px;
     font-size: 0.9rem;
-    color: var(--gray-600, #4b5563);
-    border-bottom: 1px solid var(--gray-border, #e5e7eb);
+    color: var(--gray-600, var(--gray-text-light));
+    border-bottom: 1px solid var(--gray-border, var(--gray-border));
 }
 
 .bulk-send-list {
@@ -628,7 +628,7 @@
 
 .bulk-send-item {
     padding: 16px 20px;
-    border-bottom: 1px solid var(--gray-border, #e5e7eb);
+    border-bottom: 1px solid var(--gray-border, var(--gray-border));
 }
 
 .bulk-send-item:last-child {
@@ -648,7 +648,7 @@
 
 .bulk-send-item-email {
     font-size: 0.85rem;
-    color: var(--gray-500, #6b7280);
+    color: var(--gray-500, var(--gray-text));
 }
 
 .bulk-send-item-subject {
@@ -659,7 +659,7 @@
 
 .bulk-send-item-body {
     font-size: 0.85rem;
-    color: var(--gray-600, #4b5563);
+    color: var(--gray-600, var(--gray-text-light));
     white-space: pre-line;
     line-height: 1.5;
     max-height: 120px;
@@ -668,18 +668,18 @@
 
 .bulk-send-item-generating {
     font-size: 0.85rem;
-    color: var(--blue, #3b82f6);
+    color: var(--blue, var(--blue-500));
     font-style: italic;
 }
 
 .bulk-send-item-error {
     font-size: 0.85rem;
-    color: #ef4444;
+    color: var(--red-500);
 }
 
 .bulk-send-item-no-email {
     font-size: 0.85rem;
-    color: #f59e0b;
+    color: var(--amber-500);
 }
 
 .btn-blue:disabled {
@@ -690,29 +690,29 @@
 /* ─── Dark Theme ─── */
 [data-theme="dark"] .stat-card,
 [data-theme="dark"] .panel {
-    background: #1e293b;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    background: var(--gray-800);
+    box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .panel-header {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .stat-value {
-    color: #e2e8f0;
+    color: var(--gray-200);
 }
 
 [data-theme="dark"] .data-table th {
-    color: #94a3b8;
-    border-bottom-color: #334155;
+    color: var(--gray-400);
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .data-table td {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .clickable-row:hover {
-    background: #253449;
+    background: var(--slate-253449);
 }
 
 [data-theme="dark"] .form-group input,
@@ -720,56 +720,56 @@
 [data-theme="dark"] .form-group textarea,
 [data-theme="dark"] .filter-group select,
 [data-theme="dark"] .filter-group input {
-    background: #0f172a;
-    border-color: #334155;
-    color: #e2e8f0;
+    background: var(--gray-900);
+    border-color: var(--gray-700);
+    color: var(--gray-200);
     color-scheme: dark;
 }
 
 [data-theme="dark"] .form-group label,
 [data-theme="dark"] .filter-group label {
-    color: #94a3b8;
+    color: var(--gray-400);
 }
 
 [data-theme="dark"] .modal-content {
-    background: #1e293b;
+    background: var(--gray-800);
 }
 
 [data-theme="dark"] .modal-header {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .modal-header h3 {
-    color: #f1f5f9;
+    color: var(--gray-100);
 }
 
 [data-theme="dark"] .modal-close {
-    color: #94a3b8;
+    color: var(--gray-400);
 }
 
 [data-theme="dark"] .modal-close:hover {
-    color: #e2e8f0;
+    color: var(--gray-200);
 }
 
 [data-theme="dark"] .modal-footer {
-    border-top-color: #334155;
+    border-top-color: var(--gray-700);
 }
 
 [data-theme="dark"] .bulk-send-status {
-    color: #94a3b8;
-    border-bottom-color: #334155;
+    color: var(--gray-400);
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .bulk-send-item {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .bulk-send-item-email {
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 [data-theme="dark"] .bulk-send-item-body {
-    color: #94a3b8;
+    color: var(--gray-400);
 }
 
 [data-theme="dark"] .bulk-send-list::-webkit-scrollbar,
@@ -779,52 +779,52 @@
 
 [data-theme="dark"] .bulk-send-list::-webkit-scrollbar-track,
 [data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-track {
-    background: #1e293b;
+    background: var(--gray-800);
 }
 
 [data-theme="dark"] .bulk-send-list::-webkit-scrollbar-thumb,
 [data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-thumb {
-    background: #475569;
+    background: var(--gray-600);
     border-radius: 4px;
 }
 
 [data-theme="dark"] .bulk-send-list::-webkit-scrollbar-thumb:hover,
 [data-theme="dark"] .bulk-send-item-body::-webkit-scrollbar-thumb:hover {
-    background: #64748b;
+    background: var(--gray-500);
 }
 
 [data-theme="dark"] .tabs {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .tab {
-    color: #94a3b8;
+    color: var(--gray-400);
 }
 
 [data-theme="dark"] .tab:hover {
-    color: #e2e8f0;
+    color: var(--gray-200);
 }
 
 [data-theme="dark"] .draft-status-bar {
-    background: #0f172a;
+    background: var(--gray-900);
 }
 
 [data-theme="dark"] .draft-preview {
-    background: #0f172a;
-    border-color: #334155;
+    background: var(--gray-900);
+    border-color: var(--gray-700);
 }
 
 [data-theme="dark"] .activity-item {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .filters-container {
-    border-bottom-color: #334155;
+    border-bottom-color: var(--gray-700);
 }
 
 [data-theme="dark"] .gray-border,
 [data-theme="dark"] .detail-meta {
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 [data-theme="dark"] .leads-table-wrapper::-webkit-scrollbar,
@@ -834,16 +834,16 @@
 
 [data-theme="dark"] .leads-table-wrapper::-webkit-scrollbar-track,
 [data-theme="dark"] .discovery-table-wrapper::-webkit-scrollbar-track {
-    background: #1e293b;
+    background: var(--gray-800);
 }
 
 [data-theme="dark"] .leads-table-wrapper::-webkit-scrollbar-thumb,
 [data-theme="dark"] .discovery-table-wrapper::-webkit-scrollbar-thumb {
-    background: #475569;
+    background: var(--gray-600);
     border-radius: 4px;
 }
 
 [data-theme="dark"] .leads-table-wrapper::-webkit-scrollbar-thumb:hover,
 [data-theme="dark"] .discovery-table-wrapper::-webkit-scrollbar-thumb:hover {
-    background: #64748b;
+    background: var(--gray-500);
 }

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -151,7 +151,7 @@
     align-items: center;
     gap: 12px;
     padding: 10px 20px;
-    background: var(--blue-50, var(--blue-50));
+    background: var(--blue-50);
     border-bottom: 1px solid var(--gray-border);
     font-size: 14px;
 }
@@ -617,8 +617,8 @@
 .bulk-send-status {
     padding: 12px 20px;
     font-size: 0.9rem;
-    color: var(--gray-600, var(--gray-text-light));
-    border-bottom: 1px solid var(--gray-border, var(--gray-border));
+    color: var(--gray-600);
+    border-bottom: 1px solid var(--gray-border);
 }
 
 .bulk-send-list {
@@ -628,7 +628,7 @@
 
 .bulk-send-item {
     padding: 16px 20px;
-    border-bottom: 1px solid var(--gray-border, var(--gray-border));
+    border-bottom: 1px solid var(--gray-border);
 }
 
 .bulk-send-item:last-child {
@@ -648,7 +648,7 @@
 
 .bulk-send-item-email {
     font-size: 0.85rem;
-    color: var(--gray-500, var(--gray-text));
+    color: var(--gray-500);
 }
 
 .bulk-send-item-subject {
@@ -659,7 +659,7 @@
 
 .bulk-send-item-body {
     font-size: 0.85rem;
-    color: var(--gray-600, var(--gray-text-light));
+    color: var(--gray-600);
     white-space: pre-line;
     line-height: 1.5;
     max-height: 120px;
@@ -668,7 +668,7 @@
 
 .bulk-send-item-generating {
     font-size: 0.85rem;
-    color: var(--blue, var(--blue-500));
+    color: var(--blue);
     font-style: italic;
 }
 

--- a/admin/payments/style.css
+++ b/admin/payments/style.css
@@ -118,11 +118,11 @@
    Text Colors
    ============================================================ */
 .text-red {
-    color: var(--red-500, var(--red-500)) !important;
+    color: var(--red-500) !important;
 }
 
 .text-green {
-    color: var(--emerald-500, var(--emerald-500)) !important;
+    color: var(--emerald-500) !important;
 }
 
 /* ============================================================
@@ -167,7 +167,7 @@
 .filter-group input:focus,
 .filter-group select:focus {
     outline: none;
-    border-color: var(--primary-blue, var(--blue-500));
+    border-color: var(--primary-blue);
     box-shadow: 0 0 0 2px var(--blue-alpha-15);
 }
 
@@ -186,12 +186,12 @@
 }
 
 .btn-primary-blue {
-    background: var(--primary-blue, var(--blue-500));
+    background: var(--primary-blue);
     color: var(--white);
 }
 
 .btn-primary-blue:hover {
-    background: var(--blueHover, var(--blue-700));
+    background: var(--blueHover);
 }
 
 .btn-outline {

--- a/admin/payments/style.css
+++ b/admin/payments/style.css
@@ -12,7 +12,7 @@
     display: flex;
     gap: 0;
     margin-bottom: 1.25rem;
-    background: #f3f4f6;
+    background: var(--gray-bg-light);
     border-radius: 8px;
     padding: 4px;
     width: fit-content;
@@ -26,26 +26,26 @@
     cursor: pointer;
     text-decoration: none;
     transition: all 0.2s ease;
-    color: #6b7280;
+    color: var(--gray-text);
     background: transparent;
     border: none;
 }
 
 .env-toggle-btn:hover {
-    color: #374151;
+    color: var(--gray-text-dark);
 }
 
 .env-toggle-btn.active {
-    background: white;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    background: var(--white);
+    box-shadow: 0 1px 3px var(--shadow-default);
 }
 
 .env-toggle-production.active {
-    color: #065f46;
+    color: var(--emerald-800);
 }
 
 .env-toggle-sandbox.active {
-    color: #92400e;
+    color: var(--amber-800);
 }
 
 /* ============================================================
@@ -56,33 +56,33 @@
     flex-wrap: wrap;
     gap: 4px;
     margin-bottom: 1.5rem;
-    border-bottom: 2px solid #e5e7eb;
+    border-bottom: 2px solid var(--gray-border);
     justify-content: center;
 }
 
 .tab-button {
     padding: 12px 20px;
-    background: #f9fafb;
-    border: 1px solid #d1d5db;
+    background: var(--whiteBackground);
+    border: 1px solid var(--gray-input-border);
     border-bottom: none;
     border-radius: 8px 8px 0 0;
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--gray-text);
     transition: all 0.2s ease;
     user-select: none;
 }
 
 .tab-button:hover {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--gray-bg-light);
+    color: var(--gray-text-dark);
 }
 
 .tab-button.active {
-    background: white;
-    color: #1f2937;
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
+    background: var(--white);
+    color: var(--gray-text-darker);
+    box-shadow: 0 -2px 8px var(--shadow-default);
     font-weight: 600;
 }
 
@@ -118,11 +118,11 @@
    Text Colors
    ============================================================ */
 .text-red {
-    color: var(--red-500, #ef4444) !important;
+    color: var(--red-500, var(--red-500)) !important;
 }
 
 .text-green {
-    color: var(--emerald-500, #10b981) !important;
+    color: var(--emerald-500, var(--emerald-500)) !important;
 }
 
 /* ============================================================
@@ -134,10 +134,10 @@
     gap: 10px;
     margin-bottom: 1.5rem;
     padding: 15px 20px;
-    background: white;
+    background: var(--white);
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 3px var(--shadow-default);
+    border: 1px solid var(--gray-border);
     flex-wrap: wrap;
 }
 
@@ -152,11 +152,11 @@
 .filter-group input,
 .filter-group select {
     padding: 8px 12px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--gray-input-border);
     border-radius: 6px;
     font-size: 0.875rem;
-    color: #374151;
-    background: white;
+    color: var(--gray-text-dark);
+    background: var(--white);
     min-width: 140px;
 }
 
@@ -167,8 +167,8 @@
 .filter-group input:focus,
 .filter-group select:focus {
     outline: none;
-    border-color: var(--primary-blue, #3b82f6);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    border-color: var(--primary-blue, var(--blue-500));
+    box-shadow: 0 0 0 2px var(--blue-alpha-15);
 }
 
 .payments-page .btn {
@@ -186,26 +186,26 @@
 }
 
 .btn-primary-blue {
-    background: var(--primary-blue, #3b82f6);
-    color: white;
+    background: var(--primary-blue, var(--blue-500));
+    color: var(--white);
 }
 
 .btn-primary-blue:hover {
-    background: var(--blueHover, #1d4ed8);
+    background: var(--blueHover, var(--blue-700));
 }
 
 .btn-outline {
-    background: white;
-    color: #6b7280;
-    border: 1px solid #d1d5db;
+    background: var(--white);
+    color: var(--gray-text);
+    border: 1px solid var(--gray-input-border);
 }
 
 .btn-outline:hover {
-    background: #f3f4f6;
+    background: var(--gray-bg-light);
 }
 
 .result-count {
-    color: #6b7280;
+    color: var(--gray-text);
     font-size: 0.875rem;
 }
 
@@ -213,8 +213,8 @@
    Payment Method Badge
    ============================================================ */
 .badge-method {
-    background-color: #eef2ff;
-    color: #4338ca;
+    background-color: var(--indigo-50);
+    color: var(--indigo-700);
     font-weight: 500;
 }
 
@@ -222,77 +222,77 @@
    Payment Status Badges
    ============================================================ */
 .badge-completed {
-    background-color: #d1fae5;
-    color: #065f46;
+    background-color: var(--emerald-100);
+    color: var(--emerald-800);
 }
 
 .badge-pending {
-    background-color: #fef3c7;
-    color: #92400e;
+    background-color: var(--amber-100);
+    color: var(--amber-800);
 }
 
 .badge-failed {
-    background-color: #fee2e2;
-    color: #991b1b;
+    background-color: var(--red-100);
+    color: var(--red-800);
 }
 
 .badge-refunded {
-    background-color: #e0e7ff;
-    color: #3730a3;
+    background-color: var(--indigo-100);
+    color: var(--indigo-800);
 }
 
 /* ============================================================
    Invoice Status Badges
    ============================================================ */
 .badge-invoice-draft {
-    background-color: #f3f4f6;
-    color: #4b5563;
+    background-color: var(--gray-bg-light);
+    color: var(--gray-text-light);
 }
 
 .badge-invoice-sent {
-    background-color: #dbeafe;
-    color: #1e40af;
+    background-color: var(--blue-100);
+    color: var(--blue-800);
 }
 
 .badge-invoice-viewed {
-    background-color: #e0f2fe;
-    color: #0369a1;
+    background-color: var(--sky-100);
+    color: var(--sky-700);
 }
 
 .badge-invoice-pending {
-    background-color: #fef3c7;
-    color: #92400e;
+    background-color: var(--amber-100);
+    color: var(--amber-800);
 }
 
 .badge-invoice-partial {
-    background-color: #f3e8ff;
-    color: #6d28d9;
+    background-color: var(--purple-100);
+    color: var(--purple-700);
 }
 
 .badge-invoice-paid {
-    background-color: #d1fae5;
-    color: #065f46;
+    background-color: var(--emerald-100);
+    color: var(--emerald-800);
 }
 
 .badge-invoice-overdue {
-    background-color: #fee2e2;
-    color: #991b1b;
+    background-color: var(--red-100);
+    color: var(--red-800);
 }
 
 .badge-invoice-cancelled {
-    background-color: #f3f4f6;
-    color: #6b7280;
+    background-color: var(--gray-bg-light);
+    color: var(--gray-text);
 }
 
 /* ============================================================
    Overdue Row Highlight
    ============================================================ */
 .row-overdue {
-    background-color: #fef2f2 !important;
+    background-color: var(--red-50) !important;
 }
 
 .row-overdue:hover {
-    background-color: #fee2e2 !important;
+    background-color: var(--red-100) !important;
 }
 
 /* ============================================================
@@ -315,13 +315,13 @@
 }
 
 .provider-badge.connected {
-    background-color: #d1fae5;
-    color: #065f46;
+    background-color: var(--emerald-100);
+    color: var(--emerald-800);
 }
 
 .provider-badge.disconnected {
-    background-color: #f3f4f6;
-    color: #9ca3af;
+    background-color: var(--gray-bg-light);
+    color: var(--gray-placeholder);
 }
 
 /* ============================================================
@@ -332,7 +332,7 @@
 }
 
 .expandable-row:hover {
-    background-color: #f9fafb !important;
+    background-color: var(--whiteBackground) !important;
 }
 
 .expand-arrow-cell {
@@ -343,7 +343,7 @@
 .expand-arrow {
     display: inline-block;
     transition: transform 0.2s ease;
-    color: #9ca3af;
+    color: var(--gray-placeholder);
     font-size: 0.875rem;
 }
 
@@ -353,13 +353,13 @@
 
 .detail-row td {
     padding: 0 !important;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--gray-border);
 }
 
 .company-detail {
     padding: 20px 15px;
-    background: #f9fafb;
-    border-top: 1px solid #e5e7eb;
+    background: var(--whiteBackground);
+    border-top: 1px solid var(--gray-border);
 }
 
 .detail-section {
@@ -373,12 +373,12 @@
 .detail-section-title {
     font-size: 0.8rem;
     font-weight: 600;
-    color: #374151;
+    color: var(--gray-text-dark);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin: 0 0 10px 0;
     padding-bottom: 6px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--gray-border);
 }
 
 .detail-section-grid {
@@ -396,17 +396,17 @@
 .provider-card {
     border-radius: 8px;
     padding: 14px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--gray-border);
 }
 
 .provider-card.provider-connected {
-    background: #f0fdf4;
-    border-color: #bbf7d0;
+    background: var(--green-50);
+    border-color: var(--green-200);
 }
 
 .provider-card.provider-disconnected {
-    background: #f9fafb;
-    border-color: #e5e7eb;
+    background: var(--whiteBackground);
+    border-color: var(--gray-border);
 }
 
 .provider-card-header {
@@ -419,17 +419,17 @@
 .provider-card-name {
     font-weight: 600;
     font-size: 0.875rem;
-    color: #1f2937;
+    color: var(--gray-text-darker);
 }
 
 .provider-card-status {
     font-size: 0.75rem;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--gray-text);
 }
 
 .provider-connected .provider-card-status {
-    color: #059669;
+    color: var(--emerald-600);
 }
 
 .provider-card-details {
@@ -456,7 +456,7 @@
 
 .detail-label {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--gray-text);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     font-weight: 500;
@@ -464,7 +464,7 @@
 
 .detail-value {
     font-size: 0.875rem;
-    color: #1f2937;
+    color: var(--gray-text-darker);
 }
 
 /* ============================================================

--- a/admin/referral-links/style.css
+++ b/admin/referral-links/style.css
@@ -12,17 +12,17 @@
 }
 
 .stat-card {
-    background: white;
+    background: var(--white);
     padding: 24px;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px var(--shadow-default);
 }
 
 .stat-card h3 {
     margin: 0 0 12px 0;
     font-size: 14px;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--gray-text);
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
@@ -30,13 +30,13 @@
 .stat-card .value {
     font-size: 32px;
     font-weight: 700;
-    color: #1f2937;
+    color: var(--gray-text-darker);
     margin-bottom: 4px;
 }
 
 .stat-card .subtext {
     font-size: 14px;
-    color: #9ca3af;
+    color: var(--gray-placeholder);
 }
 
 .period-selection {
@@ -45,14 +45,14 @@
     gap: 15px;
     margin-bottom: 30px;
     padding: 15px;
-    background: white;
+    background: var(--white);
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px var(--shadow-default);
 }
 
 .period-selection span {
     font-weight: 600;
-    color: #4b5563;
+    color: var(--gray-text-light);
 }
 
 .period-buttons {
@@ -64,19 +64,19 @@
     padding: 8px 16px;
     border-radius: 6px;
     text-decoration: none;
-    color: #4b5563;
-    background: #f3f4f6;
+    color: var(--gray-text-light);
+    background: var(--gray-bg-light);
     font-weight: 500;
     transition: all 0.2s;
 }
 
 .period-btn:hover {
-    background: #e5e7eb;
+    background: var(--gray-border);
 }
 
 .period-btn.active {
-    background: #3b82f6;
-    color: white;
+    background: var(--blue-500);
+    color: var(--white);
 }
 
 .chart-row {
@@ -87,10 +87,10 @@
 }
 
 .chart-container {
-    background: white;
+    background: var(--white);
     padding: 24px;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px var(--shadow-default);
     min-height: 400px;
 }
 
@@ -98,7 +98,7 @@
     margin: 0 0 20px 0;
     font-size: 18px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--gray-text-darker);
 }
 
 .chart-container canvas {
@@ -106,10 +106,10 @@
 }
 
 .table-container {
-    background: white;
+    background: var(--white);
     padding: 24px;
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px var(--shadow-default);
     margin-top: 20px;
 }
 
@@ -124,7 +124,7 @@
     margin: 0;
     font-size: 20px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--gray-text-darker);
 }
 
 .table-responsive {
@@ -137,7 +137,7 @@ table {
 }
 
 table thead {
-    background: #f9fafb;
+    background: var(--whiteBackground);
 }
 
 table th {
@@ -145,33 +145,33 @@ table th {
     text-align: left;
     font-weight: 600;
     font-size: 13px;
-    color: #6b7280;
+    color: var(--gray-text);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    border-bottom: 2px solid #e5e7eb;
+    border-bottom: 2px solid var(--gray-border);
 }
 
 table td {
     padding: 12px;
-    border-bottom: 1px solid #e5e7eb;
-    color: #374151;
+    border-bottom: 1px solid var(--gray-border);
+    color: var(--gray-text-dark);
 }
 
 table tbody tr:hover {
-    background: #f9fafb;
+    background: var(--whiteBackground);
 }
 
 code {
-    background: #f3f4f6;
+    background: var(--gray-bg-light);
     padding: 4px 8px;
     border-radius: 4px;
     font-family: 'Courier New', monospace;
     font-size: 13px;
-    color: #dc2626;
+    color: var(--red-600);
 }
 
 .link-preview {
-    color: #3b82f6;
+    color: var(--blue-500);
     text-decoration: none;
 }
 
@@ -187,13 +187,13 @@ code {
 }
 
 .status-active {
-    background: #d1fae5;
-    color: #065f46;
+    background: var(--emerald-100);
+    color: var(--emerald-800);
 }
 
 .status-inactive {
-    background: #fee2e2;
-    color: #991b1b;
+    background: var(--red-100);
+    color: var(--red-800);
 }
 
 .action-buttons {
@@ -219,44 +219,44 @@ code {
 }
 
 .btn-blue, .btn-small.btn-blue {
-    background: #3b82f6;
-    color: white;
+    background: var(--blue-500);
+    color: var(--white);
 }
 
 .btn-blue:hover, .btn-small.btn-blue:hover {
-    background: #2563eb;
+    background: var(--blue-600);
 }
 
 .btn-yellow, .btn-small.btn-yellow {
-    background: #f59e0b;
-    color: white;
+    background: var(--amber-500);
+    color: var(--white);
 }
 
 .btn-yellow:hover, .btn-small.btn-yellow:hover {
-    background: #d97706;
+    background: var(--amber-600);
 }
 
 .btn-red, .btn-small.btn-red {
-    background: #ef4444;
-    color: white;
+    background: var(--red-500);
+    color: var(--white);
 }
 
 .btn-red:hover, .btn-small.btn-red:hover {
-    background: #dc2626;
+    background: var(--red-600);
 }
 
 .btn-gray {
-    background: #6b7280;
-    color: white;
+    background: var(--gray-text);
+    color: var(--white);
 }
 
 .btn-gray:hover {
-    background: #4b5563;
+    background: var(--gray-text-light);
 }
 
 .success-message {
-    background: #d1fae5;
-    color: #065f46;
+    background: var(--emerald-100);
+    color: var(--emerald-800);
     padding: 16px;
     border-radius: 8px;
     margin-bottom: 20px;
@@ -272,21 +272,21 @@ code {
     width: 100%;
     height: 100%;
     overflow: auto;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--overlay-dark);
 }
 
 .modal-content {
-    background-color: white;
+    background-color: var(--white);
     margin: 5% auto;
     padding: 32px;
     border-radius: 12px;
     width: 90%;
     max-width: 600px;
-    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 20px 25px -5px var(--shadow-default);
 }
 
 .modal-close {
-    color: #9ca3af;
+    color: var(--gray-placeholder);
     float: right;
     font-size: 32px;
     font-weight: bold;
@@ -295,13 +295,13 @@ code {
 }
 
 .modal-close:hover {
-    color: #4b5563;
+    color: var(--gray-text-light);
 }
 
 #modalTitle {
     margin-top: 0;
     margin-bottom: 24px;
-    color: #1f2937;
+    color: var(--gray-text-darker);
 }
 
 .form-group {
@@ -312,7 +312,7 @@ code {
     display: block;
     font-weight: 600;
     margin-bottom: 6px;
-    color: #374151;
+    color: var(--gray-text-dark);
 }
 
 .form-group input[type="text"],
@@ -320,7 +320,7 @@ code {
 .form-group textarea {
     width: 100%;
     padding: 10px 12px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--gray-input-border);
     border-radius: 6px;
     font-size: 14px;
     box-sizing: border-box;
@@ -329,14 +329,14 @@ code {
 .form-group input:focus,
 .form-group textarea:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    border-color: var(--blue-500);
+    box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .form-group small {
     display: block;
     margin-top: 4px;
-    color: #6b7280;
+    color: var(--gray-text);
     font-size: 13px;
 }
 

--- a/admin/reports/style.css
+++ b/admin/reports/style.css
@@ -40,7 +40,7 @@
   background: var(--white);
   padding: 15px 20px;
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -68,7 +68,7 @@
   background: var(--white);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
   width: 80%;
   margin: auto;
 }
@@ -325,7 +325,7 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--overlay-darker);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -334,7 +334,7 @@
 .modal-content {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--shadow-default);
   width: 90%;
   max-width: 600px;
 }
@@ -438,7 +438,7 @@
 
 .offense-dot.green {
   background-color: var(--emerald-500);
-  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.15);
+  box-shadow: 0 0 0 2px var(--green-alpha-15);
 }
 
 .offense-indicator:has(.offense-dot.green) {
@@ -449,7 +449,7 @@
 
 .offense-dot.yellow {
   background-color: var(--amber-500);
-  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.15);
+  box-shadow: 0 0 0 2px var(--amber-alpha-15);
 }
 
 .offense-indicator:has(.offense-dot.yellow) {
@@ -460,7 +460,7 @@
 
 .offense-dot.red {
   background-color: var(--red-500);
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.15);
+  box-shadow: 0 0 0 2px var(--red-alpha-15);
 }
 
 .offense-indicator:has(.offense-dot.red) {

--- a/admin/search.css
+++ b/admin/search.css
@@ -16,14 +16,14 @@
     border: 1px solid var(--gray-300);
     border-radius: 4px;
     font-size: 14px;
-    background: white;
+    background: var(--white);
     transition: all 0.2s;
 }
 
 .filter-group input[type="text"]:focus {
     outline: none;
     border-color: var(--primary-blue);
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .filter-group input[type="text"]:hover {
@@ -89,12 +89,12 @@
 }
 
 .btn-delete {
-    background-color: #ef4444;
-    color: white;
+    background-color: var(--red-500);
+    color: var(--white);
 }
 
 .btn-delete:not(:disabled):hover {
-    background-color: #dc2626;
+    background-color: var(--red-600);
 }
 
 /* Checkbox column */

--- a/admin/style.css
+++ b/admin/style.css
@@ -17,7 +17,7 @@
   background: var(--white);
   border-radius: 12px;
   padding: 1.25rem 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 3px var(--shadow);
   border: 1px solid var(--gray-200);
 }
 
@@ -62,7 +62,7 @@
   background: var(--white);
   border-radius: 16px;
   padding: 1.5rem;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07);
+  box-shadow: 0 4px 6px var(--shadow-xxs);
   border: 1px solid var(--gray-200);
   min-width: 0;
   overflow: hidden;
@@ -82,31 +82,31 @@
 
 /* Dark Theme */
 [data-theme="dark"] .summary-card {
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  background: var(--gray-800);
+  border-color: var(--gray-700);
+  box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .summary-card-label {
-  color: #94a3b8;
+  color: var(--gray-400);
 }
 
 [data-theme="dark"] .summary-card-value {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .hero-section h1 {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 [data-theme="dark"] .chart-card {
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  background: var(--gray-800);
+  border-color: var(--gray-700);
+  box-shadow: 0 4px 6px var(--overlay-light);
 }
 
 [data-theme="dark"] .chart-card-title {
-  color: #f1f5f9;
+  color: var(--gray-100);
 }
 
 /* Responsive */

--- a/admin/users/style.css
+++ b/admin/users/style.css
@@ -3,7 +3,7 @@
   background: var(--white);
   border-radius: 8px;
   padding: 1.25rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
   border: 1px solid var(--gray-border);
   text-align: center;
 }
@@ -28,7 +28,7 @@
 .card {
   background: var(--white);
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
   border: 1px solid var(--gray-border);
   overflow: hidden;
 }
@@ -75,7 +75,7 @@
 .search-input:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .search-button {
@@ -155,7 +155,7 @@
 .filter-group input[type="date"]:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .custom-date-range {

--- a/community/create-post.css
+++ b/community/create-post.css
@@ -94,7 +94,7 @@ header .header-inner .menu-container .menu .community:after {
   margin: 20px auto 50px auto;
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 10px var(--shadow-sm);
   padding: 30px;
 }
 
@@ -231,7 +231,7 @@ header .header-inner .menu-container .menu .community:after {
 .preview-toggle button.active {
   background: var(--white);
   color: var(--blueText);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 2px var(--shadow-default);
 }
 
 .preview-toggle button:not(.active) {

--- a/community/formatting/allowed-domains.css
+++ b/community/formatting/allowed-domains.css
@@ -14,7 +14,7 @@
 }
 
 .domains-category {
-  background: var(--whiteBackground, var(--whiteBackground));
+  background: var(--whiteBackground);
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 30px;

--- a/community/formatting/allowed-domains.css
+++ b/community/formatting/allowed-domains.css
@@ -14,11 +14,11 @@
 }
 
 .domains-category {
-  background: var(--whiteBackground, #f9fafb);
+  background: var(--whiteBackground, var(--whiteBackground));
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 30px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-default);
 }
 
 .domains-category h3 {
@@ -36,15 +36,15 @@
 }
 
 .domains-list li {
-  background: #ffffff;
+  background: var(--white);
   padding: 8px 12px;
   border-radius: 4px;
   font-size: 14px;
 }
 
 .pattern-note {
-  background: #e3f2fd;
-  border: 1px solid #90caf9;
+  background: var(--blue-e3f2fd);
+  border: 1px solid var(--blue-90caf9);
   border-radius: 4px;
   padding: 10px;
   margin: 10px 0;
@@ -56,7 +56,7 @@
   padding: 10px;
   margin: 20px auto;
   display: block;
-  border: 2px solid #e5e7eb;
+  border: 2px solid var(--gray-border);
   border-radius: 4px;
   font-size: 16px;
 }

--- a/community/formatting/formatted-text.css
+++ b/community/formatting/formatted-text.css
@@ -3,17 +3,17 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 5px;
-  background-color: #f8f9fa;
-  border: 1px solid #e5e7eb;
+  background-color: var(--neutral-f8f9fa);
+  border: 1px solid var(--gray-border);
   border-radius: 4px 4px 0 0;
   padding: 5px;
 }
 
 .formatting-toolbar .format-btn {
-  background-color: #fff;
-  border: 1px solid #d1d5db;
+  background-color: var(--white);
+  border: 1px solid var(--gray-input-border);
   border-radius: 3px;
-  color: #4b5563;
+  color: var(--gray-text-light);
   padding: 5px 8px;
   font-size: 13px;
   cursor: pointer;
@@ -27,12 +27,12 @@
 }
 
 .formatting-toolbar .format-btn:hover {
-  background-color: #f3f4f6;
-  border-color: #9ca3af;
+  background-color: var(--gray-bg-light);
+  border-color: var(--gray-placeholder);
 }
 
 .formatting-toolbar .format-btn:active {
-  background-color: #e5e7eb;
+  background-color: var(--gray-border);
 }
 
 .formatting-toolbar + textarea {
@@ -55,9 +55,9 @@
 
 .formatting-toolbar .help-btn {
   margin-left: auto;
-  background-color: #3b82f6;
+  background-color: var(--blue-500);
   border: none;
-  color: white;
+  color: var(--white);
   border-radius: 50%;
   width: 24px;
   height: 24px;
@@ -78,14 +78,14 @@
 .formatting-toolbar .help-btn svg {
   width: 22px;
   height: 22px;
-  stroke: white;
+  stroke: var(--white);
 }
 
 .formatted-text blockquote {
   margin: 0.5em 0;
   padding: 0.5em 1.5em;
-  background: #f8fafc;
-  border-left: 4px solid #3b82f6;
+  background: var(--gray-50);
+  border-left: 4px solid var(--blue-500);
   border-radius: 4px;
   font-style: normal;
 }
@@ -106,7 +106,7 @@
 }
 
 .formatted-text a:hover {
-  color: #1d4ed8;
+  color: var(--blue-700);
   text-decoration: underline;
 }
 
@@ -118,5 +118,5 @@
 
 /* Link button styles */
 .format-btn.link-btn svg {
-  stroke: #3b82f6;
+  stroke: var(--blue-500);
 }

--- a/community/formatting/help.css
+++ b/community/formatting/help.css
@@ -23,9 +23,9 @@
 }
 
 .formatting-section {
-  background-color: #fff;
+  background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 30px;
   margin-bottom: 30px;
 }
@@ -35,7 +35,7 @@
   font-size: 20px;
   margin-bottom: 20px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-border);
 }
 
 .formatting-section p {
@@ -54,8 +54,8 @@
 }
 
 .example {
-  background-color: #f9fafb;
-  border: 1px solid #e5e7eb;
+  background-color: var(--whiteBackground);
+  border: 1px solid var(--gray-border);
   border-radius: 6px;
   padding: 20px;
 }
@@ -71,8 +71,8 @@
 }
 
 .example-input {
-  background-color: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background-color: var(--gray-bg-light);
+  border: 1px solid var(--gray-input-border);
   border-radius: 4px;
   padding: 10px;
   font-family: monospace;
@@ -80,8 +80,8 @@
 }
 
 .example-output {
-  background-color: white;
-  border: 1px solid #e5e7eb;
+  background-color: var(--white);
+  border: 1px solid var(--gray-border);
   border-radius: 4px;
   padding: 15px;
   margin-bottom: 10px;
@@ -92,10 +92,10 @@
 }
 
 kbd {
-  background-color: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background-color: var(--gray-bg-light);
+  border: 1px solid var(--gray-input-border);
   border-radius: 3px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 1px 1px var(--shadow-xl);
   display: inline-block;
   font-size: 11px;
   font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
@@ -116,13 +116,13 @@ kbd {
     Arial, sans-serif;
   line-height: 1.5;
   margin-bottom: 15px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--gray-input-border);
   border-radius: 4px;
 }
 
 .preview-container {
-  background-color: white;
-  border: 1px solid #e5e7eb;
+  background-color: var(--white);
+  border: 1px solid var(--gray-border);
   border-radius: 4px;
   padding: 15px;
   margin-top: 15px;
@@ -132,7 +132,7 @@ kbd {
   margin-top: 0;
   margin-bottom: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-border);
   font-size: 16px;
 }
 
@@ -170,14 +170,14 @@ kbd {
   align-items: flex-start;
   margin-bottom: 20px;
   padding: 15px;
-  background-color: #f8fafc;
+  background-color: var(--gray-50);
   border-radius: 6px;
   border-left: 3px solid var(--primary-blue);
 }
 
 .step-number {
   background-color: var(--primary-blue);
-  color: white;
+  color: var(--white);
   width: 24px;
   height: 24px;
   border-radius: 50%;
@@ -224,8 +224,8 @@ kbd {
   top: 0;
   width: 16px;
   height: 16px;
-  background-color: #10b981;
-  color: white;
+  background-color: var(--emerald-500);
+  color: var(--white);
   border-radius: 50%;
   display: flex;
   align-items: center;

--- a/community/guidelines.css
+++ b/community/guidelines.css
@@ -38,7 +38,7 @@ header .header-inner .menu-container .menu .community:after {
 .guidelines-section {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 30px;
   margin-bottom: 30px;
 }

--- a/community/index.css
+++ b/community/index.css
@@ -234,7 +234,7 @@ header .header-inner .menu-container .menu .community:after {
 }
 
 .post-card:hover {
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 24px var(--shadow);
   transform: translateY(-2px);
 }
 
@@ -419,15 +419,15 @@ header .header-inner .menu-container .menu .community:after {
 /* Highlighted post */
 @keyframes highlight-pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.7);
+    box-shadow: 0 0 0 0 var(--blue-600-alpha-70);
   }
 
   70% {
-    box-shadow: 0 0 0 10px rgba(37, 99, 235, 0);
+    box-shadow: 0 0 0 10px var(--blue-600-alpha-0);
   }
 
   100% {
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+    box-shadow: 0 0 0 0 var(--blue-600-alpha-0);
   }
 }
 
@@ -470,7 +470,7 @@ header .header-inner .menu-container .menu .community:after {
   display: inline-block;
   width: 30px;
   height: 30px;
-  border: 3px solid rgba(37, 99, 235, 0.3);
+  border: 3px solid var(--blue-600-alpha-30);
   border-radius: 50%;
   border-top-color: var(--primary-blue);
   animation: spin 1s linear infinite;
@@ -503,7 +503,7 @@ header .header-inner .menu-container .menu .community:after {
 .filter-select:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.2);
+  box-shadow: 0 0 0 1px var(--blue-600-alpha-20);
 }
 
 /* Responsive adjustments */

--- a/community/mentions/mentions.css
+++ b/community/mentions/mentions.css
@@ -4,7 +4,7 @@
   background-color: var(--white);
   border: 1px solid var(--gray-input-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--shadow-default);
   max-height: 200px;
   overflow-y: auto;
   z-index: 1000;

--- a/community/post-history.css
+++ b/community/post-history.css
@@ -16,7 +16,7 @@ header .header-inner .menu-container .menu .community:after {
   background: var(--white);
   border-radius: 8px;
   padding: 20px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
 }
 
 .history-header {
@@ -101,9 +101,9 @@ header .header-inner .menu-container .menu .community:after {
   height: 2px;
   background: linear-gradient(
     to right,
-    rgba(59, 130, 246, 0.5),
-    rgba(59, 130, 246, 0.8),
-    rgba(59, 130, 246, 0.5)
+    var(--blue-alpha-50),
+    var(--blue-alpha-80),
+    var(--blue-alpha-50)
   );
   margin: 30px 0;
 }

--- a/community/report/report.css
+++ b/community/report/report.css
@@ -60,7 +60,7 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--overlay-darker);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -79,7 +79,7 @@
 .report-modal-content {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 10px 20px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 6px var(--shadow-default), 0 10px 20px var(--shadow-lg);
   width: 90%;
   max-width: 500px;
   animation: slideIn 0.3s ease;
@@ -164,7 +164,7 @@
 .report-modal-content .form-group textarea:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .report-modal-content .form-group textarea {

--- a/community/users/admin_notification_settings-style.css
+++ b/community/users/admin_notification_settings-style.css
@@ -10,7 +10,7 @@
   position: relative;
   background: var(--white);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow-default);
   padding: 30px;
 }
 
@@ -96,7 +96,7 @@
 .email-field input:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 3px var(--blue-alpha-20);
 }
 
 .email-field .hint {

--- a/community/users/auth.css
+++ b/community/users/auth.css
@@ -12,7 +12,7 @@
 .auth-card {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 30px;
   width: 100%;
   max-width: 450px;
@@ -65,7 +65,7 @@
 
 .form-group input:focus {
   border-color: var(--secondary-blue);
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.2);
+  box-shadow: 0 0 0 3px var(--blue-400-alpha-20);
   outline: none;
 }
 

--- a/community/users/edit-profile.css
+++ b/community/users/edit-profile.css
@@ -16,7 +16,7 @@
   border: 1px solid var(--gray-border);
   border-radius: 12px;
   padding: 30px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--shadow-default);
 }
 
 .edit-section h2 {
@@ -121,7 +121,7 @@
 .form-group textarea:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  box-shadow: 0 0 0 3px var(--blue-600-alpha-10);
 }
 
 .form-group textarea {
@@ -195,7 +195,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-dark);
   display: none;
   align-items: center;
   justify-content: center;
@@ -229,7 +229,7 @@
   color: var(--white);
   padding: 20px;
   border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 10px 25px var(--green-alpha-30);
   animation: successSlideIn 0.5s ease-out;
   position: relative;
   overflow: hidden;
@@ -242,7 +242,7 @@
   left: -100%;
   width: 100%;
   height: 2px;
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--white-alpha-80);
   animation: progressBar 5s linear;
 }
 
@@ -264,7 +264,7 @@
 
 .countdown {
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--white-alpha-90);
   font-weight: 400;
 }
 

--- a/community/users/profile.css
+++ b/community/users/profile.css
@@ -51,7 +51,7 @@
 .profile-card {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 30px;
   display: flex;
   flex-direction: column;
@@ -99,7 +99,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--overlay-dark);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -233,7 +233,7 @@
 .impact-section {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 20px;
   margin-bottom: 20px;
 }
@@ -413,7 +413,7 @@
 .user-post-item:hover,
 .user-comment-item:hover {
   border-color: var(--gray-input-border);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 8px var(--shadow-sm);
 }
 
 .post-score,

--- a/community/users/reputation-help.css
+++ b/community/users/reputation-help.css
@@ -29,7 +29,7 @@
 .reputation-section {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   padding: 30px 30px 10px 30px;
   margin-bottom: 30px;
 }

--- a/community/users/subscription-confirm.css
+++ b/community/users/subscription-confirm.css
@@ -12,7 +12,7 @@
     border-radius: 16px;
     padding: 40px;
     border: 1px solid var(--gray-border);
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px -1px var(--shadow-default);
     text-align: center;
 }
 

--- a/community/users/subscription.css
+++ b/community/users/subscription.css
@@ -39,7 +39,7 @@
     padding: 24px;
     margin-bottom: 24px;
     border: 1px solid var(--gray-border);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px var(--shadow-default);
 }
 
 .subscription-section h2 {
@@ -526,7 +526,7 @@
 .modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay-dark);
     backdrop-filter: blur(4px);
     display: flex;
     align-items: center;
@@ -552,7 +552,7 @@
     position: relative;
     transform: scale(0.95) translateY(10px);
     transition: transform 0.3s;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 20px 40px var(--shadow-xl);
 }
 
 .modal-overlay.active .modal-container {

--- a/community/view-post.css
+++ b/community/view-post.css
@@ -522,7 +522,7 @@ header .header-inner .menu-container .menu .community:after {
 .inline-edit-form textarea:focus {
   outline: none;
   border-color: var(--secondary-blue);
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+  box-shadow: 0 0 0 2px var(--blue-600-alpha-10);
 }
 
 .inline-edit-form .form-actions {

--- a/compare/style.css
+++ b/compare/style.css
@@ -197,28 +197,28 @@ body {
 
 .btn-cta-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 8px 20px var(--blue-alpha-30);
 }
 
 .btn-cta-outline {
   background: transparent;
   color: var(--white);
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid var(--white-alpha-30);
 }
 
 .btn-cta-outline:hover {
-  border-color: rgba(255, 255, 255, 0.6);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--white-alpha-60);
+  background: var(--white-alpha-05);
 }
 
 .btn-cta-ghost {
   background: transparent;
   color: var(--hero-text-muted);
-  border: 2px solid rgba(255, 255, 255, 0.2);
+  border: 2px solid var(--white-alpha-20);
 }
 
 .btn-cta-ghost:hover {
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--white-alpha-40);
   color: var(--white);
 }
 
@@ -246,7 +246,7 @@ body {
 
 .diff-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 12px 32px var(--shadow);
 }
 
 .diff-icon {
@@ -315,7 +315,7 @@ body {
   background: var(--white);
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
 }
 
 .comparison-table thead {
@@ -420,19 +420,19 @@ body {
 
 .pricing-box:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 32px var(--shadow-default);
 }
 
 .argo-box {
   background: var(--white);
   border: 2px solid var(--primary-blue);
-  box-shadow: 0 4px 20px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 4px 20px var(--blue-alpha-10);
 }
 
 .competitor-box {
   background: var(--white);
   border: 1px solid var(--gray-200);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
 }
 
 .pricing-box-header {

--- a/contact-us/message-sent-successfully/style.css
+++ b/contact-us/message-sent-successfully/style.css
@@ -7,7 +7,7 @@ header .header-inner .menu-container .menu .contact-us:after {
 .first {
   min-height: calc(100vh - 80px);
   padding: 100px 0 40px;
-  background: linear-gradient(to bottom, var(--whiteBackground), #ffffff);
+  background: linear-gradient(to bottom, var(--whiteBackground), var(--white));
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -18,9 +18,9 @@ header .header-inner .menu-container .menu .contact-us:after {
   max-width: 800px;
   width: 85%;
   margin: 20px auto 0;
-  background: #ffffff;
+  background: var(--white);
   border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 10px 30px var(--shadow);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -41,7 +41,7 @@ header .header-inner .menu-container .menu .contact-us:after {
   align-items: center;
   justify-content: center;
   margin-bottom: 25px;
-  color: white;
+  color: var(--white);
   transform: scale(0);
   animation: popIn 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
   animation-delay: 0.2s;
@@ -61,7 +61,7 @@ header .header-inner .menu-container .menu .contact-us:after {
 h1 {
   font-size: 2.2rem;
   font-weight: 600;
-  color: #1a202c;
+  color: var(--slate-1a202c);
   margin-bottom: 16px;
   transform: translateY(20px);
   opacity: 0;
@@ -71,7 +71,7 @@ h1 {
 
 .success-message {
   font-size: 1.2rem;
-  color: #4a5568;
+  color: var(--neutral-4a5568);
   line-height: 1.6;
   margin-bottom: 30px;
   transform: translateY(20px);
@@ -82,7 +82,7 @@ h1 {
 
 /* Information box */
 .info-box {
-  background: #f7fafc;
+  background: var(--neutral-f7fafc);
   border-radius: 10px;
   padding: 25px;
   margin-bottom: 35px;
@@ -96,7 +96,7 @@ h1 {
 .info-box h3 {
   font-size: 1.2rem;
   font-weight: 500;
-  color: #2d3748;
+  color: var(--slate-2d3748);
   margin-bottom: 15px;
 }
 
@@ -105,7 +105,7 @@ h1 {
 }
 
 .info-box li {
-  color: #4a5568;
+  color: var(--neutral-4a5568);
   margin-bottom: 10px;
   padding-left: 5px;
 }
@@ -137,22 +137,22 @@ h1 {
 
 .primary-btn {
   background: var(--primary-blue);
-  color: white;
+  color: var(--white);
 }
 
 .primary-btn:hover {
   background: var(--blueHover);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
 }
 
 .secondary-btn {
-  background: #edf2f7;
-  color: #4a5568;
+  background: var(--neutral-edf2f7);
+  color: var(--neutral-4a5568);
 }
 
 .secondary-btn:hover {
-  background: #e2e8f0;
+  background: var(--gray-200);
   transform: translateY(-2px);
 }
 

--- a/contact-us/style.css
+++ b/contact-us/style.css
@@ -112,13 +112,13 @@ header .header-inner .menu-container .menu .contact-us:after {
   border-radius: 16px;
   padding: 32px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .option-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 32px var(--shadow-default);
 }
 
 .option-icon {
@@ -273,7 +273,7 @@ header .header-inner .menu-container .menu .contact-us:after {
 .form-group textarea:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .form-group input::placeholder,
@@ -314,7 +314,7 @@ header .header-inner .menu-container .menu .contact-us:after {
 
 .submit-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 8px 20px var(--blue-alpha-30);
 }
 
 .submit-btn:active {

--- a/documentation/pages/reference/style.css
+++ b/documentation/pages/reference/style.css
@@ -23,11 +23,11 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .reference-category {
-  background: var(--whiteBackground, #f9fafb);
+  background: var(--whiteBackground, var(--whiteBackground));
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 30px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-default);
 }
 
 /* Grid layout for most common items - 3 column responsive grid */
@@ -40,23 +40,23 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .language-item,
 .currency-item {
-  background: #ffffff;
+  background: var(--white);
   border-radius: 6px;
   padding: 15px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .language-item:hover,
 .currency-item:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
 }
 
 .language-item h4,
 .currency-item h4 {
   margin-bottom: 10px;
-  color: #374151;
+  color: var(--gray-text-dark);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -64,17 +64,17 @@ header .header-inner .menu-container .menu .documentation:after {
 .reference-category h3 {
   margin-bottom: 20px;
   padding-bottom: 5px;
-  color: var(--primary-blue, #2563eb);
-  border-bottom: 2px solid var(--primary-blue, #2563eb);
+  color: var(--primary-blue, var(--blue-600));
+  border-bottom: 2px solid var(--primary-blue, var(--blue-600));
 }
 
 /* Main groups for featured/common items */
 .item-group {
   margin-bottom: 25px;
-  background: #ffffff;
+  background: var(--white);
   border-radius: 6px;
   padding: 15px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
 }
 
 .item-group:last-child {
@@ -83,7 +83,7 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .item-group h4 {
   margin-bottom: 10px;
-  color: #374151;
+  color: var(--gray-text-dark);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -91,16 +91,16 @@ header .header-inner .menu-container .menu .documentation:after {
 /* Small groups for alphabetical sections */
 .item-group-small {
   margin-bottom: 15px;
-  background: #ffffff;
+  background: var(--white);
   border-radius: 6px;
   padding: 12px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
   width: 100%;
 }
 
 .item-group-small h5 {
   margin-bottom: 8px;
-  color: #374151;
+  color: var(--gray-text-dark);
   font-size: 1rem;
   font-weight: 600;
 }
@@ -115,24 +115,24 @@ header .header-inner .menu-container .menu .documentation:after {
 
 /* Currency-specific styles */
 .currency-symbol {
-  background: #f1f5f9;
+  background: var(--gray-100);
   padding: 4px 8px;
   border-radius: 4px;
   font-weight: 600;
-  color: var(--primary-blue, #2563eb);
+  color: var(--primary-blue, var(--blue-600));
   min-width: 40px;
   text-align: center;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--gray-200);
 }
 
 .currency-region,
 .language-region {
-  color: #6b7280;
+  color: var(--gray-text);
   font-style: italic;
   padding: 4px 8px;
-  background: #f1f5f9;
+  background: var(--gray-100);
   border-radius: 4px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--gray-200);
 }
 
 /* Countries list - grid layout for variants */
@@ -146,17 +146,17 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .items-list li {
-  background: #f8fafc;
+  background: var(--gray-50);
   padding: 6px 10px;
   border-radius: 4px;
   font-size: 14px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--gray-200);
   transition: background-color 0.2s;
 }
 
 .primary-name {
   font-weight: 600;
-  color: var(--primary-blue, #2563eb);
+  color: var(--primary-blue, var(--blue-600));
 }
 
 /* Alphabetical grid layout */
@@ -168,20 +168,20 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .alphabet-section {
-  background: #ffffff;
+  background: var(--white);
   border-radius: 6px;
   padding: 15px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
   min-height: 180px;
 }
 
 .alphabet-section h4 {
   margin-bottom: 12px;
-  color: #374151;
+  color: var(--gray-text-dark);
   font-size: 1rem;
   font-weight: 600;
   padding-bottom: 5px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--gray-border);
 }
 
 /* Countries page specific - single column layout for alphabetical items */
@@ -191,7 +191,7 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .alphabet-section .items-list li {
-  background: #f8fafc;
+  background: var(--gray-50);
   padding: 4px 8px;
   font-size: 13px;
 }
@@ -203,7 +203,7 @@ header .header-inner .menu-container .menu .documentation:after {
   padding: 12px;
   margin: 20px auto;
   display: block;
-  border: 2px solid #e5e7eb;
+  border: 2px solid var(--gray-border);
   border-radius: 6px;
   font-size: 16px;
   transition: border-color 0.2s;
@@ -211,28 +211,28 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .search-box:focus {
   outline: none;
-  border-color: var(--primary-blue, #2563eb);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  border-color: var(--primary-blue, var(--blue-600));
+  box-shadow: 0 0 0 3px var(--blue-600-alpha-10);
 }
 
 /* No results message */
 .no-results {
-  background: var(--whiteBackground, #f9fafb);
+  background: var(--whiteBackground, var(--whiteBackground));
   border-radius: 8px;
   padding: 40px 20px;
   margin: 20px 0 40px;
   text-align: center;
-  border: 2px dashed #d1d5db;
+  border: 2px dashed var(--gray-input-border);
 }
 
 .no-results-content h3 {
-  color: #6b7280;
+  color: var(--gray-text);
   margin-bottom: 15px;
   font-size: 1.25rem;
 }
 
 .no-results-content p {
-  color: #6b7280;
+  color: var(--gray-text);
   margin-bottom: 15px;
   font-size: 1rem;
 }
@@ -246,19 +246,19 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .no-results-content ul li {
-  background: #ffffff;
+  background: var(--white);
   padding: 8px 16px;
   margin: 8px 0;
   border-radius: 4px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--gray-border);
   font-size: 14px;
-  color: #374151;
+  color: var(--gray-text-dark);
 }
 
 /* Info boxes and notes */
 .pattern-note {
-  background: #e3f2fd;
-  border: 1px solid #90caf9;
+  background: var(--blue-e3f2fd);
+  border: 1px solid var(--blue-90caf9);
   border-radius: 8px;
   padding: 20px;
   margin: 20px 0;
@@ -266,7 +266,7 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .pattern-note h3 {
   margin-bottom: 15px;
-  color: var(--primary-blue, #2563eb);
+  color: var(--primary-blue, var(--blue-600));
 }
 
 .steps-list {
@@ -288,8 +288,8 @@ header .header-inner .menu-container .menu .documentation:after {
   position: absolute;
   left: 0;
   top: 0;
-  background: var(--primary-blue, #2563eb);
-  color: white;
+  background: var(--primary-blue, var(--blue-600));
+  color: var(--white);
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
@@ -300,16 +300,16 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .info-box {
-  background: #dbeafe;
-  border-left: 4px solid var(--primary-blue, #2563eb);
+  background: var(--blue-100);
+  border-left: 4px solid var(--primary-blue, var(--blue-600));
   padding: 15px;
   margin: 15px 0;
   border-radius: 4px;
 }
 
 .warning-box {
-  background: var(--yellow-50, #fefce8);
-  border: 1px solid #fbbf24;
+  background: var(--yellow-50, var(--yellow-50-alt));
+  border: 1px solid var(--amber-400);
   border-radius: 6px;
   padding: 15px;
   margin: 15px 0;

--- a/documentation/pages/reference/style.css
+++ b/documentation/pages/reference/style.css
@@ -23,7 +23,7 @@ header .header-inner .menu-container .menu .documentation:after {
 }
 
 .reference-category {
-  background: var(--whiteBackground, var(--whiteBackground));
+  background: var(--whiteBackground);
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 30px;
@@ -64,8 +64,8 @@ header .header-inner .menu-container .menu .documentation:after {
 .reference-category h3 {
   margin-bottom: 20px;
   padding-bottom: 5px;
-  color: var(--primary-blue, var(--blue-600));
-  border-bottom: 2px solid var(--primary-blue, var(--blue-600));
+  color: var(--primary-blue);
+  border-bottom: 2px solid var(--primary-blue);
 }
 
 /* Main groups for featured/common items */
@@ -119,7 +119,7 @@ header .header-inner .menu-container .menu .documentation:after {
   padding: 4px 8px;
   border-radius: 4px;
   font-weight: 600;
-  color: var(--primary-blue, var(--blue-600));
+  color: var(--primary-blue);
   min-width: 40px;
   text-align: center;
   border: 1px solid var(--gray-200);
@@ -156,7 +156,7 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .primary-name {
   font-weight: 600;
-  color: var(--primary-blue, var(--blue-600));
+  color: var(--primary-blue);
 }
 
 /* Alphabetical grid layout */
@@ -211,13 +211,13 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .search-box:focus {
   outline: none;
-  border-color: var(--primary-blue, var(--blue-600));
+  border-color: var(--primary-blue);
   box-shadow: 0 0 0 3px var(--blue-600-alpha-10);
 }
 
 /* No results message */
 .no-results {
-  background: var(--whiteBackground, var(--whiteBackground));
+  background: var(--whiteBackground);
   border-radius: 8px;
   padding: 40px 20px;
   margin: 20px 0 40px;
@@ -266,7 +266,7 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .pattern-note h3 {
   margin-bottom: 15px;
-  color: var(--primary-blue, var(--blue-600));
+  color: var(--primary-blue);
 }
 
 .steps-list {
@@ -288,7 +288,7 @@ header .header-inner .menu-container .menu .documentation:after {
   position: absolute;
   left: 0;
   top: 0;
-  background: var(--primary-blue, var(--blue-600));
+  background: var(--primary-blue);
   color: var(--white);
   width: 1.5rem;
   height: 1.5rem;
@@ -301,14 +301,14 @@ header .header-inner .menu-container .menu .documentation:after {
 
 .info-box {
   background: var(--blue-100);
-  border-left: 4px solid var(--primary-blue, var(--blue-600));
+  border-left: 4px solid var(--primary-blue);
   padding: 15px;
   margin: 15px 0;
   border-radius: 4px;
 }
 
 .warning-box {
-  background: var(--yellow-50, var(--yellow-50-alt));
+  background: var(--yellow-50);
   border: 1px solid var(--amber-400);
   border-radius: 6px;
   padding: 15px;

--- a/documentation/search.css
+++ b/documentation/search.css
@@ -11,7 +11,7 @@
   background: var(--white);
   border: 1px solid var(--gray-200);
   border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 20px 40px var(--shadow-lg);
   max-height: 400px;
   overflow-y: auto;
   z-index: 1000;

--- a/documentation/style.css
+++ b/documentation/style.css
@@ -24,7 +24,7 @@ body.docs-landing {
    ========================================== */
 .hero {
   position: relative;
-  background: linear-gradient(135deg, var(--gray-900) 0%, var(--gray-800) 50%, #1a365d 100%);
+  background: linear-gradient(135deg, var(--gray-900) 0%, var(--gray-800) 50%, var(--navy-1a365d) 100%);
   padding: 100px 24px 80px;
 }
 
@@ -40,9 +40,9 @@ body.docs-landing {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.9);
+  background: var(--white-alpha-10);
+  border: 1px solid var(--white-alpha-20);
+  color: var(--white-alpha-90);
   padding: 8px 16px;
   border-radius: 100px;
   font-size: 0.875rem;
@@ -65,7 +65,7 @@ body.docs-landing {
 
 .hero-subtitle {
   font-size: 1.25rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--white-alpha-70);
   margin: 0 0 40px;
   line-height: 1.5;
 }
@@ -95,12 +95,12 @@ body.docs-landing {
   width: 100%;
   padding: 18px 100px 18px 56px;
   font-size: 1rem;
-  border: 2px solid rgba(255, 255, 255, 0.1);
+  border: 2px solid var(--white-alpha-10);
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--white-alpha-95);
   color: var(--gray-900);
   transition: all 0.2s ease;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 24px var(--shadow-xl);
 }
 
 .hero-search input::placeholder {
@@ -110,7 +110,7 @@ body.docs-landing {
 .hero-search input:focus {
   outline: none;
   border-color: var(--primary-blue);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2), 0 0 0 4px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 4px 24px var(--shadow-xl), 0 0 0 4px var(--blue-alpha-20);
 }
 
 .hero-search .search-shortcut {
@@ -136,7 +136,7 @@ body.docs-landing {
 .floating-shape {
   position: absolute;
   border-radius: 50%;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(147, 51, 234, 0.2));
+  background: linear-gradient(135deg, var(--blue-alpha-30), var(--violet-alpha-20));
   filter: blur(60px);
 }
 
@@ -152,7 +152,7 @@ body.docs-landing {
   height: 300px;
   bottom: -50px;
   right: -50px;
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(59, 130, 246, 0.2));
+  background: linear-gradient(135deg, var(--green-alpha-20), var(--blue-alpha-20));
 }
 
 .shape-3 {
@@ -160,7 +160,7 @@ body.docs-landing {
   height: 200px;
   top: 50%;
   left: 60%;
-  background: linear-gradient(135deg, rgba(236, 72, 153, 0.15), rgba(147, 51, 234, 0.15));
+  background: linear-gradient(135deg, var(--pink-alpha-15), var(--violet-alpha-15));
 }
 
 /* ==========================================
@@ -188,14 +188,14 @@ body.docs-landing {
   font-size: 0.9375rem;
   font-weight: 500;
   border-radius: 12px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 16px var(--shadow), 0 1px 3px var(--shadow-sm);
   transition: all 0.2s ease;
   border: 1px solid var(--gray-100);
 }
 
 .quick-link:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 24px var(--shadow-md2);
   color: var(--primary-blue);
   border-color: var(--blue-200);
 }
@@ -301,7 +301,7 @@ body.docs-landing {
 
 .doc-card:hover {
   border-color: var(--gray-300);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 24px var(--shadow-md);
   transform: translateY(-4px);
 }
 
@@ -401,7 +401,7 @@ body.docs-landing {
 .help-button:hover {
   background: var(--blueHover);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 4px 12px var(--blue-alpha-30);
 }
 
 /* ==========================================
@@ -511,7 +511,7 @@ body.docs-page {
 /* Force header to be fixed with light gray background on doc pages */
 body.docs-page header {
   position: fixed !important;
-  background: #f7f7f8 !important;
+  background: var(--neutral-f7f7f8) !important;
   border-bottom: 1px solid var(--gray-200);
   box-shadow: none !important;
 }
@@ -536,7 +536,7 @@ body.docs-page header .menu-icon .nav-icon:after {
 }
 
 body.docs-page .account-avatar {
-  border-color: rgba(0, 0, 0, 0.15);
+  border-color: var(--shadow-lg);
 }
 
 /* ==========================================
@@ -562,7 +562,7 @@ body.docs-page .account-avatar {
   overflow-y: auto;
   border-right: 1px solid var(--gray-200);
   padding: 16px 0;
-  background: #f7f7f8;
+  background: var(--neutral-f7f7f8);
   z-index: 50;
 }
 
@@ -627,7 +627,7 @@ body.docs-page .account-avatar {
 }
 
 .nav-section-toggle:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--shadow-xs);
   color: var(--gray-900);
 }
 
@@ -675,13 +675,13 @@ body.docs-page .account-avatar {
 
 .nav-links a:hover {
   color: var(--gray-900);
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--shadow-xs);
 }
 
 .nav-links a.active {
   color: var(--primary-blue);
   font-weight: 500;
-  background: rgba(59, 130, 246, 0.08);
+  background: var(--blue-alpha-08);
   border-radius: 6px;
   position: relative;
 }
@@ -1110,7 +1110,7 @@ body.docs-page .account-avatar {
 
 .version-card:hover {
   border-color: var(--gray-300);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 16px var(--shadow-md);
 }
 
 .card-header {
@@ -1164,7 +1164,7 @@ body.docs-page .account-avatar {
 
 .version-card.premium {
   border: 2px solid var(--purple-500);
-  background: linear-gradient(135deg, rgba(147, 51, 234, 0.02) 0%, rgba(147, 51, 234, 0.05) 100%);
+  background: linear-gradient(135deg, var(--violet-alpha-02) 0%, var(--violet-alpha-05) 100%);
 }
 
 .version-price {
@@ -1317,19 +1317,19 @@ body.docs-page .account-avatar {
   align-items: center;
   justify-content: center;
   gap: 5px;
-  box-shadow: 0 4px 20px rgba(59, 130, 246, 0.4);
+  box-shadow: 0 4px 20px var(--blue-alpha-40);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .sidebar-toggle:hover {
   transform: scale(1.05);
-  box-shadow: 0 6px 24px rgba(59, 130, 246, 0.5);
+  box-shadow: 0 6px 24px var(--blue-alpha-50);
 }
 
 .hamburger-line {
   width: 24px;
   height: 3px;
-  background: white;
+  background: var(--white);
   border-radius: 2px;
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
@@ -1377,7 +1377,7 @@ body.docs-page .account-avatar {
     z-index: 1000;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
-    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 4px 0 20px var(--shadow-default);
     border-right: none;
   }
 
@@ -1404,7 +1404,7 @@ body.docs-page .account-avatar {
     left: 300px;
     width: calc(100vw - 300px);
     height: 100vh;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay-dark);
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s ease, visibility 0.3s ease;
@@ -1484,7 +1484,7 @@ body.docs-page .account-avatar {
 .search-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-dark);
   z-index: 2000;
   display: none;
   align-items: flex-start;
@@ -1523,7 +1523,7 @@ body.docs-page .account-avatar {
   border-radius: 12px 12px 0 0;
   background: var(--white);
   color: var(--gray-900);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px var(--overlay-light);
 }
 
 .search-overlay input:focus {
@@ -1545,7 +1545,7 @@ body.docs-page .account-avatar {
 .search-overlay .search-results {
   border-radius: 0 0 12px 12px;
   border-top: 1px solid var(--gray-200);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px var(--overlay-light);
 }
 
 /* Footer override for sub-pages */

--- a/downloads/style.css
+++ b/downloads/style.css
@@ -6,7 +6,7 @@
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     line-height: 1.6;
-    color: #1a1a2e;
+    color: var(--dark-1a1a2e);
     margin: 0;
     padding: 0;
     background-color: var(--light-page-bg);
@@ -22,7 +22,7 @@ body {
 .hero {
     position: relative;
     background: linear-gradient(135deg, var(--hero-gradient-start), var(--hero-gradient-end));
-    color: white;
+    color: var(--white);
     padding: 100px 20px 80px;
     text-align: center;
     overflow: hidden;
@@ -44,7 +44,7 @@ body {
 .hero-orb-1 {
     width: 400px;
     height: 400px;
-    background: linear-gradient(135deg, #3b82f6, #06b6d4);
+    background: linear-gradient(135deg, var(--blue-500), var(--cyan-500));
     top: -100px;
     right: -100px;
 }
@@ -52,7 +52,7 @@ body {
 .hero-orb-2 {
     width: 300px;
     height: 300px;
-    background: linear-gradient(135deg, #8b5cf6, #ec4899);
+    background: linear-gradient(135deg, var(--purple-500), var(--pink-500));
     bottom: -80px;
     left: -80px;
     animation-delay: -4s;
@@ -97,10 +97,10 @@ body {
 }
 
 .platform-card {
-    background: white;
+    background: var(--white);
     border-radius: 20px;
     padding: 40px 32px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px var(--shadow);
     border: 1px solid var(--gray-border);
     display: flex;
     flex-direction: column;
@@ -110,7 +110,7 @@ body {
 }
 
 .platform-card:hover {
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 12px 40px var(--shadow-md2);
     transform: translateY(-4px);
     border-color: var(--gray-input-border);
 }
@@ -129,15 +129,15 @@ body {
 }
 
 .platform-windows:hover .platform-icon {
-    color: #0078d4;
+    color: var(--blue-link-alt);
 }
 
 .platform-macos:hover .platform-icon {
-    color: #000000;
+    color: var(--black);
 }
 
 .platform-linux:hover .platform-icon {
-    color: #FCC624;
+    color: var(--brand-yellow);
 }
 
 .platform-info {
@@ -206,10 +206,10 @@ body {
 
 /* Requirements Section */
 .requirements-section {
-    background: white;
+    background: var(--white);
     border-radius: 20px;
     padding: 48px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px var(--shadow);
     border: 1px solid var(--gray-border);
     margin-bottom: 40px;
 }
@@ -276,10 +276,10 @@ body {
 }
 
 .additional-card {
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     padding: 32px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px var(--shadow);
     border: 1px solid var(--gray-border);
     display: flex;
     gap: 24px;
@@ -287,7 +287,7 @@ body {
 }
 
 .additional-card:hover {
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 8px 30px var(--shadow-md2);
     transform: translateY(-2px);
 }
 

--- a/email.css
+++ b/email.css
@@ -13,7 +13,7 @@ body {
     margin: 0 auto;
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px var(--shadow-default);
     margin-top: 20px;
     margin-bottom: 20px;
 }
@@ -22,7 +22,7 @@ body {
 .header {
     padding: 20px;
     text-align: center;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--gradient-indigo) 0%, var(--gradient-purple) 100%);
 }
 
 .header img {
@@ -57,7 +57,7 @@ p {
 
 /* Links */
 a {
-    color: #2563eb;
+    color: var(--blue-600);
     text-decoration: none;
 }
 
@@ -67,8 +67,8 @@ a:hover {
 
 /* License key display */
 .license-key {
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
+    background-color: var(--gray-50);
+    border: 1px solid var(--gray-200);
     border-radius: 4px;
     font-family: monospace;
     font-size: 18px;
@@ -81,9 +81,9 @@ a:hover {
 
 /* Button styles */
 .button {
-    background-color: #2563eb;
+    background-color: var(--blue-600);
     border-radius: 4px;
-    color: #ffffff;
+    color: var(--white);
     display: inline-block;
     font-weight: bold;
     margin-top: 15px;
@@ -93,7 +93,7 @@ a:hover {
 }
 
 .button:hover {
-    background-color: #1d4ed8;
+    background-color: var(--blue-700);
     text-decoration: none;
 }
 
@@ -109,8 +109,8 @@ a:hover {
 
 /* Footer styles */
 .footer {
-    background-color: #f8fafc;
-    border-top: 1px solid #e2e8f0;
+    background-color: var(--gray-50);
+    border-top: 1px solid var(--gray-200);
     font-size: 12px;
     padding: 20px;
     text-align: center;
@@ -122,7 +122,7 @@ a:hover {
 
 /* Header variations */
 .header-purple {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+    background: linear-gradient(135deg, var(--purple-500), var(--purple-600));
 }
 
 /* header-blue is the default, defined in .header */
@@ -135,7 +135,7 @@ a:hover {
 
 .details-table td {
     padding: 8px 0;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--gray-border);
 }
 
 .details-table td:last-child {
@@ -147,7 +147,7 @@ a:hover {
 }
 
 .details-table .label {
-    color: #6b7280;
+    color: var(--gray-text);
 }
 
 .details-table .value {
@@ -171,32 +171,32 @@ a:hover {
 }
 
 .info-box-gray {
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
 }
 
 .info-box-warning {
-    background: #fef3c7;
-    border: 1px solid #fcd34d;
+    background: var(--amber-100);
+    border: 1px solid var(--amber-300);
 }
 
 .info-box-success {
-    background: #d1fae5;
-    border: 1px solid #6ee7b7;
+    background: var(--emerald-100);
+    border: 1px solid var(--emerald-300);
 }
 
 .info-box-note {
-    background: #f0fdf4;
-    border: 1px solid #86efac;
+    background: var(--green-50);
+    border: 1px solid var(--green-300);
 }
 
 /* Payment/receipt box */
 .payment-box {
-    background: #f8fafc;
+    background: var(--gray-50);
     padding: 20px;
     border-radius: 8px;
     margin: 20px 0;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--gray-border);
 }
 
 .payment-box h3 {
@@ -205,8 +205,8 @@ a:hover {
 
 /* Credit display */
 .credit-display {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
-    color: white;
+    background: linear-gradient(135deg, var(--purple-500), var(--purple-600));
+    color: var(--white);
     padding: 30px;
     border-radius: 12px;
     margin: 25px 0;
@@ -227,11 +227,11 @@ a:hover {
 
 /* Button variations */
 .button-purple {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+    background: linear-gradient(135deg, var(--purple-500), var(--purple-600));
 }
 
 .button-purple:hover {
-    background: linear-gradient(135deg, #7c3aed, #6d28d9);
+    background: linear-gradient(135deg, var(--purple-600), var(--purple-700));
 }
 
 /* Status badges */
@@ -242,8 +242,8 @@ a:hover {
 }
 
 .status-active {
-    background: #d1fae5;
-    color: #065f46;
+    background: var(--emerald-100);
+    color: var(--emerald-800);
 }
 
 /* Lists */
@@ -259,7 +259,7 @@ a:hover {
 }
 
 .styled-list {
-    color: #374151;
+    color: var(--gray-text-dark);
     line-height: 1.8;
 }
 
@@ -268,8 +268,8 @@ a:hover {
     text-align: center;
     margin-top: 30px;
     padding-top: 20px;
-    border-top: 1px solid #e5e7eb;
-    color: #6b7280;
+    border-top: 1px solid var(--gray-border);
+    color: var(--gray-text);
     font-size: 14px;
 }
 
@@ -280,7 +280,7 @@ a:hover {
 
 /* Text colors */
 .text-muted {
-    color: #6b7280;
+    color: var(--gray-text);
 }
 
 /* Mobile responsive */

--- a/error-pages/error.css
+++ b/error-pages/error.css
@@ -13,7 +13,7 @@ body {
 .large-header {
   position: relative;
   width: 100%;
-  background: #111;
+  background: var(--near-black);
   overflow: hidden;
   background-size: cover;
   background-position: center center;
@@ -31,14 +31,14 @@ body {
 }
 
 .text-container .main-title {
-  color: #f9f1e9;
+  color: var(--warm-bg);
   font-size: 12rem;
   font-weight: 500;
   letter-spacing: .1em;
 }
 
 .text-container .sub-title {
-  color: #f9f1e9;
+  color: var(--warm-bg);
   text-align: center;
   font-size: 2.8rem;
   font-weight: 500;
@@ -56,14 +56,14 @@ body {
   transition: .33s all ease;
   cursor: pointer;
   background: transparent;
-  border: 1px solid #fff;
-  color: #fff;
+  border: 1px solid var(--white);
+  color: var(--white);
   margin: 30px auto;
 }
 
 .text-container .btn:hover {
-  background: rgba(0, 0, 0, 0.4);
-  color: #fff;
+  background: var(--overlay-medium);
+  color: var(--white);
 }
 
 @media (max-width: 1200px) {

--- a/legal/style.css
+++ b/legal/style.css
@@ -9,7 +9,7 @@
 .legal-content {
   background-color: var(--white);
   border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 10px var(--shadow);
   padding: 40px;
 }
 

--- a/older-versions/style.css
+++ b/older-versions/style.css
@@ -9,7 +9,7 @@
 .hero {
   position: relative;
   background: linear-gradient(135deg, var(--hero-gradient-start), var(--hero-gradient-end));
-  color: white;
+  color: var(--white);
   padding: 100px 20px 80px;
   text-align: center;
   overflow: hidden;
@@ -31,7 +31,7 @@
 .hero-orb-1 {
   width: 400px;
   height: 400px;
-  background: linear-gradient(135deg, #3b82f6, #06b6d4);
+  background: linear-gradient(135deg, var(--blue-500), var(--cyan-500));
   top: -100px;
   right: -100px;
 }
@@ -39,7 +39,7 @@
 .hero-orb-2 {
   width: 300px;
   height: 300px;
-  background: linear-gradient(135deg, #8b5cf6, #ec4899);
+  background: linear-gradient(135deg, var(--purple-500), var(--pink-500));
   bottom: -80px;
   left: -80px;
   animation-delay: -4s;
@@ -77,14 +77,14 @@
 
 /* Warning box */
 .warning-box {
-  background: linear-gradient(135deg, #fff3cd, #ffeaa7);
-  border: 1px solid #f0c040;
+  background: linear-gradient(135deg, var(--yellow-warning-bg), var(--yellow-highlight));
+  border: 1px solid var(--gold-f0c040);
   border-radius: 12px;
   padding: 24px;
   margin: 40px auto;
   max-width: 800px;
-  color: #856404;
-  box-shadow: 0 4px 12px rgba(240, 192, 64, 0.15);
+  color: var(--yellow-warning-text);
+  box-shadow: 0 4px 12px var(--gold-alpha-15);
 }
 
 /* Platform Tabs */
@@ -100,7 +100,7 @@
   align-items: center;
   gap: 10px;
   padding: 14px 24px;
-  background: white;
+  background: var(--white);
   border: 2px solid var(--gray-border);
   border-radius: 12px;
   cursor: pointer;
@@ -118,7 +118,7 @@
 .platform-tab.active {
   background: var(--primary-blue);
   border-color: var(--primary-blue);
-  color: white;
+  color: var(--white);
 }
 
 .platform-tab:disabled {
@@ -143,8 +143,8 @@
 }
 
 .platform-tab.active .coming-soon-label {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
+  background: var(--white-alpha-20);
+  color: var(--white);
 }
 
 /* Platform Content */
@@ -166,7 +166,7 @@
 .warning-box h3 {
   margin-top: 0;
   margin-bottom: 12px;
-  color: #856404;
+  color: var(--yellow-warning-text);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -177,7 +177,7 @@
 }
 
 .warning-box a {
-  color: #3b82f6;
+  color: var(--blue-500);
   text-decoration: none;
   font-weight: 500;
 }
@@ -194,11 +194,11 @@
 }
 
 .version-download-card {
-  background: white;
+  background: var(--white);
   border-radius: 20px;
   padding: 32px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e5e7eb;
+  box-shadow: 0 4px 20px var(--shadow);
+  border: 1px solid var(--gray-border);
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: start;
@@ -207,14 +207,14 @@
 }
 
 .version-download-card:hover {
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 30px var(--shadow-md2);
   transform: translateY(-2px);
-  border-color: #d1d5db;
+  border-color: var(--gray-input-border);
 }
 
 .version-info h3 {
   margin: 0 0 16px 0;
-  color: #1f2937;
+  color: var(--gray-text-darker);
   font-size: 1.5rem;
   font-weight: 700;
 }
@@ -224,14 +224,14 @@
 }
 
 .meta-item {
-  color: #6b7280;
+  color: var(--gray-text);
   font-size: 0.9rem;
   margin-bottom: 6px;
   line-height: 1.5;
 }
 
 .meta-item strong {
-  color: #374151;
+  color: var(--gray-text-dark);
   font-weight: 600;
   min-width: 80px;
   display: inline-block;
@@ -246,8 +246,8 @@
 }
 
 .version-badge {
-  background: linear-gradient(135deg, #f3f4f6, #e5e7eb);
-  color: #6b7280;
+  background: linear-gradient(135deg, var(--gray-bg-light), var(--gray-border));
+  color: var(--gray-text);
   padding: 6px 14px;
   border-radius: 20px;
   font-size: 0.75rem;
@@ -259,23 +259,23 @@
 
 /* No versions available state */
 .version-card {
-  background: white;
+  background: var(--white);
   border-radius: 20px;
   padding: 60px 40px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e5e7eb;
+  box-shadow: 0 4px 20px var(--shadow);
+  border: 1px solid var(--gray-border);
 }
 
 .no-versions h3 {
-  color: #1f2937;
+  color: var(--gray-text-darker);
   font-size: 1.5rem;
   margin-bottom: 16px;
   font-weight: 700;
 }
 
 .no-versions p {
-  color: #6b7280;
+  color: var(--gray-text);
   font-size: 1rem;
   line-height: 1.6;
   max-width: 400px;

--- a/portal/style.css
+++ b/portal/style.css
@@ -42,7 +42,7 @@ body {
 
 .portal-header {
     background: linear-gradient(135deg, var(--hero-gradient-start), var(--hero-gradient-end));
-    color: white;
+    color: var(--white);
     padding: 24px 20px;
 }
 
@@ -85,18 +85,18 @@ body {
     gap: 6px;
     font-size: 13px;
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--white-alpha-80);
     text-decoration: none;
     padding: 6px 14px;
     border-radius: 6px;
-    background: rgba(255, 255, 255, 0.12);
+    background: var(--white-alpha-12);
     transition: all 0.2s ease;
     white-space: nowrap;
 }
 
 .portal-all-invoices-link:hover {
-    background: rgba(255, 255, 255, 0.22);
-    color: #ffffff;
+    background: var(--white-alpha-22);
+    color: var(--white);
 }
 
 .portal-all-invoices-link svg {
@@ -134,7 +134,7 @@ body {
     background: var(--white);
     border-radius: 12px;
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
 }
 
@@ -152,7 +152,7 @@ body {
     padding: 14px 24px;
     background: var(--white);
     border-radius: 12px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
     flex-wrap: wrap;
 }
@@ -170,7 +170,7 @@ body {
     background: var(--white);
     border-radius: 12px;
     padding: 28px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
 }
 
@@ -303,7 +303,7 @@ body {
 .invoice-items-section {
     background: var(--white);
     border-radius: 12px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
     overflow: hidden;
 }
@@ -400,7 +400,7 @@ body {
     background: var(--white);
     border-radius: 12px;
     padding: 20px 24px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
 }
 
@@ -425,7 +425,7 @@ body {
     background: var(--white);
     border-radius: 12px;
     padding: 28px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     margin-bottom: 20px;
 }
 
@@ -532,7 +532,7 @@ body {
 .form-control:focus {
     outline: none;
     border-color: var(--primary-blue);
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    box-shadow: 0 0 0 3px var(--blue-alpha-10);
 }
 
 .card-element-container {
@@ -568,7 +568,7 @@ body {
 .btn-submit:hover {
     background: var(--blueHover);
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    box-shadow: 0 4px 12px var(--blue-alpha-30);
 }
 
 .btn-submit:disabled {
@@ -659,7 +659,7 @@ body {
     background: var(--white);
     border-radius: 12px;
     padding: 40px 28px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     text-align: center;
     margin-bottom: 20px;
     animation: fadeInUp 0.4s ease;
@@ -822,14 +822,14 @@ body {
 .invoice-card {
     background: var(--white);
     border-radius: 10px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
     overflow: hidden;
     transition: box-shadow 0.2s ease;
     border-left: 4px solid var(--primary-blue);
 }
 
 .invoice-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px var(--shadow-default);
 }
 
 .invoice-card.overdue {
@@ -939,7 +939,7 @@ body {
     background: var(--white);
     border-radius: 10px;
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
 }
 
 .all-invoices-table thead th {
@@ -987,7 +987,7 @@ body {
     padding: 48px 24px;
     background: var(--white);
     border-radius: 10px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px var(--shadow);
 }
 
 .empty-state svg {
@@ -1010,7 +1010,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(255, 255, 255, 0.96);
+    background-color: var(--white-alpha-96);
     z-index: 9999;
     display: flex;
     flex-direction: column;

--- a/pricing/premium/checkout/style.css
+++ b/pricing/premium/checkout/style.css
@@ -19,7 +19,7 @@ h1 {
   background: var(--white);
   padding: 30px;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px var(--shadow-default);
   margin-top: 50px;
 }
 
@@ -68,7 +68,7 @@ h1 {
 
 .checkout-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 6px 12px var(--shadow-lg);
 }
 
 .order-summary {
@@ -116,7 +116,7 @@ h1 {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: var(--white-alpha-95);
   z-index: 9999;
   display: flex;
   flex-direction: column;

--- a/pricing/premium/style.css
+++ b/pricing/premium/style.css
@@ -13,7 +13,7 @@
 
 .ai-badge-large {
     display: inline-block;
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--white-alpha-20);
     backdrop-filter: blur(8px);
     padding: 8px 20px;
     border-radius: 30px;
@@ -81,13 +81,13 @@
     padding: 32px 24px;
     border-radius: 16px;
     text-align: center;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px var(--shadow);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .ai-feature-card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 10px 30px rgba(139, 92, 246, 0.15);
+    box-shadow: 0 10px 30px var(--purple-alpha-15);
 }
 
 .ai-feature-icon {
@@ -167,7 +167,7 @@
 .billing-option.active {
     background: var(--white);
     color: var(--purple-500);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px var(--shadow-default);
 }
 
 .billing-option:hover:not(.active) {
@@ -185,7 +185,7 @@
     background: var(--white);
     padding: 32px 48px;
     border-radius: 20px;
-    box-shadow: 0 10px 40px rgba(139, 92, 246, 0.15);
+    box-shadow: 0 10px 40px var(--purple-alpha-15);
     border: 2px solid var(--purple-500);
 }
 

--- a/pricing/premium/thank-you/style.css
+++ b/pricing/premium/thank-you/style.css
@@ -161,7 +161,7 @@ h1 {
     background: var(--white);
     padding: 16px;
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px var(--shadow-sm);
 }
 
 .feature-item svg {

--- a/pricing/style.css
+++ b/pricing/style.css
@@ -131,7 +131,7 @@ body {
   border-radius: 20px;
   padding: 40px 32px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px var(--shadow);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   position: relative;
   border: 2px solid transparent;
@@ -142,7 +142,7 @@ body {
 
 .pricing-card:hover {
   transform: translateY(-8px);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 20px 40px var(--shadow-md2);
 }
 
 .free-card {
@@ -150,7 +150,7 @@ body {
 }
 
 .free-card:hover {
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 20px 40px var(--shadow);
 }
 
 .ai-card {
@@ -158,7 +158,7 @@ body {
 }
 
 .ai-card:hover {
-  box-shadow: 0 20px 40px rgba(139, 92, 246, 0.2);
+  box-shadow: 0 20px 40px var(--purple-alpha-20);
 }
 
 .card-badge {
@@ -288,7 +288,7 @@ body {
 }
 
 .ai-card:hover .ai-cta {
-  box-shadow: 0 4px 15px rgba(139, 92, 246, 0.4);
+  box-shadow: 0 4px 15px var(--purple-alpha-40);
 }
 
 .payment-grid {
@@ -312,7 +312,7 @@ body {
   padding: clamp(16px, 4vw, 24px);
   border-radius: 12px;
   border: none;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--shadow-default);
   cursor: pointer;
   transition: all 0.3s ease;
   display: flex;
@@ -323,7 +323,7 @@ body {
 
 .payment-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 10px 20px var(--shadow-xl);
 }
 
 .payment-btn img {

--- a/resources/header/dark.css
+++ b/resources/header/dark.css
@@ -1,10 +1,10 @@
 header .menu-icon .nav-icon {
-  background: #000 !important;
+  background: var(--black) !important;
 }
 
 header .menu-icon .nav-icon:before,
 header .menu-icon .nav-icon:after {
-  background: #000 !important;
+  background: var(--black) !important;
 }
 
 /* Add transparent background only when menu is open */
@@ -17,31 +17,31 @@ header .header-inner .logo {
 }
 
 header .header-inner .menu-container ul li a {
-  color: #000 !important;
+  color: var(--black) !important;
 }
 
 header .header-inner .menu-container ul li a:after {
-  background: #000 !important;
+  background: var(--black) !important;
 }
 
 .account-avatar {
-  background-color: white;
+  background-color: var(--white);
   justify-content: center;
-  color: #333;
-  border: 2px solid #a3a3a3;
+  color: var(--dark-gray);
+  border: 2px solid var(--neutral-a3a3a3);
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
 .account-button:hover .account-avatar {
   transform: scale(1.05);
-  border-color: #656565;
+  border-color: var(--neutral-656565);
 }
 
 .author-avatar-placeholder {
-  background-color: white;
-  color: #333;
+  background-color: var(--white);
+  color: var(--dark-gray);
 }
 
 .account-avatar svg {
-  stroke: #333;
+  stroke: var(--dark-gray);
 }

--- a/resources/header/style.css
+++ b/resources/header/style.css
@@ -29,7 +29,7 @@ body.menu-open::after {
   left: 0;
   width: 100%;
   height: calc(100% - 50px);
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--overlay-light);
   backdrop-filter: blur(1px);
   -webkit-backdrop-filter: blur(1px);
   z-index: 90;
@@ -52,12 +52,12 @@ header {
 header.sticky {
   position: fixed;
   background: var(--white);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow-default);
   z-index: 100;
   opacity: 1;
 }
 
-/* Change text color to black only when sticky */
+/* Change text color to var(--black) only when sticky */
 header.sticky .menu-icon .nav-icon {
   background: var(--gray-900) !important;
 }
@@ -314,7 +314,7 @@ header .header-inner .menu-container ul li a:hover::after {
   text-decoration: none;
   overflow: hidden;
   font-size: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid var(--white-alpha-30);
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
@@ -326,7 +326,7 @@ header .header-inner .menu-container ul li a:hover::after {
 
 .account-button:hover .account-avatar {
   transform: scale(1.05);
-  border-color: rgba(255, 255, 255, 0.8);
+  border-color: var(--white-alpha-80);
 }
 
 .author-avatar {

--- a/resources/notifications/notifications.css
+++ b/resources/notifications/notifications.css
@@ -3,7 +3,7 @@
     padding: 12px 15px;
     border-radius: 6px;
     margin-bottom: 0;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px var(--shadow-default);
     text-align: center;
     animation: fadeInOut 3s forwards;
     overflow: hidden;
@@ -18,15 +18,15 @@
 }
 
 .success-message {
-    background-color: #d1fae5;
-    border: 1px solid #10b981;
-    color: #065f46;
+    background-color: var(--emerald-100);
+    border: 1px solid var(--emerald-500);
+    color: var(--emerald-800);
 }
 
 .error-message {
-    background-color: #fee2e2;
-    border: 1px solid #ef4444;
-    color: #b91c1c;
+    background-color: var(--red-100);
+    border: 1px solid var(--red-500);
+    color: var(--red-700);
 }
 
 /* Animation for fade in and out */

--- a/resources/styles/button.css
+++ b/resources/styles/button.css
@@ -29,7 +29,7 @@
 }
 
 .btn-outline:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--white-alpha-10);
 }
 
 .btn-blue {
@@ -93,7 +93,7 @@
 }
 
 .btn-black:hover {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--shadow-sm);
 }
 
 .back-button {

--- a/resources/styles/checkbox.css
+++ b/resources/styles/checkbox.css
@@ -13,7 +13,7 @@
   outline: none;
   transition: all 0.2s ease-in-out;
   position: relative;
-  background-color: white;
+  background-color: var(--white);
 }
 
 .checkbox input[type="checkbox"]:checked {
@@ -25,7 +25,7 @@
   position: absolute;
   width: 5px;
   height: 10px;
-  border: solid white;
+  border: solid var(--white);
   border-width: 0 2px 2px 0;
   left: 4px;
   transform: rotate(45deg);
@@ -36,7 +36,7 @@
 }
 
 .checkbox input[type="checkbox"]:focus {
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 0 3px var(--blue-alpha-30);
 }
 
 .checkbox label {

--- a/resources/styles/custom-colors.css
+++ b/resources/styles/custom-colors.css
@@ -142,8 +142,8 @@
   --yellow-warning-bg: #fff3cd;
   --yellow-warning-text: #856404;
   --yellow-highlight: #ffeaa7;
-  --fde68a: #fde68a;
-  --ede9fe: #ede9fe;
+  --amber-200: #fde68a;
+  --violet-100: #ede9fe;
 
   /* Blue extended */
   --blue-link: #0066cc;

--- a/resources/styles/custom-colors.css
+++ b/resources/styles/custom-colors.css
@@ -120,6 +120,162 @@
   /* Pink */
   --pink-500: #ec4899;
 
+  /* Additional neutrals */
+  --black: #000000;
+  --neutral-111827: #111827;
+  --neutral-4a5568: #4a5568;
+  --neutral-666: #666666;
+  --neutral-f8f9fa: #f8f9fa;
+  --neutral-f7f7f8: #f7f7f8;
+  --dark-1a1a2e: #1a1a2e;
+  --warm-bg: #f9f1e9;
+
+  /* Indigo extended */
+  --indigo-200: #c7d2fe;
+  --indigo-400: #818cf8;
+  --indigo-700: #4338ca;
+
+  /* Pink extended */
+  --pink-400: #f472b6;
+
+  /* Yellow/Warning */
+  --yellow-warning-bg: #fff3cd;
+  --yellow-warning-text: #856404;
+  --yellow-highlight: #ffeaa7;
+  --fde68a: #fde68a;
+  --ede9fe: #ede9fe;
+
+  /* Blue extended */
+  --blue-link: #0066cc;
+  --blue-link-alt: #0078d4;
+  --blue-link-dark: #0366cc;
+  --blue-e6f3ff: #e6f3ff;
+  --blue-e3f2fd: #e3f2fd;
+  --blue-90caf9: #90caf9;
+  --gold-f0c040: #f0c040;
+
+  /* Shadows & Overlays */
+  --shadow-xs: rgba(0, 0, 0, 0.04);
+  --shadow-sm: rgba(0, 0, 0, 0.05);
+  --shadow-md: rgba(0, 0, 0, 0.06);
+  --shadow: rgba(0, 0, 0, 0.08);
+  --shadow-default: rgba(0, 0, 0, 0.1);
+  --shadow-md2: rgba(0, 0, 0, 0.12);
+  --shadow-lg: rgba(0, 0, 0, 0.15);
+  --shadow-xl: rgba(0, 0, 0, 0.2);
+  --overlay-light: rgba(0, 0, 0, 0.3);
+  --overlay-medium: rgba(0, 0, 0, 0.4);
+  --overlay-dark: rgba(0, 0, 0, 0.5);
+  --overlay-darker: rgba(0, 0, 0, 0.6);
+
+  /* White alpha */
+  --white-alpha-05: rgba(255, 255, 255, 0.05);
+  --white-alpha-10: rgba(255, 255, 255, 0.1);
+  --white-alpha-12: rgba(255, 255, 255, 0.12);
+  --white-alpha-15: rgba(255, 255, 255, 0.15);
+  --white-alpha-20: rgba(255, 255, 255, 0.2);
+  --white-alpha-22: rgba(255, 255, 255, 0.22);
+  --white-alpha-25: rgba(255, 255, 255, 0.25);
+  --white-alpha-30: rgba(255, 255, 255, 0.3);
+  --white-alpha-40: rgba(255, 255, 255, 0.4);
+  --white-alpha-50: rgba(255, 255, 255, 0.5);
+  --white-alpha-60: rgba(255, 255, 255, 0.6);
+  --white-alpha-70: rgba(255, 255, 255, 0.7);
+  --white-alpha-80: rgba(255, 255, 255, 0.8);
+  --white-alpha-90: rgba(255, 255, 255, 0.9);
+  --white-alpha-95: rgba(255, 255, 255, 0.95);
+  --white-alpha-96: rgba(255, 255, 255, 0.96);
+
+  /* Blue alpha */
+  --blue-alpha-08: rgba(59, 130, 246, 0.08);
+  --blue-alpha-10: rgba(59, 130, 246, 0.1);
+  --blue-alpha-12: rgba(59, 130, 246, 0.12);
+  --blue-alpha-15: rgba(59, 130, 246, 0.15);
+  --blue-alpha-20: rgba(59, 130, 246, 0.2);
+  --blue-alpha-30: rgba(59, 130, 246, 0.3);
+  --blue-alpha-40: rgba(59, 130, 246, 0.4);
+  --blue-alpha-50: rgba(59, 130, 246, 0.5);
+  --blue-alpha-80: rgba(59, 130, 246, 0.8);
+  --blue-600-alpha-0: rgba(37, 99, 235, 0);
+  --blue-600-alpha-10: rgba(37, 99, 235, 0.1);
+  --blue-600-alpha-20: rgba(37, 99, 235, 0.2);
+  --blue-600-alpha-30: rgba(37, 99, 235, 0.3);
+  --blue-600-alpha-70: rgba(37, 99, 235, 0.7);
+
+  /* Green alpha */
+  --green-alpha-10: rgba(16, 185, 129, 0.1);
+  --green-alpha-15: rgba(16, 185, 129, 0.15);
+  --green-alpha-20: rgba(16, 185, 129, 0.2);
+  --green-alpha-30: rgba(16, 185, 129, 0.3);
+
+  /* Red alpha */
+  --red-alpha-15: rgba(239, 68, 68, 0.15);
+  --red-alpha-20: rgba(239, 68, 68, 0.2);
+
+  /* Purple alpha */
+  --purple-alpha-15: rgba(139, 92, 246, 0.15);
+  --purple-alpha-20: rgba(139, 92, 246, 0.2);
+  --purple-alpha-40: rgba(139, 92, 246, 0.4);
+
+  /* Amber alpha */
+  --amber-alpha-15: rgba(245, 158, 11, 0.15);
+  --amber-alpha-20: rgba(245, 158, 11, 0.2);
+
+  /* Gray alpha */
+  --gray-text-alpha-50: rgba(55, 65, 81, 0.5);
+  --gray-alpha-20: rgba(107, 114, 128, 0.2);
+  --gray-bg-light-alpha-80: rgba(243, 244, 246, 0.8);
+  --gray-rgb-border: rgb(225, 225, 225);
+
+  /* Indigo alpha */
+  --indigo-alpha-12: rgba(99, 102, 241, 0.12);
+  --indigo-alpha-20: rgba(99, 102, 241, 0.2);
+
+  /* Blue-400 alpha */
+  --blue-400-alpha-20: rgba(96, 165, 250, 0.2);
+
+  /* Additional neutrals (extended) */
+  --near-black: #111111;
+  --neutral-f7fafc: #f7fafc;
+  --neutral-edf2f7: #edf2f7;
+  --neutral-f1f1f1: #f1f1f1;
+  --neutral-f0f0f0: #f0f0f0;
+  --neutral-eee: #eeeeee;
+  --neutral-ddd: #dddddd;
+  --neutral-cccfd5: #cccfd5;
+  --neutral-a3a3a3: #a3a3a3;
+  --neutral-656565: #656565;
+
+  /* Slate/Navy */
+  --slate-1a202c: #1a202c;
+  --slate-2d3748: #2d3748;
+  --slate-253449: #253449;
+  --slate-3f4f63: #3f4f63;
+  --navy-1a365d: #1a365d;
+  --navy-1e3a5f: #1e3a5f;
+
+  /* Brand/Gradient colors */
+  --brand-yellow: #FCC624;
+  --gradient-indigo: #667eea;
+  --gradient-purple: #764ba2;
+  --yellow-50-alt: #fefce8;
+  --purple-50-alt: #f5f3ff;
+
+  /* Additional alpha */
+  --shadow-xxs: rgba(0, 0, 0, 0.07);
+  --gold-alpha-15: rgba(240, 192, 64, 0.15);
+  --red-alpha-10: rgba(239, 68, 68, 0.1);
+  --red-alpha-30: rgba(239, 68, 68, 0.3);
+  --pink-alpha-15: rgba(236, 72, 153, 0.15);
+  --green-alpha-40: rgba(16, 185, 129, 0.4);
+  --violet-alpha-02: rgba(147, 51, 234, 0.02);
+  --violet-alpha-05: rgba(147, 51, 234, 0.05);
+  --violet-alpha-15: rgba(147, 51, 234, 0.15);
+  --violet-alpha-20: rgba(147, 51, 234, 0.2);
+  --sky-alpha-20: rgba(14, 165, 233, 0.2);
+  --purple-alpha-50: rgba(139, 92, 246, 0.5);
+  --gray-alpha-30: rgba(107, 114, 128, 0.3);
+
   /* Hero/Footer theme */
   --hero-gradient-start: #0f172a;
   --hero-gradient-end: #1e293b;

--- a/resources/styles/faq.css
+++ b/resources/styles/faq.css
@@ -7,7 +7,7 @@
 .faq,
 .ai-faq {
     padding: 120px 0 60px 0;
-    background: white;
+    background: var(--white);
 }
 
 .faq h2,
@@ -15,7 +15,7 @@
     font-size: 36px;
     text-align: center;
     margin-bottom: 48px;
-    color: #0f172a;
+    color: var(--gray-900);
 }
 
 .faq-grid {
@@ -24,7 +24,7 @@
 }
 
 .faq-item {
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
     border-radius: 16px;
     margin-bottom: 16px;
     overflow: hidden;
@@ -32,12 +32,12 @@
 }
 
 .faq-item:hover {
-    border-color: #3b82f6;
+    border-color: var(--blue-500);
 }
 
 .faq-item.active {
-    border-color: #3b82f6;
-    box-shadow: 0 4px 20px rgba(59, 130, 246, 0.1);
+    border-color: var(--blue-500);
+    box-shadow: 0 4px 20px var(--blue-alpha-10);
 }
 
 .faq-question {
@@ -46,17 +46,17 @@
     justify-content: space-between;
     padding: 24px;
     cursor: pointer;
-    background: white;
+    background: var(--white);
     transition: background 0.3s ease;
 }
 
 .faq-question:hover {
-    background: #f8fafc;
+    background: var(--gray-50);
 }
 
 .faq-question h3 {
     font-size: 1.1rem;
-    color: #0f172a;
+    color: var(--gray-900);
     margin: 0;
     font-weight: 600;
     padding-right: 16px;
@@ -66,7 +66,7 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: #f1f5f9;
+    background: var(--gray-100);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -77,16 +77,16 @@
 .faq-icon svg {
     width: 16px;
     height: 16px;
-    color: #64748b;
+    color: var(--gray-500);
     transition: transform 0.3s ease;
 }
 
 .faq-item.active .faq-icon {
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
 }
 
 .faq-item.active .faq-icon svg {
-    color: white;
+    color: var(--white);
     transform: rotate(180deg);
 }
 
@@ -102,7 +102,7 @@
 
 .faq-answer-content {
     padding: 0 24px 24px;
-    color: #64748b;
+    color: var(--gray-500);
     font-size: 1rem;
     line-height: 1.7;
 }
@@ -116,12 +116,12 @@
 }
 
 .faq-answer-content a {
-    color: #3b82f6;
+    color: var(--blue-500);
     text-decoration: underline;
 }
 
 .faq-answer-content a:hover {
-    color: #1d4ed8;
+    color: var(--blue-700);
 }
 
 /* Responsive */

--- a/style.css
+++ b/style.css
@@ -2500,7 +2500,7 @@ a {
 }
 
 .contact-icon.feedback {
-    background: linear-gradient(135deg, var(--purple-50-alt), var(--ede9fe));
+    background: linear-gradient(135deg, var(--purple-50-alt), var(--violet-100));
 }
 
 .contact-icon.feedback svg {
@@ -2516,7 +2516,7 @@ a {
 }
 
 .contact-icon.docs {
-    background: linear-gradient(135deg, var(--amber-100), var(--fde68a));
+    background: linear-gradient(135deg, var(--amber-100), var(--amber-200));
 }
 
 .contact-icon.docs svg {

--- a/style.css
+++ b/style.css
@@ -4,8 +4,8 @@ body {
     padding: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     line-height: 1.6;
-    color: #1a1a2e;
-    background-color: #ffffff;
+    color: var(--dark-1a1a2e);
+    background-color: var(--white);
     overflow-x: hidden;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -361,60 +361,60 @@ a {
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
-    color: white;
-    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.4);
+    background: linear-gradient(135deg, var(--blue-500) 0%, var(--blue-700) 100%);
+    color: var(--white);
+    box-shadow: 0 4px 14px var(--blue-alpha-40);
 }
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(59, 130, 246, 0.5);
+    box-shadow: 0 8px 25px var(--blue-alpha-50);
 }
 
 .btn-secondary {
-    background: #f1f5f9;
-    color: #1e293b;
-    border: 1px solid #e2e8f0;
+    background: var(--gray-100);
+    color: var(--gray-800);
+    border: 1px solid var(--gray-200);
 }
 
 .btn-secondary:hover {
-    background: #e2e8f0;
+    background: var(--gray-200);
     transform: translateY(-2px);
 }
 
 .btn-white {
-    background: white;
-    color: #1d4ed8;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
+    background: var(--white);
+    color: var(--blue-700);
+    box-shadow: 0 4px 14px var(--shadow-default);
 }
 
 .btn-white:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 8px 25px var(--shadow-lg);
 }
 
 .btn-outline-white {
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-    border: 2px solid rgba(255, 255, 255, 0.5);
+    background: var(--white-alpha-15);
+    color: var(--white);
+    border: 2px solid var(--white-alpha-50);
     backdrop-filter: blur(8px);
 }
 
 .btn-outline-white:hover {
-    background: rgba(255, 255, 255, 0.25);
-    border-color: white;
+    background: var(--white-alpha-25);
+    border-color: var(--white);
     transform: translateY(-2px);
 }
 
 .btn-ai {
-    background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-    color: white;
-    box-shadow: 0 4px 14px rgba(139, 92, 246, 0.4);
+    background: linear-gradient(135deg, var(--purple-500) 0%, var(--purple-600) 100%);
+    color: var(--white);
+    box-shadow: 0 4px 14px var(--purple-alpha-40);
 }
 
 .btn-ai:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(139, 92, 246, 0.5);
+    box-shadow: 0 8px 25px var(--purple-alpha-50);
 }
 
 .btn-block {
@@ -431,7 +431,7 @@ a {
     align-items: center;
     padding: 120px 0 80px;
     overflow: hidden;
-    background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
+    background: linear-gradient(135deg, var(--gray-900) 0%, var(--gray-800) 50%, var(--gray-900) 100%);
 }
 
 .hero-bg {
@@ -451,7 +451,7 @@ a {
 .hero-orb-1 {
     width: 600px;
     height: 600px;
-    background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+    background: linear-gradient(135deg, var(--blue-500), var(--purple-500));
     top: -200px;
     right: -100px;
     animation: heroOrbFadeIn 2s ease-out forwards, heroOrbPulse 4s ease-in-out infinite 2s, heroOrbFloat1 15s ease-in-out infinite;
@@ -460,7 +460,7 @@ a {
 .hero-orb-2 {
     width: 400px;
     height: 400px;
-    background: linear-gradient(135deg, #06b6d4, #3b82f6);
+    background: linear-gradient(135deg, var(--cyan-500), var(--blue-500));
     bottom: -100px;
     left: -100px;
     animation: heroOrbFadeIn 2s ease-out 0.3s forwards, heroOrbPulse 5s ease-in-out infinite 2.3s, heroOrbFloat2 18s ease-in-out infinite;
@@ -469,7 +469,7 @@ a {
 .hero-orb-3 {
     width: 300px;
     height: 300px;
-    background: linear-gradient(135deg, #8b5cf6, #ec4899);
+    background: linear-gradient(135deg, var(--purple-500), var(--pink-500));
     top: 50%;
     left: 30%;
     animation: heroOrbFadeIn 2s ease-out 0.6s forwards, heroOrbPulse 6s ease-in-out infinite 2.6s, heroOrbFloat3 12s ease-in-out infinite;
@@ -546,7 +546,7 @@ a {
 }
 
 .hero-content {
-    color: white;
+    color: var(--white);
 }
 
 .hero-app-title {
@@ -554,7 +554,7 @@ a {
     font-weight: 800;
     margin-bottom: 24px;
     letter-spacing: -0.03em;
-    background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 50%, #f472b6 100%);
+    background: linear-gradient(135deg, var(--blue-400) 0%, var(--purple-400) 50%, var(--pink-400) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -572,7 +572,7 @@ a {
 }
 
 .text-gradient {
-    background: linear-gradient(135deg, #60a5fa, #a78bfa, #f472b6, #60a5fa);
+    background: linear-gradient(135deg, var(--blue-400), var(--purple-400), var(--pink-400), var(--blue-400));
     background-size: 300% 300%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -602,7 +602,7 @@ a {
 .hero-subtitle {
     font-size: 1.25rem;
     margin-bottom: 32px;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--white-alpha-80);
     line-height: 1.7;
     max-width: 500px;
 }
@@ -617,13 +617,13 @@ a {
     display: block;
     font-size: 1.75rem;
     font-weight: 700;
-    color: white;
+    color: var(--white);
 }
 
 .stat-label {
     display: block;
     font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--white-alpha-60);
 }
 
 /* Hero Visual */
@@ -636,12 +636,12 @@ a {
 }
 
 .device-frame {
-    background: linear-gradient(145deg, #1e293b, #0f172a);
+    background: linear-gradient(145deg, var(--gray-800), var(--gray-900));
     border-radius: 16px;
     padding: 12px;
     box-shadow:
-        0 25px 50px -12px rgba(0, 0, 0, 0.5),
-        0 0 0 1px rgba(255, 255, 255, 0.1);
+        0 25px 50px -12px var(--overlay-dark),
+        0 0 0 1px var(--white-alpha-10);
 }
 
 .device-screen {
@@ -653,13 +653,13 @@ a {
 
 .floating-card {
     position: absolute;
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     padding: 16px 20px;
     display: flex;
     align-items: center;
     gap: 14px;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 20px 40px var(--overlay-light);
     min-width: 200px;
 }
 
@@ -677,21 +677,21 @@ a {
     width: 48px;
     height: 48px;
     border-radius: 12px;
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: var(--white);
 }
 
 .floating-card-icon.success {
-    background: linear-gradient(135deg, #10b981, #059669);
+    background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
 }
 
 .floating-card-label {
     display: block;
     font-size: 0.8rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin-bottom: 2px;
 }
 
@@ -699,11 +699,11 @@ a {
     display: block;
     font-size: 1rem;
     font-weight: 600;
-    color: #1e293b;
+    color: var(--gray-800);
 }
 
 .floating-card-value.success {
-    color: #059669;
+    color: var(--emerald-600);
 }
 
 /* ========================================
@@ -711,13 +711,13 @@ a {
    ======================================== */
 .trusted-section {
     padding: 60px 0;
-    background: #f8fafc;
-    border-bottom: 1px solid #e2e8f0;
+    background: var(--gray-50);
+    border-bottom: 1px solid var(--gray-200);
 }
 
 .trusted-label {
     text-align: center;
-    color: #64748b;
+    color: var(--gray-500);
     font-size: 0.9rem;
     margin-bottom: 24px;
     text-transform: uppercase;
@@ -733,12 +733,12 @@ a {
 }
 
 .trusted-logo {
-    color: #94a3b8;
+    color: var(--gray-400);
     transition: color 0.3s ease;
 }
 
 .trusted-logo:hover {
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 /* ========================================
@@ -752,8 +752,8 @@ a {
 
 .section-tag {
     display: inline-block;
-    background: linear-gradient(135deg, #3b82f6, #8b5cf6);
-    color: white;
+    background: linear-gradient(135deg, var(--blue-500), var(--purple-500));
+    color: var(--white);
     padding: 6px 16px;
     border-radius: 50px;
     font-size: 0.85rem;
@@ -775,7 +775,7 @@ a {
 
 .section-description {
     font-size: 1.125rem;
-    color: #64748b;
+    color: var(--gray-500);
     line-height: 1.7;
 }
 
@@ -788,7 +788,7 @@ a {
    ======================================== */
 .features-section {
     padding: 120px 0;
-    background: white;
+    background: var(--white);
 }
 
 .features-tabs {
@@ -811,8 +811,8 @@ a {
     align-items: center;
     gap: 16px;
     padding: 10px;
-    background: white;
-    border: 1px solid #e2e8f0;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
     border-radius: 12px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -820,23 +820,23 @@ a {
 }
 
 .tab-btn:hover {
-    border-color: #3b82f6;
-    background: #f8fafc;
+    border-color: var(--blue-500);
+    background: var(--gray-50);
 }
 
 .tab-btn.active {
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
     border-color: transparent;
-    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+    box-shadow: 0 8px 20px var(--blue-alpha-30);
 }
 
 .tab-btn.active .tab-icon,
 .tab-btn.active .tab-title {
-    color: white;
+    color: var(--white);
 }
 
 .tab-btn.active .tab-subtitle {
-    color: white;
+    color: var(--white);
     opacity: 0.8;
 }
 
@@ -844,16 +844,16 @@ a {
     width: 48px;
     height: 48px;
     border-radius: 10px;
-    background: #f1f5f9;
+    background: var(--gray-100);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #3b82f6;
+    color: var(--blue-500);
     flex-shrink: 0;
 }
 
 .tab-btn.active .tab-icon {
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--white-alpha-20);
 }
 
 .tab-text {
@@ -864,7 +864,7 @@ a {
     display: block;
     font-size: 1rem;
     font-weight: 600;
-    color: #1e293b;
+    color: var(--gray-800);
     margin-bottom: 2px;
     transition: color 0.3s ease;
 }
@@ -872,7 +872,7 @@ a {
 .tab-subtitle {
     display: block;
     font-size: 0.85rem;
-    color: #64748b;
+    color: var(--gray-500);
     transition: color 0.3s ease;
 }
 
@@ -905,7 +905,7 @@ a {
 
 .tab-content-text p {
     font-size: 1.1rem;
-    color: #64748b;
+    color: var(--gray-500);
     line-height: 1.7;
     margin-bottom: 24px;
 }
@@ -924,39 +924,39 @@ a {
     align-items: center;
     gap: 12px;
     font-size: 1rem;
-    color: #475569;
+    color: var(--gray-600);
 }
 
 .feature-list li svg {
-    color: #10b981;
+    color: var(--emerald-500);
     flex-shrink: 0;
 }
 
 /* Feature Visual Cards */
 .feature-visual-card {
-    background: linear-gradient(145deg, #f8fafc, #f1f5f9);
+    background: linear-gradient(145deg, var(--gray-50), var(--gray-100));
     border-radius: 24px;
     padding: 32px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
 }
 
 .visual-mockup {
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px var(--shadow);
 }
 
 /* Receipt Mockup */
 .phone-frame {
-    background: linear-gradient(145deg, #1e293b, #0f172a);
+    background: linear-gradient(145deg, var(--gray-800), var(--gray-900));
     border-radius: 24px;
     padding: 8px;
     margin: 0 auto;
 }
 
 .phone-screen {
-    background: white;
+    background: var(--white);
     border-radius: 20px;
     padding: 20px;
     position: relative;
@@ -975,8 +975,8 @@ a {
     left: 0;
     right: 0;
     height: 3px;
-    background: linear-gradient(90deg, transparent, #3b82f6, transparent);
-    box-shadow: 0 0 12px 3px rgba(59, 130, 246, 0.3);
+    background: linear-gradient(90deg, transparent, var(--blue-500), transparent);
+    box-shadow: 0 0 12px 3px var(--blue-alpha-30);
     animation: scanLine 2.5s ease-in-out 1;
     opacity: 1;
     transition: opacity 0.3s ease;
@@ -995,14 +995,14 @@ a {
     margin: auto;
     width: 80px;
     height: 80px;
-    background: linear-gradient(135deg, #10b981, #059669);
+    background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     opacity: 0;
     z-index: 10;
-    box-shadow: 0 10px 30px rgba(16, 185, 129, 0.4);
+    box-shadow: 0 10px 30px var(--green-alpha-40);
     transform: scale(0);
 }
 
@@ -1013,7 +1013,7 @@ a {
 .scan-complete-indicator svg {
     width: 40px;
     height: 40px;
-    color: white;
+    color: var(--white);
 }
 
 .scan-complete-indicator svg polyline {
@@ -1031,26 +1031,26 @@ a {
     z-index: 2;
     font-family: 'Courier New', Courier, monospace;
     font-size: 0.78rem;
-    color: #334155;
+    color: var(--gray-700);
 }
 
 .receipt-header {
     margin-bottom: 16px;
     padding-bottom: 12px;
-    border-bottom: 1px dashed #cbd5e1;
+    border-bottom: 1px dashed var(--gray-300);
     text-align: center;
 }
 
 .receipt-store-name {
     font-weight: 700;
     font-size: 0.9rem;
-    color: #0f172a;
+    color: var(--gray-900);
     margin-bottom: 2px;
 }
 
 .receipt-date {
     font-size: 0.7rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .receipt-items {
@@ -1066,8 +1066,8 @@ a {
 
 .receipt-item.receipt-tax {
     padding-top: 8px;
-    border-top: 1px dashed #cbd5e1;
-    color: #64748b;
+    border-top: 1px dashed var(--gray-300);
+    color: var(--gray-500);
     font-size: 0.72rem;
 }
 
@@ -1075,10 +1075,10 @@ a {
     display: flex;
     justify-content: space-between;
     padding-top: 12px;
-    border-top: 2px solid #0f172a;
+    border-top: 2px solid var(--gray-900);
     font-weight: 700;
     font-size: 0.88rem;
-    color: #0f172a;
+    color: var(--gray-900);
 }
 
 .scan-text {
@@ -1088,13 +1088,13 @@ a {
 }
 
 .scan-text.highlighted {
-    background-color: rgba(59, 130, 246, 0.12);
-    color: #1e40af;
+    background-color: var(--blue-alpha-12);
+    color: var(--blue-800);
 }
 
 .scan-text.extracted {
-    background-color: rgba(16, 185, 129, 0.10);
-    color: #065f46;
+    background-color: var(--green-alpha-10);
+    color: var(--emerald-800);
 }
 
 .ai-badge {
@@ -1102,8 +1102,8 @@ a {
     bottom: 20px;
     left: 50%;
     transform: translateX(-50%);
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
-    color: white;
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
+    color: var(--white);
     padding: 8px 16px;
     border-radius: 50px;
     font-size: 0.8rem;
@@ -1124,7 +1124,7 @@ a {
 }
 
 .ai-badge.complete {
-    background: linear-gradient(135deg, #10b981, #059669);
+    background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
 }
 
 .ai-badge.complete .badge-text-scanning {
@@ -1156,7 +1156,7 @@ a {
 
 .chart-period {
     font-size: 0.85rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .chart-area {
@@ -1172,10 +1172,10 @@ a {
     position: absolute;
     top: 10px;
     right: 10px;
-    background: white;
+    background: var(--white);
     padding: 12px 16px;
     border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px var(--shadow-default);
     text-align: center;
 }
 
@@ -1183,13 +1183,13 @@ a {
     display: block;
     font-size: 1.5rem;
     font-weight: 700;
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 .prediction-text {
     display: block;
     font-size: 0.75rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 /* Inventory Mockup */
@@ -1208,20 +1208,20 @@ a {
     align-items: center;
     gap: 16px;
     padding: 16px;
-    background: #f8fafc;
+    background: var(--gray-50);
     border-radius: 12px;
 }
 
 .inventory-item .item-icon {
     width: 48px;
     height: 48px;
-    background: white;
+    background: var(--white);
     border-radius: 10px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #64748b;
-    border: 1px solid #e2e8f0;
+    color: var(--gray-500);
+    border: 1px solid var(--gray-200);
 }
 
 .inventory-item .item-details {
@@ -1238,14 +1238,14 @@ a {
     font-size: 0.85rem;
 }
 
-.inventory-item .item-stock.high { color: #10b981; }
-.inventory-item .item-stock.medium { color: #f59e0b; }
-.inventory-item .item-stock.low { color: #ef4444; }
+.inventory-item .item-stock.high { color: var(--emerald-500); }
+.inventory-item .item-stock.medium { color: var(--amber-500); }
+.inventory-item .item-stock.low { color: var(--red-500); }
 
 .inventory-item .item-bar {
     width: 60px;
     height: 6px;
-    background: #e2e8f0;
+    background: var(--gray-200);
     border-radius: 3px;
     overflow: hidden;
 }
@@ -1255,7 +1255,7 @@ a {
     display: block;
     width: 90%;
     height: 100%;
-    background: #10b981;
+    background: var(--emerald-500);
     border-radius: 3px;
 }
 
@@ -1264,7 +1264,7 @@ a {
     display: block;
     width: 50%;
     height: 100%;
-    background: #f59e0b;
+    background: var(--amber-500);
     border-radius: 3px;
 }
 
@@ -1273,7 +1273,7 @@ a {
     display: block;
     width: 15%;
     height: 100%;
-    background: #ef4444;
+    background: var(--red-500);
     border-radius: 3px;
 }
 
@@ -1301,14 +1301,14 @@ a {
 .cal-nav button {
     width: 32px;
     height: 32px;
-    border: 1px solid #e2e8f0;
-    background: white;
+    border: 1px solid var(--gray-200);
+    background: var(--white);
     border-radius: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .calendar-grid {
@@ -1324,23 +1324,23 @@ a {
     justify-content: center;
     font-size: 0.85rem;
     border-radius: 8px;
-    color: #475569;
+    color: var(--gray-600);
 }
 
 .cal-day.header {
     font-weight: 600;
-    color: #94a3b8;
+    color: var(--gray-400);
     font-size: 0.75rem;
 }
 
 .cal-day.booked {
-    background: #fecaca;
-    color: #dc2626;
+    background: var(--red-200);
+    color: var(--red-600);
 }
 
 .cal-day.available {
-    background: #d1fae5;
-    color: #059669;
+    background: var(--emerald-100);
+    color: var(--emerald-600);
 }
 
 .calendar-legend {
@@ -1355,7 +1355,7 @@ a {
     align-items: center;
     gap: 6px;
     font-size: 0.8rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .legend-item .dot {
@@ -1364,8 +1364,8 @@ a {
     border-radius: 50%;
 }
 
-.legend-item .dot.booked { background: #fecaca; }
-.legend-item .dot.available { background: #d1fae5; }
+.legend-item .dot.booked { background: var(--red-200); }
+.legend-item .dot.available { background: var(--emerald-100); }
 
 /* Customer Mockup */
 .customers-mockup {
@@ -1377,7 +1377,7 @@ a {
     align-items: center;
     gap: 16px;
     padding: 20px;
-    background: #f8fafc;
+    background: var(--gray-50);
     border-radius: 12px;
     margin-bottom: 12px;
 }
@@ -1389,18 +1389,18 @@ a {
 .customer-avatar {
     width: 48px;
     height: 48px;
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: var(--white);
     font-weight: 600;
     font-size: 1rem;
 }
 
 .customer-avatar.alt {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+    background: linear-gradient(135deg, var(--purple-500), var(--purple-600));
 }
 
 .customer-info {
@@ -1414,7 +1414,7 @@ a {
 
 .customer-email {
     font-size: 0.85rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .customer-stats {
@@ -1434,7 +1434,7 @@ a {
 
 .customer-stats .stat-lbl {
     font-size: 0.75rem;
-    color: #94a3b8;
+    color: var(--gray-400);
 }
 
 /* Invoice Mockup */
@@ -1443,7 +1443,7 @@ a {
 }
 
 .invoice-preview {
-    background: #f8fafc;
+    background: var(--gray-50);
     border-radius: 12px;
     padding: 24px;
     position: relative;
@@ -1475,7 +1475,7 @@ a {
 
 .meta-label {
     font-size: 0.75rem;
-    color: #94a3b8;
+    color: var(--gray-400);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
@@ -1489,12 +1489,12 @@ a {
     justify-content: space-between;
     align-items: center;
     padding-top: 20px;
-    border-top: 2px solid #e2e8f0;
+    border-top: 2px solid var(--gray-200);
 }
 
 .total-label {
     font-size: 0.9rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .total-value {
@@ -1513,8 +1513,8 @@ a {
 }
 
 .invoice-status.paid {
-    background: #d1fae5;
-    color: #059669;
+    background: var(--emerald-100);
+    color: var(--emerald-600);
 }
 
 /* AI Import Mockup */
@@ -1523,7 +1523,7 @@ a {
    ======================================== */
 .ai-import-section {
     padding: 120px 0;
-    background: #f8fafc;
+    background: var(--gray-50);
     overflow: hidden;
 }
 
@@ -1551,25 +1551,25 @@ a {
     width: 48px;
     height: 48px;
     min-width: 48px;
-    background: white;
+    background: var(--white);
     border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #6366f1;
-    box-shadow: 0 2px 12px rgba(99, 102, 241, 0.12);
+    color: var(--indigo-500);
+    box-shadow: 0 2px 12px var(--indigo-alpha-12);
 }
 
 .ai-feature-detail h4 {
     font-size: 1rem;
     font-weight: 600;
     margin-bottom: 4px;
-    color: #1e293b;
+    color: var(--gray-800);
 }
 
 .ai-feature-detail p {
     font-size: 0.9rem;
-    color: #64748b;
+    color: var(--gray-500);
     line-height: 1.5;
     margin: 0;
 }
@@ -1587,11 +1587,11 @@ a {
 
 /* Spreadsheet card */
 .demo-spreadsheet {
-    background: white;
+    background: var(--white);
     border-radius: 16px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    box-shadow: 0 4px 24px var(--shadow-md), 0 1px 2px var(--shadow-xs);
     overflow: hidden;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
 }
 
 .demo-spreadsheet-header {
@@ -1599,24 +1599,24 @@ a {
     align-items: center;
     gap: 10px;
     padding: 14px 20px;
-    background: linear-gradient(135deg, #f1f5f9, #e2e8f0);
-    border-bottom: 1px solid #e2e8f0;
+    background: linear-gradient(135deg, var(--gray-100), var(--gray-200));
+    border-bottom: 1px solid var(--gray-200);
 }
 
 .demo-file-icon {
-    color: #059669;
+    color: var(--emerald-600);
 }
 
 .demo-file-name {
     font-size: 0.85rem;
     font-weight: 600;
-    color: #1e293b;
+    color: var(--gray-800);
 }
 
 .demo-file-badge {
     margin-left: auto;
-    background: #dcfce7;
-    color: #059669;
+    background: var(--green-100);
+    color: var(--emerald-600);
     padding: 2px 10px;
     border-radius: 50px;
     font-size: 0.7rem;
@@ -1634,12 +1634,12 @@ a {
     grid-template-columns: 1.2fr 1.4fr 1.2fr 1fr;
     gap: 0;
     font-size: 0.78rem;
-    border-bottom: 1px solid #f1f5f9;
+    border-bottom: 1px solid var(--gray-100);
 }
 
 .demo-table-row span {
     padding: 10px 16px;
-    border-right: 1px solid #f1f5f9;
+    border-right: 1px solid var(--gray-100);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1650,13 +1650,13 @@ a {
 }
 
 .demo-table-header-row {
-    background: #f8fafc;
+    background: var(--gray-50);
     font-weight: 600;
-    color: #475569;
+    color: var(--gray-600);
 }
 
 .demo-table-row:not(.demo-table-header-row) {
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .demo-table-faded {
@@ -1666,9 +1666,9 @@ a {
 .demo-row-count {
     padding: 8px 16px;
     font-size: 0.75rem;
-    color: #94a3b8;
+    color: var(--gray-400);
     text-align: center;
-    border-top: 1px solid #f1f5f9;
+    border-top: 1px solid var(--gray-100);
 }
 
 /* AI Processor */
@@ -1716,7 +1716,7 @@ a {
     font-size: 0.75rem;
     font-weight: 700;
     line-height: 1;
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    background: linear-gradient(135deg, var(--indigo-500), var(--purple-500));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -1724,17 +1724,17 @@ a {
 
 .processor-text {
     font-size: 0.85rem;
-    color: #6366f1;
+    color: var(--indigo-500);
     font-weight: 500;
 }
 
 /* Mapping results */
 .demo-mapping-results {
-    background: white;
+    background: var(--white);
     border-radius: 16px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    box-shadow: 0 4px 24px var(--shadow-md), 0 1px 2px var(--shadow-xs);
     overflow: hidden;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
     opacity: 0;
     transform: translateY(10px);
     transition: opacity 0.5s ease, transform 0.5s ease;
@@ -1750,19 +1750,19 @@ a {
     justify-content: space-between;
     align-items: center;
     padding: 14px 20px;
-    background: linear-gradient(135deg, #eef2ff, #e0e7ff);
-    border-bottom: 1px solid #c7d2fe;
+    background: linear-gradient(135deg, var(--indigo-50), var(--indigo-100));
+    border-bottom: 1px solid var(--indigo-200);
 }
 
 .demo-mapping-title {
     font-size: 0.85rem;
     font-weight: 600;
-    color: #4338ca;
+    color: var(--indigo-700);
 }
 
 .demo-mapping-badge {
-    background: #6366f1;
-    color: white;
+    background: var(--indigo-500);
+    color: var(--white);
     padding: 3px 10px;
     border-radius: 50px;
     font-size: 0.7rem;
@@ -1775,7 +1775,7 @@ a {
     align-items: center;
     gap: 12px;
     padding: 12px 20px;
-    border-bottom: 1px solid #f1f5f9;
+    border-bottom: 1px solid var(--gray-100);
     opacity: 0;
     transform: translateX(-10px);
     transition: opacity 0.4s ease, transform 0.4s ease;
@@ -1788,16 +1788,16 @@ a {
 
 .demo-map-source {
     font-size: 0.82rem;
-    color: #64748b;
-    background: #f8fafc;
+    color: var(--gray-500);
+    background: var(--gray-50);
     padding: 6px 12px;
     border-radius: 6px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
     text-align: center;
 }
 
 .demo-map-arrow {
-    color: #6366f1;
+    color: var(--indigo-500);
     display: flex;
     align-items: center;
 }
@@ -1805,19 +1805,19 @@ a {
 .demo-map-target {
     font-size: 0.82rem;
     font-weight: 600;
-    color: #1e293b;
-    background: #eef2ff;
+    color: var(--gray-800);
+    background: var(--indigo-50);
     padding: 6px 12px;
     border-radius: 6px;
-    border: 1px solid #c7d2fe;
+    border: 1px solid var(--indigo-200);
     text-align: center;
 }
 
 .demo-map-confidence {
     font-size: 0.72rem;
     font-weight: 700;
-    color: #059669;
-    background: #d1fae5;
+    color: var(--emerald-600);
+    background: var(--emerald-100);
     padding: 3px 8px;
     border-radius: 50px;
     min-width: 36px;
@@ -1826,8 +1826,8 @@ a {
 
 .demo-mapping-footer {
     padding: 14px 20px;
-    background: #f0fdf4;
-    border-top: 1px solid #bbf7d0;
+    background: var(--green-50);
+    border-top: 1px solid var(--green-200);
     opacity: 0;
     transition: opacity 0.5s ease;
 }
@@ -1842,23 +1842,23 @@ a {
     gap: 8px;
     font-size: 0.82rem;
     font-weight: 600;
-    color: #059669;
+    color: var(--emerald-600);
 }
 
 .demo-mapping-success svg {
-    color: #059669;
+    color: var(--emerald-600);
 }
 
 .success-icon {
     width: 64px;
     height: 64px;
-    background: white;
+    background: var(--white);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     margin: 0 auto 16px;
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 /* Expense Tracking Mockup */
@@ -1867,8 +1867,8 @@ a {
 }
 
 .expense-form-preview {
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
     border-radius: 16px;
     padding: 24px;
 }
@@ -1876,13 +1876,13 @@ a {
 .expense-form-header {
     margin-bottom: 20px;
     padding-bottom: 16px;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 1px solid var(--gray-200);
 }
 
 .expense-form-header .form-title {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #1e293b;
+    color: var(--gray-800);
 }
 
 .expense-form-fields {
@@ -1900,23 +1900,23 @@ a {
 
 .field-label {
     font-size: 0.9rem;
-    color: #64748b;
+    color: var(--gray-500);
     font-weight: 500;
 }
 
 .field-value {
     font-size: 0.95rem;
-    color: #1e293b;
+    color: var(--gray-800);
     font-weight: 600;
-    background: white;
+    background: var(--white);
     padding: 8px 12px;
     border-radius: 8px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
 }
 
 .field-toggle {
     display: flex;
-    background: #e2e8f0;
+    background: var(--gray-200);
     border-radius: 8px;
     padding: 4px;
 }
@@ -1925,14 +1925,14 @@ a {
     padding: 2px 8px;
     font-size: 0.85rem;
     font-weight: 500;
-    color: #64748b;
+    color: var(--gray-500);
     border-radius: 6px;
     transition: all 0.2s ease;
 }
 
 .toggle-option.active {
-    background: #3b82f6;
-    color: white;
+    background: var(--blue-500);
+    color: var(--white);
 }
 
 .expense-form-validation {
@@ -1940,7 +1940,7 @@ a {
     flex-direction: column;
     gap: 8px;
     padding-top: 16px;
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid var(--gray-200);
 }
 
 .validation-check {
@@ -1948,7 +1948,7 @@ a {
     align-items: center;
     gap: 8px;
     font-size: 0.85rem;
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 .validation-check svg {
@@ -1960,7 +1960,7 @@ a {
    ======================================== */
 .how-it-works-section {
     padding: 120px 0;
-    background: #f8fafc;
+    background: var(--gray-50);
 }
 
 .steps-grid {
@@ -1984,8 +1984,8 @@ a {
     transform: translateX(-50%);
     width: 32px;
     height: 32px;
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
-    color: white;
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
+    color: var(--white);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -1997,14 +1997,14 @@ a {
 .step-icon {
     width: 80px;
     height: 80px;
-    background: white;
+    background: var(--white);
     border-radius: 20px;
     display: flex;
     align-items: center;
     justify-content: center;
     margin: 24px auto 20px;
-    color: #3b82f6;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    color: var(--blue-500);
+    box-shadow: 0 4px 20px var(--shadow);
 }
 
 .step-card h3 {
@@ -2014,14 +2014,14 @@ a {
 
 .step-card p {
     font-size: 0.95rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin: 0;
 }
 
 .step-connector {
     width: 80px;
     height: 2px;
-    background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+    background: linear-gradient(90deg, var(--blue-500), var(--purple-500));
     margin-top: 72px;
 }
 
@@ -2030,7 +2030,7 @@ a {
    ======================================== */
 .mobile-section {
     padding: 120px 0;
-    background: white;
+    background: var(--white);
     overflow: hidden;
 }
 
@@ -2057,10 +2057,10 @@ a {
 .mobile-phone {
     position: absolute;
     width: 240px;
-    background: linear-gradient(145deg, #1e293b, #0f172a);
+    background: linear-gradient(145deg, var(--gray-800), var(--gray-900));
     border-radius: 32px;
     padding: 8px;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 25px 50px -12px var(--overlay-medium);
 }
 
 .mobile-phone.phone-1 {
@@ -2078,7 +2078,7 @@ a {
 }
 
 .mobile-phone-screen {
-    background: white;
+    background: var(--white);
     border-radius: 26px;
     overflow: hidden;
     aspect-ratio: 9/17;
@@ -2093,7 +2093,7 @@ a {
 .mobile-screen-placeholder {
     width: 100%;
     height: 100%;
-    background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+    background: linear-gradient(180deg, var(--gray-50) 0%, var(--gray-200) 100%);
     display: flex;
     flex-direction: column;
     padding: 20px;
@@ -2109,12 +2109,12 @@ a {
 .mobile-screen-logo {
     width: 32px;
     height: 32px;
-    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
     border-radius: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: var(--white);
     font-weight: 700;
     font-size: 14px;
 }
@@ -2132,15 +2132,15 @@ a {
 }
 
 .mobile-stat-card {
-    background: white;
+    background: var(--white);
     border-radius: 12px;
     padding: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px var(--shadow-sm);
 }
 
 .mobile-stat-card .stat-label {
     font-size: 10px;
-    color: #64748b;
+    color: var(--gray-500);
     display: block;
     margin-bottom: 4px;
 }
@@ -2151,15 +2151,15 @@ a {
 }
 
 .mobile-stat-card .stat-value.positive {
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 .mobile-screen-chart {
     flex: 1;
-    background: white;
+    background: var(--white);
     border-radius: 12px;
     padding: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px var(--shadow-sm);
 }
 
 .mobile-chart-title {
@@ -2177,7 +2177,7 @@ a {
 
 .mobile-chart-bar {
     flex: 1;
-    background: linear-gradient(180deg, #3b82f6 0%, #1d4ed8 100%);
+    background: linear-gradient(180deg, var(--blue-500) 0%, var(--blue-700) 100%);
     border-radius: 4px 4px 0 0;
     min-height: 20px;
 }
@@ -2210,12 +2210,12 @@ a {
 .mobile-feature-icon {
     width: 48px;
     height: 48px;
-    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+    background: linear-gradient(135deg, var(--blue-100), var(--blue-200));
     border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #1d4ed8;
+    color: var(--blue-700);
     flex-shrink: 0;
 }
 
@@ -2226,7 +2226,7 @@ a {
 
 .mobile-feature-text p {
     font-size: 0.95rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin: 0;
 }
 
@@ -2235,7 +2235,7 @@ a {
    ======================================== */
 .security-section {
     padding: 120px 0;
-    background: #f8fafc;
+    background: var(--gray-50);
 }
 
 .security-content {
@@ -2269,12 +2269,12 @@ a {
 .security-icon {
     width: 48px;
     height: 48px;
-    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+    background: linear-gradient(135deg, var(--blue-100), var(--blue-200));
     border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #1d4ed8;
+    color: var(--blue-700);
     flex-shrink: 0;
 }
 
@@ -2285,7 +2285,7 @@ a {
 
 .security-detail p {
     font-size: 0.95rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin: 0;
 }
 
@@ -2303,7 +2303,7 @@ a {
 .shield-svg {
     width: 100%;
     height: auto;
-    filter: drop-shadow(0 20px 40px rgba(59, 130, 246, 0.3));
+    filter: drop-shadow(0 20px 40px var(--blue-alpha-30));
 }
 
 /* ========================================
@@ -2311,7 +2311,7 @@ a {
    ======================================== */
 .pricing-section {
     padding: 60px 0 120px 0;
-    background: #f8fafc;
+    background: var(--gray-50);
 }
 
 .pricing-grid {
@@ -2323,10 +2323,10 @@ a {
 }
 
 .pricing-card {
-    background: white;
+    background: var(--white);
     border-radius: 24px;
     padding: 32px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--gray-200);
     position: relative;
     transition: all 0.3s ease;
     display: flex;
@@ -2339,11 +2339,11 @@ a {
 
 .pricing-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 20px 40px var(--shadow-default);
 }
 
 .pricing-card.ai-card {
-    border: 2px solid #8b5cf6;
+    border: 2px solid var(--purple-500);
 }
 
 .pricing-header {
@@ -2353,8 +2353,8 @@ a {
 
 .pricing-tag {
     display: inline-block;
-    background: #f1f5f9;
-    color: #64748b;
+    background: var(--gray-100);
+    color: var(--gray-500);
     padding: 6px 12px;
     border-radius: 50px;
     font-size: 0.8rem;
@@ -2363,8 +2363,8 @@ a {
 }
 
 .pricing-tag.ai {
-    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
-    color: white;
+    background: linear-gradient(135deg, var(--purple-500), var(--purple-600));
+    color: var(--white);
 }
 
 .pricing-amount {
@@ -2374,7 +2374,7 @@ a {
 .pricing-amount .currency {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #64748b;
+    color: var(--gray-500);
     vertical-align: top;
 }
 
@@ -2386,20 +2386,20 @@ a {
 
 .pricing-amount .period {
     font-size: 1rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin-left: 4px;
 }
 
 .pricing-alt {
     font-size: 0.9rem;
-    color: #8b5cf6;
+    color: var(--purple-500);
     font-weight: 600;
     margin-bottom: 8px;
 }
 
 .pricing-description {
     font-size: 0.95rem;
-    color: #64748b;
+    color: var(--gray-500);
 }
 
 .pricing-features {
@@ -2413,7 +2413,7 @@ a {
     align-items: center;
     gap: 12px;
     padding: 12px 0;
-    border-bottom: 1px solid #f1f5f9;
+    border-bottom: 1px solid var(--gray-100);
     font-size: 0.95rem;
 }
 
@@ -2422,7 +2422,7 @@ a {
 }
 
 .pricing-features li svg {
-    color: #10b981;
+    color: var(--emerald-500);
     flex-shrink: 0;
 }
 
@@ -2438,7 +2438,7 @@ a {
    ======================================== */
 .contact-section {
     padding: 80px 0;
-    background: #f8fafc;
+    background: var(--gray-50);
     overflow: hidden;
 }
 
@@ -2455,7 +2455,7 @@ a {
 
 .contact-header p {
     font-size: 1.15rem;
-    color: #64748b;
+    color: var(--gray-500);
     max-width: 500px;
     margin: 0 auto;
 }
@@ -2469,23 +2469,23 @@ a {
 }
 
 .contact-card {
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     padding: 32px;
     text-align: center;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 4px 20px var(--shadow-sm);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .contact-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 12px 32px var(--shadow-default);
 }
 
 .contact-icon {
     width: 56px;
     height: 56px;
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    background: linear-gradient(135deg, var(--blue-50), var(--blue-100));
     border-radius: 14px;
     display: flex;
     align-items: center;
@@ -2496,31 +2496,31 @@ a {
 .contact-icon svg {
     width: 28px;
     height: 28px;
-    color: #3b82f6;
+    color: var(--blue-500);
 }
 
 .contact-icon.feedback {
-    background: linear-gradient(135deg, #f5f3ff, #ede9fe);
+    background: linear-gradient(135deg, var(--purple-50-alt), var(--ede9fe));
 }
 
 .contact-icon.feedback svg {
-    color: #8b5cf6;
+    color: var(--purple-500);
 }
 
 .contact-icon.community {
-    background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+    background: linear-gradient(135deg, var(--emerald-50), var(--emerald-100));
 }
 
 .contact-icon.community svg {
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 .contact-icon.docs {
-    background: linear-gradient(135deg, #fef3c7, #fde68a);
+    background: linear-gradient(135deg, var(--amber-100), var(--fde68a));
 }
 
 .contact-icon.docs svg {
-    color: #d97706;
+    color: var(--amber-600);
 }
 
 .contact-card h3 {
@@ -2530,7 +2530,7 @@ a {
 
 .contact-card p {
     font-size: 0.95rem;
-    color: #64748b;
+    color: var(--gray-500);
     margin-bottom: 16px;
     line-height: 1.6;
 }
@@ -2539,7 +2539,7 @@ a {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    color: #3b82f6;
+    color: var(--blue-500);
     font-weight: 500;
     font-size: 0.95rem;
     text-decoration: none;
@@ -2561,15 +2561,15 @@ a {
 .contact-cta {
     text-align: center;
     padding: 32px;
-    background: white;
+    background: var(--white);
     border-radius: 16px;
     max-width: 400px;
     margin: 0 auto;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 4px 20px var(--shadow-sm);
 }
 
 .contact-cta p {
-    color: #64748b;
+    color: var(--gray-500);
     margin-bottom: 16px;
     font-size: 1rem;
 }
@@ -2646,8 +2646,8 @@ a {
     left: 0;
     right: 0;
     bottom: 0;
-    background: radial-gradient(circle at 30% 50%, rgba(59, 130, 246, 0.15), transparent 50%),
-                radial-gradient(circle at 70% 50%, rgba(139, 92, 246, 0.15), transparent 50%);
+    background: radial-gradient(circle at 30% 50%, var(--blue-alpha-15), transparent 50%),
+                radial-gradient(circle at 70% 50%, var(--purple-alpha-15), transparent 50%);
     pointer-events: none;
 }
 
@@ -2666,14 +2666,14 @@ a {
 
 .cta-content h2 {
     font-size: 3rem;
-    color: white;
+    color: var(--white);
     margin-bottom: 16px;
     letter-spacing: -0.02em;
 }
 
 .cta-content > p {
     font-size: 1.25rem;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--white-alpha-80);
     margin-bottom: 40px;
 }
 
@@ -2695,12 +2695,12 @@ a {
     display: flex;
     align-items: center;
     gap: 8px;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--white-alpha-80);
     font-size: 0.9rem;
 }
 
 .cta-feature svg {
-    color: #10b981;
+    color: var(--emerald-500);
 }
 
 /* ========================================

--- a/whats-new/style.css
+++ b/whats-new/style.css
@@ -99,7 +99,7 @@ header .header-inner .menu-container .menu .whats-new:after {
 
 .hero .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 8px 20px var(--blue-alpha-30);
 }
 
 .hero .btn-secondary:hover {
@@ -142,13 +142,13 @@ header .header-inner .menu-container .menu .whats-new:after {
   border-radius: 16px;
   padding: 24px;
   line-height: 1.6;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-sm);
   border: 1px solid var(--gray-border);
   transition: box-shadow 0.2s ease;
 }
 
 .version-card:hover {
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 30px var(--shadow);
 }
 
 .version-card:first-child {


### PR DESCRIPTION
## Summary
This PR systematically replaces hardcoded color values throughout the codebase with CSS custom properties (CSS variables) defined in `custom-colors.css`. This improves maintainability, consistency, and enables easier theme switching.

## Key Changes
- **Color variable definitions**: Added 160+ new CSS custom properties to `custom-colors.css` including:
  - Basic colors (black, white, neutrals)
  - Color variants (blue, emerald, red, purple, pink, cyan, gray shades)
  - Shadow and overlay variables with opacity levels
  - Alpha channel variants for white, blue, and purple
  - Semantic color names (e.g., `--shadow-default`, `--overlay-light`)

- **Stylesheet updates**: Replaced hardcoded hex/rgba values with variables across:
  - Admin panel styles (`admin/common-style.css`, `admin/payments/style.css`, etc.)
  - Main site styles (`style.css`, `documentation/style.css`)
  - Component styles (buttons, cards, tables, badges, alerts)
  - Community and portal styles
  - Email templates

- **Consistent naming**: Established naming conventions for variables:
  - Color-based: `--{color}-{shade}` (e.g., `--blue-500`, `--gray-200`)
  - Semantic: `--shadow-default`, `--overlay-light`, `--white-alpha-80`
  - Fallback patterns: `var(--variable, fallback-value)`

## Implementation Details
- All color replacements maintain visual consistency with original hardcoded values
- Variables are organized by color family in `custom-colors.css`
- Fallback values provided where appropriate for backward compatibility
- Shadow and overlay opacity levels standardized (0.04 to 0.6)
- White alpha variants range from 0.05 to 0.96 opacity

https://claude.ai/code/session_01F45iVmmwX28RASbPrTW51j