### PR TITLE
Add configurable reply-to email address for styled emails

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -843,7 +843,7 @@ function send_outreach_email($pdo)
     // Format body for HTML email (convert newlines to <br>)
     $htmlBody = '<p>' . nl2br(htmlspecialchars($lead['draft_body'])) . '</p>';
 
-    $result = send_styled_email($lead['email'], $lead['draft_subject'], $htmlBody, '', 'contact@argorobots.com', 'Argo Books');
+    $result = send_styled_email($lead['email'], $lead['draft_subject'], $htmlBody, '', 'contact@argorobots.com', 'Argo Books', 'contact@argorobots.com');
 
     if ($result) {
         $stmt = $pdo->prepare("UPDATE outreach_leads SET

--- a/email_sender.php
+++ b/email_sender.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/smtp_mailer.php';
  * @param string $header_style Optional custom header style (default: blue gradient)
  * @return bool True if successful, false otherwise
  */
-function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null)
+function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null)
 {
     $css = file_get_contents(__DIR__ . '/email.css');
 
@@ -62,7 +62,7 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
                 $mailer->setFrom($from_email, $from_name ?? 'Argo Books');
             }
             $mailer->addAddress($to_email);
-            $mailer->addReplyTo('support@argorobots.com');
+            $mailer->addReplyTo($reply_to ?? 'support@argorobots.com');
             $mailer->Subject = $subject;
             $mailer->Body = $email_html;
             $mailer->send();
@@ -78,7 +78,7 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
         'MIME-Version: 1.0',
         'Content-Type: text/html; charset=UTF-8',
         'From: ' . $actualFrom,
-        'Reply-To: support@argorobots.com',
+        'Reply-To: ' . ($reply_to ?? 'support@argorobots.com'),
         'X-Mailer: PHP/' . phpversion()
     ];
 


### PR DESCRIPTION
## Summary
This PR adds support for configurable reply-to email addresses in the `send_styled_email()` function, allowing callers to specify a custom reply-to address instead of always defaulting to 'support@argorobots.com'.

## Key Changes
- Added optional `$reply_to` parameter to `send_styled_email()` function signature with null default
- Updated PHPMailer implementation to use the provided reply-to address or fall back to 'support@argorobots.com'
- Updated native PHP mail headers to use the provided reply-to address or fall back to 'support@argorobots.com'
- Updated outreach email sending to explicitly set reply-to as 'contact@argorobots.com' for outreach campaigns

## Implementation Details
The `$reply_to` parameter is optional and defaults to null. When null, the function maintains backward compatibility by using 'support@argorobots.com' as the reply-to address. This change applies to both the PHPMailer and native PHP mail implementations within the function.

https://claude.ai/code/session_017kvxEdmDR9ddHtWajdgcVB