### PR TITLE
Add yearly pricing and savings display to premium plan API

### DIFF
--- a/api/pricing/plans.php
+++ b/api/pricing/plans.php
@@ -13,11 +13,15 @@ require_once __DIR__ . '/../../config/pricing.php';
 
 $pricing = get_pricing_config();
 $monthlyPrice = $pricing['premium_monthly_price'];
+$yearlyPrice = $pricing['premium_yearly_price'];
+$yearlySavings = ($monthlyPrice * 12) - $yearlyPrice;
 $currency = $pricing['currency'];
 
 echo json_encode([
     'premium' => [
         'price_display' => '$' . number_format($monthlyPrice, 0) . ' ' . $currency,
         'billing_period' => '/month',
+        'yearly_price_display' => '$' . number_format($yearlyPrice, 0),
+        'yearly_savings_display' => '$' . number_format($yearlySavings, 0),
     ],
 ]);


### PR DESCRIPTION
## Summary
Extended the pricing API endpoint to include yearly billing option information alongside the existing monthly pricing display.

## Key Changes
- Added retrieval of yearly price from pricing configuration
- Calculated yearly savings amount (difference between 12 months of monthly billing vs annual billing)
- Extended API response to include:
  - `yearly_price_display`: Formatted yearly price
  - `yearly_savings_display`: Formatted savings amount when choosing yearly billing

## Implementation Details
- Yearly savings is calculated as: (monthly_price × 12) - yearly_price
- All price values are formatted consistently using `number_format()` with currency symbol
- The changes maintain backward compatibility by adding new fields without modifying existing ones

https://claude.ai/code/session_01Q8tkjtJUPEDVRAhni4mCoy