### PR TITLE
Add company size filter to outreach leads

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -127,6 +127,7 @@ function get_leads($pdo)
 {
     $status = $_GET['status'] ?? '';
     $response_status = $_GET['response_status'] ?? '';
+    $company_size = $_GET['company_size'] ?? '';
     $search = $_GET['search'] ?? '';
     $sort = $_GET['sort'] ?? 'date_added_desc';
 
@@ -140,6 +141,13 @@ function get_leads($pdo)
     if ($response_status) {
         $where[] = 'response_status = ?';
         $params[] = $response_status;
+    }
+    if ($company_size === 'exclude_large') {
+        $where[] = 'company_size != ?';
+        $params[] = 'large';
+    } elseif ($company_size) {
+        $where[] = 'company_size = ?';
+        $params[] = $company_size;
     }
     if ($search) {
         $where[] = '(business_name LIKE ? OR email LIKE ? OR contact_name LIKE ? OR city LIKE ? OR category LIKE ?)';
@@ -240,7 +248,7 @@ function update_lead($pdo)
 
     $fields = [
         'business_name', 'contact_name', 'email', 'phone', 'website', 'address',
-        'category', 'city', 'source', 'status', 'response_status',
+        'category', 'city', 'source', 'status', 'response_status', 'company_size',
         'notes', 'feedback_summary', 'offer_sent',
         'draft_subject', 'draft_body', 'contact_page_url',
         'first_contact_date', 'last_contact_date',
@@ -897,7 +905,7 @@ function export_csv($pdo)
     $output = fopen('php://output', 'w');
 
     $headers = ['ID', 'Business Name', 'Contact Name', 'Email', 'Phone', 'Website', 'Address',
-        'Category', 'City', 'Source', 'Status', 'Response Status',
+        'Category', 'City', 'Source', 'Status', 'Response Status', 'Company Size',
         'Date Added', 'First Contact', 'Last Contact', 'Offer Sent',
         'Notes', 'Feedback Summary', 'Draft Subject', 'Draft Body'];
     fputcsv($output, $headers);
@@ -907,6 +915,7 @@ function export_csv($pdo)
             $lead['id'], $lead['business_name'], $lead['contact_name'], $lead['email'],
             $lead['phone'], $lead['website'], $lead['address'], $lead['category'],
             $lead['city'], $lead['source'], $lead['status'], $lead['response_status'],
+            $lead['company_size'] ?? 'unknown',
             $lead['date_added'], $lead['first_contact_date'],
             $lead['last_contact_date'], $lead['offer_sent'],
             $lead['notes'], $lead['feedback_summary'], $lead['draft_subject'], $lead['draft_body'],

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -602,6 +602,9 @@ function import_leads($pdo)
 {
     $data = json_decode(file_get_contents('php://input'), true);
     $businesses = $data['businesses'] ?? [];
+    $companySize = $data['company_size'] ?? 'unknown';
+    $validSizes = ['unknown', 'small', 'medium', 'large'];
+    if (!in_array($companySize, $validSizes)) $companySize = 'unknown';
 
     if (empty($businesses)) {
         json_response(['success' => false, 'message' => 'No businesses to import'], 400);
@@ -623,8 +626,8 @@ function import_leads($pdo)
             }
 
             $stmt = $pdo->prepare("INSERT INTO outreach_leads
-                (business_name, phone, website, address, category, city, source, places_id, contact_page_url, email)
-                VALUES (?, ?, ?, ?, ?, ?, 'google_places', ?, ?, ?)");
+                (business_name, phone, website, address, category, city, source, places_id, contact_page_url, email, company_size)
+                VALUES (?, ?, ?, ?, ?, ?, 'google_places', ?, ?, ?, ?)");
             $stmt->execute([
                 $biz['business_name'] ?? 'Unknown',
                 $biz['phone'] ?? null,
@@ -635,6 +638,7 @@ function import_leads($pdo)
                 $biz['places_id'] ?? null,
                 $biz['contact_page_url'] ?? null,
                 $biz['email'] ?? null,
+                $companySize,
             ]);
 
             $id = $pdo->lastInsertId();

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -164,6 +164,17 @@ include '../admin_header.php';
                 </select>
             </div>
             <div class="filter-group">
+                <label for="filterSize">Company Size</label>
+                <select id="filterSize" onchange="loadLeads()">
+                    <option value="">All</option>
+                    <option value="small">Small</option>
+                    <option value="medium">Medium</option>
+                    <option value="large">Large</option>
+                    <option value="unknown">Unknown</option>
+                    <option value="exclude_large">Exclude Large</option>
+                </select>
+            </div>
+            <div class="filter-group">
                 <label for="filterSort">Sort</label>
                 <select id="filterSort" onchange="loadLeads()">
                     <option value="date_added_desc">Newest First</option>
@@ -291,6 +302,15 @@ include '../admin_header.php';
                         <select id="detailOfferSent">
                             <option value="0">No</option>
                             <option value="1">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Company Size</label>
+                        <select id="detailCompanySize">
+                            <option value="unknown">Unknown</option>
+                            <option value="small">Small</option>
+                            <option value="medium">Medium</option>
+                            <option value="large">Large</option>
                         </select>
                     </div>
                     <div class="form-group">

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -94,6 +94,13 @@ include '../admin_header.php';
             <div class="discovery-actions">
                 <span id="discoveryCount">0 results</span>
                 <div>
+                    <label for="discCompanySize" style="margin-right:4px;">Tag size:</label>
+                    <select id="discCompanySize" style="margin-right:8px;">
+                        <option value="unknown">Unknown</option>
+                        <option value="small">Small</option>
+                        <option value="medium">Medium</option>
+                        <option value="large">Large</option>
+                    </select>
                     <button class="btn btn-small btn-blue" onclick="selectAllDiscovery()">Select All</button>
                     <button class="btn btn-small btn-blue" onclick="deselectAllDiscovery()">Deselect All</button>
                     <button class="btn btn-small btn-blue" onclick="importSelected()">Import Selected</button>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -13,11 +13,13 @@ function updateUrlParams() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
+    const size = document.getElementById('filterSize').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.set('search', search);
     if (status) params.set('status', status);
     if (response) params.set('response', response);
+    if (size) params.set('size', size);
     if (sort && sort !== 'date_added_desc') params.set('sort', sort);
 
     const newUrl = params.toString()
@@ -31,6 +33,7 @@ function restoreFiltersFromUrl() {
     if (params.has('search')) document.getElementById('filterSearch').value = params.get('search');
     if (params.has('status')) document.getElementById('filterStatus').value = params.get('status');
     if (params.has('response')) document.getElementById('filterResponse').value = params.get('response');
+    if (params.has('size')) document.getElementById('filterSize').value = params.get('size');
     if (params.has('sort')) document.getElementById('filterSort').value = params.get('sort');
 }
 
@@ -154,11 +157,13 @@ async function loadLeads() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
+    const size = document.getElementById('filterSize').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.search = search;
     if (status) params.status = status;
     if (response) params.response_status = response;
+    if (size) params.company_size = size;
     if (sort) params.sort = sort;
 
     // Persist filters to URL
@@ -439,6 +444,7 @@ async function openLeadDetail(id) {
         document.getElementById('detailResponseStatus').value = lead.response_status || 'no_response';
 
         document.getElementById('detailOfferSent').value = lead.offer_sent ? '1' : '0';
+        document.getElementById('detailCompanySize').value = lead.company_size || 'unknown';
         document.getElementById('detailContactPageUrl').value = lead.contact_page_url || '';
         document.getElementById('detailNotes').value = lead.notes || '';
         document.getElementById('detailFeedback').value = lead.feedback_summary || '';
@@ -534,6 +540,7 @@ async function saveLeadDetails() {
         response_status: document.getElementById('detailResponseStatus').value,
 
         offer_sent: document.getElementById('detailOfferSent').value,
+        company_size: document.getElementById('detailCompanySize').value,
         contact_page_url: document.getElementById('detailContactPageUrl').value,
         notes: document.getElementById('detailNotes').value,
         feedback_summary: document.getElementById('detailFeedback').value,

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -722,7 +722,8 @@ async function importAll() {
 
 async function doImport(businesses) {
     try {
-        const result = await api('import_leads', { method: 'POST', body: { businesses } });
+        const companySize = document.getElementById('discCompanySize').value || 'unknown';
+        const result = await api('import_leads', { method: 'POST', body: { businesses, company_size: companySize } });
         notify(result.message, result.success ? 'success' : 'error');
         if (result.success) {
             loadLeads();

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -576,6 +576,7 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     approved_at DATETIME DEFAULT NULL,
     sent_at DATETIME DEFAULT NULL,
     contact_page_url VARCHAR(500) DEFAULT NULL,
+    company_size ENUM('unknown','small','medium','large') DEFAULT 'unknown',
     places_id VARCHAR(255) DEFAULT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX idx_outreach_status (status),


### PR DESCRIPTION
## Summary
- Adds a `company_size` enum field (`unknown`, `small`, `medium`, `large`) to the `outreach_leads` table
- Adds a "Company Size" filter dropdown to the outreach page with an **"Exclude Large"** option to filter out large companies
- Adds a Company Size selector to the lead detail modal so you can tag each lead's size
- Includes the field in CSV exports and the update API

## How to use
1. Run the DB migration to add the column: `ALTER TABLE outreach_leads ADD COLUMN company_size ENUM('unknown','small','medium','large') DEFAULT 'unknown' AFTER contact_page_url;`
2. Tag leads with their company size in the lead detail modal
3. Use the "Exclude Large" filter option to hide large companies from the list

## Test plan
- [ ] Run the ALTER TABLE migration on the database
- [ ] Verify the Company Size filter dropdown appears on the outreach page
- [ ] Set a lead's company size to "large" and confirm "Exclude Large" filter hides it
- [ ] Verify company size is saved/loaded correctly in the lead detail modal
- [ ] Verify CSV export includes the company size column

https://claude.ai/code/session_016qu7AQoCHYp2C3S5pYjEfJ