### PR TITLE
Add CTA buttons to honest take sections across comparison pages

### DIFF
--- a/compare/argo-books-vs-freshbooks/index.php
+++ b/compare/argo-books-vs-freshbooks/index.php
@@ -318,6 +318,10 @@
                 <h3>An honest take</h3>
                 <p>FreshBooks excels at invoicing, time tracking, and client management — especially for freelancers and service-based businesses. If those are your core needs, FreshBooks is a great tool.</p>
                 <p>But if you're a product-based small business that needs inventory management, offline access, and straightforward finance tracking without paying $26+ CAD/month, Argo Books is built for you.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/argo-books-vs-odoo/index.php
+++ b/compare/argo-books-vs-odoo/index.php
@@ -312,6 +312,10 @@
                 <h3>An honest take</h3>
                 <p>Odoo is a powerful, full-featured ERP platform with CRM, HR, manufacturing, e-commerce, and hundreds of other modules. If your business needs an all-in-one enterprise system, Odoo is hard to beat.</p>
                 <p>But if you're a small business that just needs straightforward finance management, inventory tracking, and invoicing without configuring an entire ERP — Argo Books gets you there in minutes, not weeks.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/argo-books-vs-quickbooks/index.php
+++ b/compare/argo-books-vs-quickbooks/index.php
@@ -327,6 +327,10 @@
                 <span class="section-label">An Honest Take</span>
                 <h2>QuickBooks is powerful — but is it right for you?</h2>
                 <p class="section-desc">QuickBooks is a mature platform with payroll, tax filing, and hundreds of integrations. If your business needs those features today, it's a solid choice. But as a publicly traded company, Intuit's priorities don't always align with small business owners — and it shows in the rising prices, aggressive feature gating, and complexity you don't need. Argo Books is built for you. Simple pricing, no upsells, and every feature included in one plan.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/argo-books-vs-wave/index.php
+++ b/compare/argo-books-vs-wave/index.php
@@ -309,6 +309,10 @@
                 <h3>An honest take</h3>
                 <p>Wave is an excellent free option for freelancers and service-based businesses that need invoicing, basic accounting, and bank transaction imports. If those are your core needs, Wave is a solid choice.</p>
                 <p>But if you sell physical products and need inventory management, offline access, predictive analytics, or biometric security — features Wave doesn't offer — Argo Books is built for you.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/argo-books-vs-xero/index.php
+++ b/compare/argo-books-vs-xero/index.php
@@ -324,6 +324,10 @@
                 <h3>An honest take</h3>
                 <p>Xero is a polished, globally popular platform with strong app integrations, unlimited users on every plan, and a clean UI. If your business already works with an accountant or needs deep third-party integrations, Xero is a solid choice.</p>
                 <p>But if you're a small business owner who wants an app that is really easy to use, with offline access, local data storage, and straightforward finance management without paying $55+/month for unlimited invoices — Argo Books is built for you.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/argo-books-vs-zipbooks/index.php
+++ b/compare/argo-books-vs-zipbooks/index.php
@@ -306,6 +306,10 @@
                 <h3>An honest take</h3>
                 <p>ZipBooks was acquired by Divvy, which was later acquired by BILL Holdings, and since the acquisitions, the product appears to have little active development or support. Users have reported issues with bugs, missing features, and difficulty reaching customer service — raising concerns about the long-term viability of the platform.</p>
                 <p>If you're looking for a simple bookkeeping tool that's actively maintained, Argo Books offers AI receipt scanning, predictive analytics, inventory management, and local data storage at a lower premium price — plus offline access so you're never locked out of your own data.</p>
+                <a href="../../downloads/" class="btn-cta btn-cta-primary honest-take-cta">
+                    <span>Get Started Now</span>
+                    <?= svg_icon('arrow-right', 18) ?>
+                </a>
             </div>
         </div>
     </section>

--- a/compare/style.css
+++ b/compare/style.css
@@ -566,8 +566,16 @@ body {
   margin: 0 0 12px;
 }
 
-.honest-card p:last-child {
+.honest-card p:last-of-type {
   margin-bottom: 0;
+}
+
+.honest-take-cta {
+  margin-top: 24px;
+}
+
+.honest-take-alt .honest-take-cta {
+  margin-top: 28px;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
Added "Get Started Now" call-to-action buttons to the "honest take" sections across all product comparison pages, with corresponding styling updates to support the new component.

## Key Changes
- **CSS Updates** (`compare/style.css`):
  - Changed `.honest-card p:last-child` to `.honest-card p:last-of-type` for more robust selector specificity
  - Added `.honest-take-cta` class with 24px top margin for standard spacing
  - Added `.honest-take-alt .honest-take-cta` variant with 28px top margin for alternative layout

- **Comparison Pages** - Added identical CTA button markup to 6 comparison pages:
  - `argo-books-vs-freshbooks/index.php`
  - `argo-books-vs-odoo/index.php`
  - `argo-books-vs-quickbooks/index.php`
  - `argo-books-vs-wave/index.php`
  - `argo-books-vs-xero/index.php`
  - `argo-books-vs-zipbooks/index.php`

## Implementation Details
- Each CTA button links to `../../downloads/` with primary button styling
- Button includes an arrow-right icon (18px) for visual emphasis
- Consistent placement after the second paragraph in each honest take section
- Spacing adjustments account for both standard and alternative layout variants

https://claude.ai/code/session_01TBJSUmL4xV4Vr6bGx8a8pM