### PR TITLE
Add company size filter with AI classification to outreach

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -959,7 +959,7 @@ Return ONLY the JSON, no other text.";
     }
 
     // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','ready_to_contact','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
+    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
     $stmt->execute([$parsed['subject'], $parsed['body'], $id]);
 
     log_activity($pdo, $id, 'draft_generated', 'AI draft generated');

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -796,7 +796,12 @@ function summarize_business($website)
     if (strlen($text) < 50) return null;
 
     $result = call_openai(
-        "You summarize businesses based on their website content. Respond with ONLY a 1-2 sentence summary describing what the business does, what services or products they offer, and who their customers are. Be specific and factual. Do not include any other text.",
+        "You summarize businesses based on their website content. Respond with ONLY a concise summary (3-5 sentences) covering:
+1. What specific services or products they offer
+2. Who their typical customers are
+3. How they likely handle billing (e.g. do they invoice clients, do project quotes, charge hourly, sell products, etc.)
+4. Any pain points a simple bookkeeping/invoicing tool could solve for them (e.g. tracking job expenses, sending invoices, managing payments)
+Be specific and factual based on the website content. Do not include any other text or preamble.",
         "Website content from $website:\n\n$text"
     );
 
@@ -826,6 +831,17 @@ function generate_draft($pdo)
         }
     }
 
+    $isLocal = false;
+    $city = strtolower(trim($lead['city'] ?? ''));
+    $province = strtolower(trim($lead['province'] ?? ''));
+    if ($province === 'saskatchewan' || $province === 'sk' || in_array($city, ['saskatoon','regina','prince albert','moose jaw','swift current','yorkton','north battleford','estevan','weyburn','martensville','warman','humboldt','melfort','meadow lake','lloydminster'])) {
+        $isLocal = true;
+    }
+
+    $localInstruction = $isLocal
+        ? "- The business is in Saskatchewan. Evan is a local Saskatchewan developer based in Saskatoon. ALWAYS mention being local, e.g. \"I'm a local Saskatoon developer\" or \"As a fellow Saskatchewan business\". This local connection is important, make it feel personal."
+        : "- Evan is an independent software developer based in Saskatoon, Saskatchewan. Mention this briefly for context.";
+
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
 
 About Argo Books:
@@ -837,16 +853,26 @@ About Argo Books:
 Rules:
 - Keep it very short (2-3 short paragraphs max, under 100 words ideally)
 - Sound human, friendly, and genuine, not like marketing spam
-- Briefly describe Argo Books as a simpler alternative to QuickBooks that requires no accounting knowledge. Do NOT just say \"check it out\" without explaining what it is
-- The sender's name is Evan, he is a local independent software developer based in Saskatoon building software for small businesses. Always mention that Evan is a local Saskatoon software developer in the email body
+$localInstruction
 - Do NOT refer to a \"team\", Evan is a solo developer
 - Get to the point quickly in the first sentence - say why you are emailing. Do NOT open with generic filler like \"I hope this message finds you well\" or vague flattery like \"I admire your work\"
 - Use the business name in the greeting (e.g. \"Hi LVM Landscaping\" or \"Hi [contact name]\" if available)
+
+PERSONALIZATION (this is critical):
+- If a business summary is provided, you MUST use it to make the email specific to their business. Do not write a generic email when you have summary info
+- Connect Argo Books features directly to their business needs. Examples:
+  - If they do services/contracting: mention how easy it is to invoice clients after a job
+  - If they sell products: mention simple expense tracking and bookkeeping
+  - If they likely deal with quotes/estimates: mention invoicing features
+  - If they have multiple revenue streams: mention how it keeps everything organized without accounting knowledge
+- Reference their actual business type naturally (e.g. \"I know running a landscaping business means a lot of invoicing\" not just \"I see you run a business\")
+- Only reference Argo Books features that are relevant to what they do. Do not list every feature
+- Do NOT invent details about the business you do not have
+- If no summary is available, keep it more general but still mention their industry/category if known
+
+- Briefly describe Argo Books as a simpler alternative to QuickBooks that requires no accounting knowledge. Do NOT just say \"check it out\" without explaining what it is
 - Mention you are looking for honest feedback from small business owners
 - If appropriate, mention offering a free 1-year premium license in exchange for feedback
-- If a business summary is provided, use it to personalize the email. For example if they likely send invoices, mention the invoicing feature. If they do services, mention expense tracking. Only reference features that are relevant to their business
-- Do NOT invent details about the business you do not have
-- If limited info is available, keep it more general rather than making up praise
 - Use a casual but professional tone
 - NEVER use placeholders like [Your Name], [Your Title], [Your Company], etc.
 - Include a link to the website: https://argorobots.com/
@@ -863,6 +889,7 @@ Return ONLY the JSON, no other text.";
     $details = "Business: {$lead['business_name']}";
     if ($lead['category']) $details .= "\nCategory/Industry: {$lead['category']}";
     if ($lead['city']) $details .= "\nCity: {$lead['city']}";
+    if ($isLocal) $details .= "\nLocal: Yes, this business is in Saskatchewan (same province as Evan)";
     if ($lead['website']) $details .= "\nWebsite: {$lead['website']}";
     if ($lead['contact_name']) $details .= "\nContact person: {$lead['contact_name']}";
     if ($summary) $details .= "\nBusiness summary: $summary";

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -878,6 +878,7 @@ PERSONALIZATION (this is critical):
 - ALWAYS include the website link https://argorobots.com/ in the email body. This is required in every single email, no exceptions
 - NEVER use em dashes in the email. Use commas, periods, or regular hyphens instead
 - The subject line should be about the recipient's business, NOT about Argo Books. Make it feel personal and curiosity-driven (e.g. \"Quick question about [business name]\", \"Thought of you guys\")
+- You MUST include the line \"You can check it out here: https://argorobots.com/\" (or similar natural phrasing with that exact URL) somewhere in the email body, ideally after mentioning what Argo Books is
 - End the email body with a line like \"Feel free to reply to this email if you have any questions!\" or similar, before the sign-off
 - Always sign off with three separate lines: \"All the best,\" then \"Evan\" then \"Argo Books\" (each on its own line, separated by \\n)
 
@@ -913,6 +914,25 @@ Return ONLY the JSON, no other text.";
             'subject' => "Quick question for {$lead['business_name']}",
             'body' => $content,
         ];
+    }
+
+    // Ensure the website URL is in the body — inject before sign-off if AI omitted it
+    if (stripos($parsed['body'], 'argorobots.com') === false) {
+        $parsed['body'] = preg_replace(
+            '/(Feel free to|Don\'t hesitate|Let me know|Reply to this)/i',
+            "You can check it out here: https://argorobots.com/\n\n$1",
+            $parsed['body'],
+            1
+        );
+        // If regex didn't match, append before sign-off
+        if (stripos($parsed['body'], 'argorobots.com') === false) {
+            $parsed['body'] = preg_replace(
+                '/(\nAll the best)/i',
+                "\n\nYou can check it out here: https://argorobots.com/\n$1",
+                $parsed['body'],
+                1
+            );
+        }
     }
 
     // Save draft to lead

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -363,19 +363,42 @@ function scrape_email_from_website($url)
 
     $falsePositives = ['example.com', 'sentry.io', 'wixpress.com', 'wordpress.org', 'w3.org', 'schema.org', 'googleapis.com', 'gravatar.com'];
 
+    // Clean an extracted email: decode URL encoding, strip non-ASCII and whitespace
+    $cleanEmail = function($email) {
+        $email = urldecode($email);
+        // Strip any non-ASCII characters (emojis, special chars, zero-width spaces, etc.)
+        $email = preg_replace('/[^\x20-\x7E]/', '', $email);
+        $email = trim($email);
+        // Validate it still looks like an email after cleaning
+        if (preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $email)) {
+            return $email;
+        }
+        return null;
+    };
+
     // Helper to extract email from HTML
-    $extractEmail = function($html) use ($falsePositives) {
+    $extractEmail = function($html) use ($falsePositives, $cleanEmail) {
+        // URL-decode the HTML so mailto:%20info@... becomes mailto: info@...
+        $decodedHtml = urldecode($html);
+
         // Look for mailto: links first (most reliable)
-        if (preg_match_all('/mailto:([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/', $html, $matches)) {
-            foreach ($matches[1] as $email) {
+        if (preg_match_all('/mailto:\s*([^\s"\'<>]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/', $decodedHtml, $matches)) {
+            foreach ($matches[1] as $raw) {
+                $email = $cleanEmail($raw);
+                if (!$email) continue;
                 $dominated = false;
                 foreach ($falsePositives as $fp) { if (str_contains(strtolower($email), $fp)) { $dominated = true; break; } }
                 if (!$dominated) return $email;
             }
         }
-        // Fallback: email patterns in text
-        if (preg_match_all('/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/', $html, $matches)) {
-            foreach ($matches[0] as $email) {
+        // Fallback: email patterns in text (strip HTML tags first to avoid matching attributes)
+        $text = strip_tags($decodedHtml);
+        // Remove common non-ASCII clutter (emojis, zero-width chars) before matching
+        $text = preg_replace('/[^\x20-\x7E\n\r\t]/', ' ', $text);
+        if (preg_match_all('/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/', $text, $matches)) {
+            foreach ($matches[0] as $raw) {
+                $email = $cleanEmail($raw);
+                if (!$email) continue;
                 $dominated = false;
                 foreach ($falsePositives as $fp) { if (str_contains(strtolower($email), $fp)) { $dominated = true; break; } }
                 if (!$dominated) return $email;

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -875,7 +875,7 @@ PERSONALIZATION (this is critical):
 - If appropriate, mention offering a free 1-year premium license in exchange for feedback
 - Use a casual but professional tone
 - NEVER use placeholders like [Your Name], [Your Title], [Your Company], etc.
-- Include a link to the website: https://argorobots.com/
+- ALWAYS include the website link https://argorobots.com/ in the email body. This is required in every single email, no exceptions
 - NEVER use em dashes in the email. Use commas, periods, or regular hyphens instead
 - The subject line should be about the recipient's business, NOT about Argo Books. Make it feel personal and curiosity-driven (e.g. \"Quick question about [business name]\", \"Thought of you guys\")
 - End the email body with a line like \"Feel free to reply to this email if you have any questions!\" or similar, before the sign-off

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -449,6 +449,7 @@ function search_businesses()
     $province = trim($_GET['province'] ?? '');
     $category = trim($_GET['category'] ?? '');
     $limit = min(100, max(1, (int)($_GET['limit'] ?? 20)));
+    $excludePlaceIds = array_filter(explode(',', $_GET['exclude_place_ids'] ?? ''));
 
     if (empty($city)) {
         json_response(['success' => false, 'message' => 'City is required'], 400);
@@ -462,6 +463,10 @@ function search_businesses()
     $location = $province ? "$city, $province" : $city;
     $businesses = [];
     $seenPlaceIds = [];
+    // Pre-seed seen IDs so we skip businesses the client already has
+    foreach ($excludePlaceIds as $id) {
+        $seenPlaceIds[trim($id)] = true;
+    }
     $maxRounds = 5;
     $roundsUsed = 0;
 
@@ -512,6 +517,14 @@ function search_businesses()
         shuffle($categoryPool);
         for ($i = 0; $i < $maxRounds; $i++) {
             $queries[] = $categoryPool[$i] . " in $location";
+        }
+    }
+
+    // Track which pool category was searched per round (for labeling when no category provided)
+    $queryCategories = [];
+    if (!$category) {
+        foreach ($queries as $q) {
+            $queryCategories[] = ucwords(str_replace(" in $location", '', $q));
         }
     }
 
@@ -585,7 +598,7 @@ function search_businesses()
                     'places_id' => $placeId,
                     'business_name' => $place['name'] ?? '',
                     'address' => $place['formatted_address'] ?? '',
-                    'category' => $category ?: (isset($place['types'][0]) ? ucfirst(str_replace('_', ' ', $place['types'][0])) : ''),
+                    'category' => $category ?: ($queryCategories[$round] ?? (isset($place['types'][0]) ? ucfirst(str_replace('_', ' ', $place['types'][0])) : '')),
                     'city' => $city,
                     'phone' => null,
                     'website' => null,

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -480,23 +480,73 @@ function search_businesses()
         $queries[] = "$category companies in $location";
         $queries[] = "best $category in $location";
     } else {
-        $queries[] = "businesses in $location";
-        $queries[] = "services in $location";
-        $queries[] = "companies in $location";
-        $queries[] = "local businesses near $location";
-        $queries[] = "shops and services in $location";
+        // When no category provided, use a wide spread of real business categories
+        // so each round searches a different industry instead of generic synonyms
+        $categoryPool = [
+            'restaurants', 'plumbers', 'electricians', 'dentists', 'lawyers',
+            'accountants', 'real estate agents', 'insurance agents', 'auto repair',
+            'hair salons', 'fitness gyms', 'chiropractors', 'veterinarians',
+            'cleaning services', 'landscaping', 'roofing contractors', 'HVAC',
+            'photographers', 'florists', 'bakeries', 'coffee shops', 'pet stores',
+            'daycare centers', 'tutoring services', 'martial arts studios',
+            'yoga studios', 'massage therapists', 'optometrists', 'pharmacies',
+            'printing services', 'moving companies', 'pest control', 'locksmiths',
+            'car dealerships', 'tire shops', 'furniture stores', 'jewelry stores',
+            'clothing boutiques', 'tattoo parlors', 'breweries', 'catering',
+            'wedding planners', 'interior designers', 'architects', 'surveyors',
+            'physiotherapists', 'psychologists', 'counsellors', 'notaries',
+            'bookkeepers', 'IT support', 'web design', 'marketing agencies',
+            'sign shops', 'trophy shops', 'music schools', 'dance studios',
+            'dog groomers', 'boarding kennels', 'farm equipment dealers',
+            'hardware stores', 'building supplies', 'appliance repair',
+            'upholstery services', 'tailors', 'dry cleaners', 'spas',
+            'tanning salons', 'nail salons', 'barber shops', 'optical stores',
+            'hearing aid clinics', 'home inspectors', 'appraisers',
+            'property management', 'storage facilities', 'courier services',
+            'towing services', 'glass repair', 'fencing contractors',
+            'concrete contractors', 'paving contractors', 'tree services',
+            'snow removal', 'pool services', 'septic services',
+            'garage door repair', 'security companies', 'staffing agencies',
+            'travel agencies', 'event venues', 'food trucks',
+        ];
+        shuffle($categoryPool);
+        for ($i = 0; $i < $maxRounds; $i++) {
+            $queries[] = $categoryPool[$i] . " in $location";
+        }
     }
+
+    // Map category keywords to Google Places types for more targeted results
+    $placeTypeMap = [
+        'restaurant' => 'restaurant', 'plumber' => 'plumber',
+        'electrician' => 'electrician', 'dentist' => 'dentist',
+        'lawyer' => 'lawyer', 'accountant' => 'accounting',
+        'gym' => 'gym', 'salon' => 'hair_care', 'veterinarian' => 'veterinary_care',
+        'pharmacy' => 'pharmacy', 'car dealership' => 'car_dealer',
+        'bakery' => 'bakery', 'cafe' => 'cafe', 'coffee' => 'cafe',
+        'spa' => 'spa', 'florist' => 'florist', 'pet store' => 'pet_store',
+        'furniture' => 'furniture_store', 'jewelry' => 'jewelry_store',
+        'hardware' => 'hardware_store', 'barber' => 'hair_care',
+        'locksmith' => 'locksmith', 'storage' => 'storage',
+        'travel agenc' => 'travel_agency', 'insurance' => 'insurance_agency',
+        'real estate' => 'real_estate_agency',
+    ];
 
     for ($round = 0; $round < $maxRounds && count($businesses) < $limit; $round++) {
         $query = $queries[$round] ?? null;
         if (!$query) break;
+        $countBefore = count($businesses);
         $roundsUsed++;
 
         // Initial search for this round
-        $url = 'https://maps.googleapis.com/maps/api/place/textsearch/json?' . http_build_query([
-            'query' => $query,
-            'key' => $apiKey,
-        ]);
+        $params = ['query' => $query, 'key' => $apiKey];
+        // Try to match a Google Places type from the query for better results
+        foreach ($placeTypeMap as $keyword => $type) {
+            if (stripos($query, $keyword) !== false) {
+                $params['type'] = $type;
+                break;
+            }
+        }
+        $url = 'https://maps.googleapis.com/maps/api/place/textsearch/json?' . http_build_query($params);
 
         $resp = @file_get_contents($url, false, $httpContext);
         if ($resp === false) {
@@ -590,6 +640,12 @@ function search_businesses()
             $candidates = $nextData['results'] ?? [];
             $nextPageToken = $nextData['next_page_token'] ?? null;
             $pagesUsed++;
+        }
+
+        // Bail early if this round produced too few new results (diminishing returns)
+        $newThisRound = count($businesses) - $countBefore;
+        if ($newThisRound < 2 && $round > 0) {
+            break;
         }
     }
 

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -79,6 +79,11 @@ switch ($action) {
         get_activity($pdo);
         break;
 
+    // AI classification
+    case 'classify_company_sizes':
+        classify_company_sizes($pdo);
+        break;
+
     // CSV
     case 'export_csv':
         export_csv($pdo);
@@ -127,6 +132,7 @@ function get_leads($pdo)
 {
     $status = $_GET['status'] ?? '';
     $response_status = $_GET['response_status'] ?? '';
+    $company_size = $_GET['company_size'] ?? '';
     $search = $_GET['search'] ?? '';
     $sort = $_GET['sort'] ?? 'date_added_desc';
 
@@ -140,6 +146,10 @@ function get_leads($pdo)
     if ($response_status) {
         $where[] = 'response_status = ?';
         $params[] = $response_status;
+    }
+    if ($company_size) {
+        $where[] = 'company_size = ?';
+        $params[] = $company_size;
     }
     if ($search) {
         $where[] = '(business_name LIKE ? OR email LIKE ? OR contact_name LIKE ? OR city LIKE ? OR category LIKE ?)';
@@ -243,7 +253,7 @@ function update_lead($pdo)
         'category', 'city', 'source', 'status', 'response_status',
         'notes', 'feedback_summary', 'offer_sent',
         'draft_subject', 'draft_body', 'contact_page_url',
-        'first_contact_date', 'last_contact_date',
+        'first_contact_date', 'last_contact_date', 'company_size',
     ];
 
     $setClauses = [];
@@ -615,8 +625,8 @@ function import_leads($pdo)
             }
 
             $stmt = $pdo->prepare("INSERT INTO outreach_leads
-                (business_name, phone, website, address, category, city, source, places_id, contact_page_url, email)
-                VALUES (?, ?, ?, ?, ?, ?, 'google_places', ?, ?, ?)");
+                (business_name, phone, website, address, category, city, source, places_id, contact_page_url, email, company_size)
+                VALUES (?, ?, ?, ?, ?, ?, 'google_places', ?, ?, ?, ?)");
             $stmt->execute([
                 $biz['business_name'] ?? 'Unknown',
                 $biz['phone'] ?? null,
@@ -627,6 +637,7 @@ function import_leads($pdo)
                 $biz['places_id'] ?? null,
                 $biz['contact_page_url'] ?? null,
                 $biz['email'] ?? null,
+                $biz['company_size'] ?? null,
             ]);
 
             $id = $pdo->lastInsertId();
@@ -995,5 +1006,65 @@ function import_csv($pdo)
     json_response(['success' => true, 'imported' => $imported, 'message' => "Imported $imported leads from CSV"]);
 }
 
-// ─── AI Enrichment ───
+// ─── AI Company Size Classification ───
+
+function classify_company_sizes($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+    $businesses = $data['businesses'] ?? [];
+
+    if (empty($businesses)) {
+        json_response(['success' => false, 'message' => 'No businesses to classify'], 400);
+    }
+
+    // Build a list of businesses with their details for AI classification
+    $businessList = [];
+    foreach ($businesses as $i => $biz) {
+        $entry = ($i + 1) . '. ' . ($biz['business_name'] ?? 'Unknown');
+        if (!empty($biz['category'])) $entry .= ' (Category: ' . $biz['category'] . ')';
+        if (!empty($biz['address'])) $entry .= ' - ' . $biz['address'];
+        if (!empty($biz['website'])) $entry .= ' [' . $biz['website'] . ']';
+        $businessList[] = $entry;
+    }
+
+    $systemPrompt = "You classify businesses by company size. For each business in the list, determine if it is 'small', 'medium', or 'large' based on available information.
+
+Guidelines:
+- Small: Solo operators, freelancers, local mom-and-pop shops, single-location businesses with likely fewer than 20 employees. Most local service businesses (plumbers, landscapers, cleaners, small restaurants, local retail) are small.
+- Medium: Businesses with multiple locations, established regional presence, or likely 20-200 employees. Regional chains, mid-size professional firms, established contractors with large teams.
+- Large: Major corporations, national/international chains, franchises of well-known brands, businesses with likely 200+ employees.
+
+When in doubt, lean toward 'small' for local businesses found via Google Places search.
+
+Return ONLY a JSON array of size classifications in the same order as the input list.
+Example: [\"small\", \"medium\", \"small\", \"large\"]";
+
+    $userPrompt = "Classify these businesses by size:\n\n" . implode("\n", $businessList);
+
+    $result = call_openai($systemPrompt, $userPrompt);
+
+    if (isset($result['error'])) {
+        json_response(['success' => false, 'message' => $result['error']], 500);
+    }
+
+    $content = trim($result['content']);
+    $content = preg_replace('/^```json\s*/i', '', $content);
+    $content = preg_replace('/\s*```$/', '', $content);
+
+    $sizes = json_decode($content, true);
+
+    if (!is_array($sizes)) {
+        json_response(['success' => false, 'message' => 'Failed to parse AI classification response'], 500);
+    }
+
+    // Validate and normalize sizes
+    $validSizes = ['small', 'medium', 'large'];
+    $normalized = [];
+    foreach ($sizes as $size) {
+        $s = strtolower(trim($size));
+        $normalized[] = in_array($s, $validSizes) ? $s : 'small';
+    }
+
+    json_response(['success' => true, 'sizes' => $normalized]);
+}
 

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -916,7 +916,7 @@ Return ONLY the JSON, no other text.";
     }
 
     // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','researching','ready_to_contact','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
+    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','ready_to_contact','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
     $stmt->execute([$parsed['subject'], $parsed['body'], $id]);
 
     log_activity($pdo, $id, 'draft_generated', 'AI draft generated');

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -360,7 +360,7 @@ include '../admin_header.php';
                     <div class="draft-actions">
                         <button class="btn btn-blue" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
                         <button class="btn btn-blue" onclick="togglePreview()">Preview</button>
-                        <button class="btn btn-blue" onclick="copyDraft()">Copy</button>
+                        <button class="btn btn-blue" onclick="copyDraft(this)">Copy</button>
                         <button class="btn btn-blue" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
                     </div>
                     <div class="draft-info" id="draftInfo"></div>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -353,14 +353,9 @@ include '../admin_header.php';
                         <label>Message Body</label>
                         <textarea id="draftBody" rows="12" placeholder="Email body..."></textarea>
                     </div>
-                    <div id="draftPreview" class="draft-preview" style="display:none;">
-                        <h4>Preview</h4>
-                        <div id="draftPreviewContent"></div>
-                    </div>
                     <div class="draft-actions">
                         <button class="btn btn-blue" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
-                        <button class="btn btn-blue" onclick="togglePreview()">Preview</button>
-                        <button class="btn btn-blue" onclick="copyDraft(this)">Copy</button>
+                        <button class="btn btn-blue btn-small" onclick="copyDraft(this)">Copy</button>
                         <button class="btn btn-blue" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
                     </div>
                     <div class="draft-info" id="draftInfo"></div>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -359,9 +359,9 @@ include '../admin_header.php';
                         <textarea id="draftBody" rows="12" placeholder="Email body..."></textarea>
                     </div>
                     <div class="draft-actions">
-                        <button class="btn btn-blue" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
-                        <button class="btn btn-blue btn-small" onclick="copyDraft(this)">Copy</button>
-                        <button class="btn btn-blue" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
+                        <button class="btn btn-blue btn-small" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
+                        <button class="btn btn-blue btn-small" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
+                        <button class="btn btn-blue btn-small draft-copy-btn" onclick="copyDraft(this)">Copy</button>
                     </div>
                     <div class="draft-info" id="draftInfo"></div>
                 </div>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -153,7 +153,6 @@ include '../admin_header.php';
                 <select id="filterStatus" onchange="loadLeads()">
                     <option value="">All</option>
                     <option value="new">New</option>
-                    <option value="ready_to_contact">Ready to Contact</option>
                     <option value="draft_generated">Draft Generated</option>
                     <option value="contacted">Contacted</option>
                     <option value="replied">Replied</option>
@@ -292,7 +291,6 @@ include '../admin_header.php';
                         <label>Status</label>
                         <select id="detailStatus">
                             <option value="new">New</option>
-                            <option value="ready_to_contact">Ready to Contact</option>
                             <option value="draft_generated">Draft Generated</option>
                             <option value="contacted">Contacted</option>
                             <option value="replied">Replied</option>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -203,6 +203,12 @@ include '../admin_header.php';
         <button class="btn btn-small btn-blue" onclick="bulkDeleteLeads()">Delete Selected</button>
     </div>
 
+    <!-- Bulk Draft Progress -->
+    <div class="bulk-draft-progress" id="bulkDraftProgress" style="display:none;">
+        <span class="bulk-draft-spinner"></span>
+        <span id="bulkDraftProgressText"></span>
+    </div>
+
     <!-- Leads Table -->
     <div class="leads-table-wrapper">
         <table class="data-table leads-table">

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -206,6 +206,7 @@ include '../admin_header.php';
     <div class="bulk-draft-progress" id="bulkDraftProgress" style="display:none;">
         <span class="bulk-draft-spinner"></span>
         <span id="bulkDraftProgressText"></span>
+        <button class="btn btn-small" id="btnCancelDraft" onclick="cancelBulkDrafts()" style="margin-left:8px;">Cancel</button>
     </div>
 
     <!-- Leads Table -->

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -153,7 +153,6 @@ include '../admin_header.php';
                 <select id="filterStatus" onchange="loadLeads()">
                     <option value="">All</option>
                     <option value="new">New</option>
-                    <option value="researching">Researching</option>
                     <option value="ready_to_contact">Ready to Contact</option>
                     <option value="draft_generated">Draft Generated</option>
                     <option value="contacted">Contacted</option>
@@ -292,7 +291,6 @@ include '../admin_header.php';
                         <label>Status</label>
                         <select id="detailStatus">
                             <option value="new">New</option>
-                            <option value="researching">Researching</option>
                             <option value="ready_to_contact">Ready to Contact</option>
                             <option value="draft_generated">Draft Generated</option>
                             <option value="contacted">Contacted</option>

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -334,10 +334,9 @@ include '../admin_header.php';
                     <label>Feedback Summary</label>
                     <textarea id="detailFeedback" rows="3" placeholder="Summarize feedback received..."></textarea>
                 </div>
-                <div class="detail-meta" id="detailMeta"></div>
                 <div class="detail-actions">
-                    <button class="btn btn-blue" onclick="saveLeadDetails()">Save Changes</button>
                     <button class="btn btn-red" onclick="deleteCurrentLead()">Delete Lead</button>
+                    <button class="btn btn-blue" onclick="saveLeadDetails()">Save Changes</button>
                 </div>
             </div>
 

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -75,6 +75,15 @@ include '../admin_header.php';
                     <input type="text" id="discCategory" placeholder="e.g. landscaping, cleaners">
                 </div>
                 <div class="form-group">
+                    <label for="discCompanySize">Company Size</label>
+                    <select id="discCompanySize" onchange="renderDiscoveryResults()">
+                        <option value="">All Sizes</option>
+                        <option value="small">Small</option>
+                        <option value="medium">Medium</option>
+                        <option value="large">Large</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label for="discLimit">Limit</label>
                     <select id="discLimit">
                         <option value="5">5</option>
@@ -111,6 +120,7 @@ include '../admin_header.php';
                             <th>Website</th>
                             <th>Address</th>
                             <th>Category</th>
+                            <th>Size</th>
                         </tr>
                     </thead>
                     <tbody id="discoveryTableBody"></tbody>
@@ -161,6 +171,15 @@ include '../admin_header.php';
                     <option value="positive">Positive</option>
                     <option value="neutral">Neutral</option>
                     <option value="negative">Negative</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="filterCompanySize">Company Size</label>
+                <select id="filterCompanySize" onchange="loadLeads()">
+                    <option value="">All Sizes</option>
+                    <option value="small">Small</option>
+                    <option value="medium">Medium</option>
+                    <option value="large">Large</option>
                 </select>
             </div>
             <div class="filter-group">
@@ -291,6 +310,15 @@ include '../admin_header.php';
                         <select id="detailOfferSent">
                             <option value="0">No</option>
                             <option value="1">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Company Size</label>
+                        <select id="detailCompanySize">
+                            <option value="">Unknown</option>
+                            <option value="small">Small</option>
+                            <option value="medium">Medium</option>
+                            <option value="large">Large</option>
                         </select>
                     </div>
                     <div class="form-group">

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -359,8 +359,8 @@ include '../admin_header.php';
                         <textarea id="draftBody" rows="12" placeholder="Email body..."></textarea>
                     </div>
                     <div class="draft-actions">
-                        <button class="btn btn-blue btn-small" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
-                        <button class="btn btn-blue btn-small" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
+                        <button class="btn btn-blue" onclick="generateDraft()" id="btnGenerate">Generate Draft</button>
+                        <button class="btn btn-blue" onclick="sendEmail()" id="btnSend" disabled>Send Email</button>
                         <button class="btn btn-blue btn-small draft-copy-btn" onclick="copyDraft(this)">Copy</button>
                     </div>
                     <div class="draft-info" id="draftInfo"></div>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -631,62 +631,87 @@ async function searchBusinesses() {
     btn.disabled = true;
     btn.textContent = 'Searching...';
 
-    const params = {
+    const sizeFilter = document.getElementById('discCompanySize').value;
+    const limit = parseInt(document.getElementById('discLimit').value);
+    const baseParams = {
         city: city,
         province: document.getElementById('discProvince').value.trim(),
         category: document.getElementById('discCategory').value.trim(),
-        limit: document.getElementById('discLimit').value,
+        limit: limit,
     };
 
-    const data = await api('search_businesses', { params });
+    discoveryResults = [];
+    document.getElementById('discoveryResults').style.display = 'block';
+
+    // If a size filter is active, we may need multiple search+classify rounds
+    // to accumulate enough results that match the filter
+    const maxAttempts = sizeFilter ? 3 : 1;
+    let lastNote = null;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        // Exclude businesses we already have so the API finds new ones
+        const excludeIds = discoveryResults.map(b => b.places_id).filter(Boolean).join(',');
+        const params = { ...baseParams };
+        if (excludeIds) params.exclude_place_ids = excludeIds;
+
+        btn.textContent = attempt === 0 ? 'Searching...' : `Searching (round ${attempt + 1})...`;
+        const data = await api('search_businesses', { params });
+
+        if (!data.success) {
+            if (attempt === 0) {
+                btn.disabled = false;
+                btn.textContent = 'Search';
+                notify(data.message, 'error');
+                return;
+            }
+            break;
+        }
+
+        if (!data.businesses.length) break;
+        lastNote = data.note || null;
+
+        // Classify sizes for the new batch
+        const newBatch = data.businesses;
+        try {
+            const classifyData = await api('classify_company_sizes', {
+                method: 'POST',
+                body: { businesses: newBatch }
+            });
+            if (classifyData.success && classifyData.sizes) {
+                classifyData.sizes.forEach((size, i) => {
+                    if (i < newBatch.length) newBatch[i].company_size = size;
+                });
+            }
+        } catch (e) {
+            console.warn('Company size classification failed:', e.message);
+        }
+
+        // Add new batch to results and re-render
+        discoveryResults = discoveryResults.concat(newBatch);
+        renderDiscoveryResults();
+        saveDiscoveryToSession();
+
+        // Check if we have enough filtered results
+        if (!sizeFilter) break;
+        const filteredCount = discoveryResults.filter(b => b.company_size === sizeFilter).length;
+        if (filteredCount >= limit) break;
+    }
+
     btn.disabled = false;
     btn.textContent = 'Search';
 
-    if (!data.success) {
-        notify(data.message, 'error');
-        return;
-    }
-
-    discoveryResults = data.businesses;
-    document.getElementById('discoveryResults').style.display = 'block';
-    renderDiscoveryResults();
-    saveDiscoveryToSession();
-
-    if (data.note) {
-        notify(data.note, 'info');
-    }
-
-    // AI-classify company sizes in the background
-    if (discoveryResults.length) {
-        classifyDiscoveryCompanySizes();
-    }
-}
-
-async function classifyDiscoveryCompanySizes() {
-    try {
-        const data = await api('classify_company_sizes', {
-            method: 'POST',
-            body: { businesses: discoveryResults }
-        });
-        if (data.success && data.sizes) {
-            data.sizes.forEach((size, i) => {
-                if (i < discoveryResults.length) {
-                    discoveryResults[i].company_size = size;
-                }
-            });
-            // Apply filter if one is selected
-            const sizeFilter = document.getElementById('discCompanySize').value;
-            renderDiscoveryResults();
-            saveDiscoveryToSession();
-            if (sizeFilter) {
-                notify('Company sizes classified. Filter applied.', 'success');
-            } else {
-                notify('Company sizes classified by AI.', 'success');
-            }
+    if (lastNote && sizeFilter) {
+        const filteredCount = discoveryResults.filter(b => b.company_size === sizeFilter).length;
+        if (filteredCount < limit) {
+            notify(`Found ${filteredCount} ${sizeFilter} businesses out of ${discoveryResults.length} total. Not enough ${sizeFilter} businesses in this area.`, 'info');
         }
-    } catch (e) {
-        // Non-critical, just log
-        console.warn('Company size classification failed:', e.message);
+    } else if (lastNote) {
+        notify(lastNote, 'info');
+    }
+
+    if (discoveryResults.length) {
+        const msg = sizeFilter ? 'Company sizes classified. Filter applied.' : 'Company sizes classified by AI.';
+        notify(msg, 'success');
     }
 }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -452,11 +452,7 @@ async function openLeadDetail(id) {
         document.getElementById('detailFeedback').value = lead.feedback_summary || '';
 
         // Meta info
-        let meta = `Added: ${formatDateTime(lead.date_added)}`;
-        if (lead.first_contact_date) meta += ` | First contact: ${formatDateTime(lead.first_contact_date)}`;
-        if (lead.last_contact_date) meta += ` | Last contact: ${formatDateTime(lead.last_contact_date)}`;
-        if (lead.sent_at) meta += ` | Last sent: ${formatDateTime(lead.sent_at)}`;
-        document.getElementById('detailMeta').textContent = meta;
+        // Meta info removed from UI
 
         // Draft tab
         document.getElementById('draftSubject').value = lead.draft_subject || '';

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -892,8 +892,10 @@ async function generateDraft() {
         if (data.success) {
             document.getElementById('draftSubject').value = data.subject;
             document.getElementById('draftBody').value = data.body;
-            // Refresh lead to update status
-            openLeadDetail(currentLeadId);
+            // Refresh draft status without switching tabs
+            const leadData = await api('get_lead', { params: { id: currentLeadId } });
+            if (leadData.success) updateDraftStatus(leadData.lead);
+            loadActivity(currentLeadId);
         } else {
             notify(data.message, 'error');
         }

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -892,7 +892,15 @@ function copyDraft() {
     const subject = document.getElementById('draftSubject').value;
     const body = document.getElementById('draftBody').value;
     const text = `Subject: ${subject}\n\n${body}`;
-    navigator.clipboard.writeText(text).catch(() => {
+
+    const copied = () => {
+        const btn = event.target;
+        const original = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(() => btn.textContent = original, 1000);
+    };
+
+    navigator.clipboard.writeText(text).then(copied).catch(() => {
         // Fallback
         const ta = document.createElement('textarea');
         ta.value = text;
@@ -900,6 +908,7 @@ function copyDraft() {
         ta.select();
         document.execCommand('copy');
         document.body.removeChild(ta);
+        copied();
     });
 }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -257,16 +257,27 @@ function getSelectedLeadIds() {
     return Array.from(document.querySelectorAll('.lead-check:checked')).map(cb => parseInt(cb.value));
 }
 
+let bulkDraftCancelled = false;
+
+function cancelBulkDrafts() {
+    bulkDraftCancelled = true;
+    const btn = document.getElementById('btnCancelDraft');
+    if (btn) { btn.disabled = true; btn.textContent = 'Cancelling...'; }
+}
+
 async function bulkGenerateDrafts() {
     const ids = getSelectedLeadIds();
     if (!ids.length) return;
     if (!confirm(`Generate drafts for ${ids.length} lead(s)?`)) return;
 
+    bulkDraftCancelled = false;
     const total = ids.length;
     let success = 0, fail = 0;
     const progressEl = document.getElementById('bulkDraftProgress');
     const progressText = document.getElementById('bulkDraftProgressText');
+    const cancelBtn = document.getElementById('btnCancelDraft');
     progressEl.style.display = 'flex';
+    if (cancelBtn) { cancelBtn.disabled = false; cancelBtn.textContent = 'Cancel'; }
 
     // Disable the draft button during processing
     const draftBtn = document.getElementById('btnDraftSelected');
@@ -281,6 +292,8 @@ async function bulkGenerateDrafts() {
     // Process drafts concurrently (3 at a time)
     const CONCURRENCY = 3;
     async function processDraft(id) {
+        if (bulkDraftCancelled) return;
+
         const row = document.querySelector(`#lead-check-${id}`)?.closest('tr');
         const draftCellBtn = row?.querySelector('.actions-cell .btn-blue[title="Generate Draft"]');
         if (draftCellBtn) {
@@ -290,6 +303,10 @@ async function bulkGenerateDrafts() {
 
         try {
             const result = await api('generate_draft', { method: 'POST', body: { id } });
+            if (bulkDraftCancelled) {
+                if (draftCellBtn) { draftCellBtn.disabled = false; draftCellBtn.textContent = 'Draft'; }
+                return;
+            }
             if (result.success) {
                 success++;
                 if (draftCellBtn) draftCellBtn.remove();
@@ -315,16 +332,21 @@ async function bulkGenerateDrafts() {
 
     // Run in batches of CONCURRENCY
     for (let i = 0; i < ids.length; i += CONCURRENCY) {
+        if (bulkDraftCancelled) break;
         const batch = ids.slice(i, i + CONCURRENCY);
         await Promise.all(batch.map(id => processDraft(id)));
     }
 
     // Done
-    progressText.textContent = `Done: ${success} drafted` + (fail ? `, ${fail} failed` : '');
+    const cancelled = bulkDraftCancelled;
+    const doneMsg = cancelled
+        ? `Cancelled: ${success} drafted` + (fail ? `, ${fail} failed` : '') + `, ${total - success - fail} skipped`
+        : `Done: ${success} drafted` + (fail ? `, ${fail} failed` : '');
+    progressText.textContent = doneMsg;
     setTimeout(() => { progressEl.style.display = 'none'; }, 3000);
 
     if (draftBtn) draftBtn.disabled = false;
-    notify(`Drafted: ${success}, Failed: ${fail}`, success ? 'success' : 'error');
+    notify(doneMsg, success ? 'success' : 'error');
     loadStats();
     updateBulkBar();
 }

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -262,16 +262,66 @@ async function bulkGenerateDrafts() {
     if (!ids.length) return;
     if (!confirm(`Generate drafts for ${ids.length} lead(s)?`)) return;
 
+    const total = ids.length;
     let success = 0, fail = 0;
+    const progressEl = document.getElementById('bulkDraftProgress');
+    const progressText = document.getElementById('bulkDraftProgressText');
+    progressEl.style.display = 'flex';
+
+    // Disable the draft button during processing
+    const draftBtn = document.getElementById('btnDraftSelected');
+    if (draftBtn) draftBtn.disabled = true;
+
+    function updateProgress() {
+        const done = success + fail;
+        progressText.textContent = `Drafting: ${done} of ${total} complete` + (fail ? ` (${fail} failed)` : '');
+    }
+    updateProgress();
+
     for (const id of ids) {
+        // Update the row's Draft button to show it's in progress
+        const row = document.querySelector(`#lead-check-${id}`)?.closest('tr');
+        const draftCellBtn = row?.querySelector('.actions-cell .btn-blue[title="Generate Draft"]');
+        if (draftCellBtn) {
+            draftCellBtn.disabled = true;
+            draftCellBtn.textContent = 'Drafting...';
+        }
+
         try {
             const result = await api('generate_draft', { method: 'POST', body: { id } });
-            if (result.success) success++; else fail++;
-        } catch { fail++; }
+            if (result.success) {
+                success++;
+                // Update this row immediately: remove draft button, update status badge
+                if (draftCellBtn) draftCellBtn.remove();
+                if (row) {
+                    const badge = row.querySelector('.badge');
+                    if (badge && !['contacted','replied','interested','not_interested','onboarded'].includes(badge.textContent.trim().toLowerCase().replace(/\s+/g, '_'))) {
+                        badge.className = 'badge badge-status-draft_generated';
+                        badge.textContent = 'Draft Generated';
+                    }
+                    // Update checkbox data attribute
+                    const cb = row.querySelector('.lead-check');
+                    if (cb) cb.dataset.hasDraft = '1';
+                }
+            } else {
+                fail++;
+                if (draftCellBtn) { draftCellBtn.disabled = false; draftCellBtn.textContent = 'Draft'; }
+            }
+        } catch {
+            fail++;
+            if (draftCellBtn) { draftCellBtn.disabled = false; draftCellBtn.textContent = 'Draft'; }
+        }
+        updateProgress();
     }
+
+    // Done
+    progressText.textContent = `Done: ${success} drafted` + (fail ? `, ${fail} failed` : '');
+    setTimeout(() => { progressEl.style.display = 'none'; }, 3000);
+
+    if (draftBtn) draftBtn.disabled = false;
     notify(`Drafted: ${success}, Failed: ${fail}`, success ? 'success' : 'error');
-    loadLeads();
     loadStats();
+    updateBulkBar();
 }
 
 async function bulkDeleteLeads() {

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -245,11 +245,11 @@ function updateBulkBar() {
         }
     }
 
-    // Disable "Draft Selected" if any selected lead already has a draft
+    // Switch to "Redraft Selected" if all selected leads already have drafts
     const draftBtn = document.getElementById('btnDraftSelected');
     if (draftBtn) {
-        const anyDrafted = Array.from(checked).some(cb => cb.dataset.hasDraft === '1');
-        draftBtn.disabled = anyDrafted;
+        const allDrafted = checked.length > 0 && Array.from(checked).every(cb => cb.dataset.hasDraft === '1');
+        draftBtn.textContent = allDrafted ? 'Redraft Selected' : 'Draft Selected';
     }
 }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -262,7 +262,6 @@ async function bulkGenerateDrafts() {
     if (!ids.length) return;
     if (!confirm(`Generate drafts for ${ids.length} lead(s)?`)) return;
 
-    notify(`Generating ${ids.length} draft(s)...`, 'info');
     let success = 0, fail = 0;
     for (const id of ids) {
         try {
@@ -705,13 +704,6 @@ async function searchBusinesses() {
         if (filteredCount < limit) {
             notify(`Found ${filteredCount} ${sizeFilter} businesses out of ${discoveryResults.length} total. Not enough ${sizeFilter} businesses in this area.`, 'info');
         }
-    } else if (lastNote) {
-        notify(lastNote, 'info');
-    }
-
-    if (discoveryResults.length) {
-        const msg = sizeFilter ? 'Company sizes classified. Filter applied.' : 'Company sizes classified by AI.';
-        notify(msg, 'success');
     }
 }
 
@@ -900,9 +892,7 @@ function copyDraft() {
     const subject = document.getElementById('draftSubject').value;
     const body = document.getElementById('draftBody').value;
     const text = `Subject: ${subject}\n\n${body}`;
-    navigator.clipboard.writeText(text).then(() => {
-        notify('Draft copied to clipboard', 'success');
-    }).catch(() => {
+    navigator.clipboard.writeText(text).catch(() => {
         // Fallback
         const ta = document.createElement('textarea');
         ta.value = text;
@@ -910,7 +900,6 @@ function copyDraft() {
         ta.select();
         document.execCommand('copy');
         document.body.removeChild(ta);
-        notify('Draft copied to clipboard', 'success');
     });
 }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -874,19 +874,6 @@ async function sendEmail() {
     }
 }
 
-function togglePreview() {
-    const preview = document.getElementById('draftPreview');
-    if (preview.style.display === 'none') {
-        const subject = document.getElementById('draftSubject').value;
-        const body = document.getElementById('draftBody').value;
-        document.getElementById('draftPreviewContent').innerHTML =
-            '<p><strong>Subject:</strong> ' + esc(subject) + '</p><hr>' +
-            '<p>' + esc(body).replace(/\n/g, '<br>') + '</p>';
-        preview.style.display = 'block';
-    } else {
-        preview.style.display = 'none';
-    }
-}
 
 function copyDraft(btn) {
     const subject = document.getElementById('draftSubject').value;

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -278,8 +278,9 @@ async function bulkGenerateDrafts() {
     }
     updateProgress();
 
-    for (const id of ids) {
-        // Update the row's Draft button to show it's in progress
+    // Process drafts concurrently (3 at a time)
+    const CONCURRENCY = 3;
+    async function processDraft(id) {
         const row = document.querySelector(`#lead-check-${id}`)?.closest('tr');
         const draftCellBtn = row?.querySelector('.actions-cell .btn-blue[title="Generate Draft"]');
         if (draftCellBtn) {
@@ -291,7 +292,6 @@ async function bulkGenerateDrafts() {
             const result = await api('generate_draft', { method: 'POST', body: { id } });
             if (result.success) {
                 success++;
-                // Update this row immediately: remove draft button, update status badge
                 if (draftCellBtn) draftCellBtn.remove();
                 if (row) {
                     const badge = row.querySelector('.badge');
@@ -299,7 +299,6 @@ async function bulkGenerateDrafts() {
                         badge.className = 'badge badge-status-draft_generated';
                         badge.textContent = 'Draft Generated';
                     }
-                    // Update checkbox data attribute
                     const cb = row.querySelector('.lead-check');
                     if (cb) cb.dataset.hasDraft = '1';
                 }
@@ -312,6 +311,12 @@ async function bulkGenerateDrafts() {
             if (draftCellBtn) { draftCellBtn.disabled = false; draftCellBtn.textContent = 'Draft'; }
         }
         updateProgress();
+    }
+
+    // Run in batches of CONCURRENCY
+    for (let i = 0; i < ids.length; i += CONCURRENCY) {
+        const batch = ids.slice(i, i + CONCURRENCY);
+        await Promise.all(batch.map(id => processDraft(id)));
     }
 
     // Done
@@ -377,11 +382,12 @@ async function openBulkSendModal() {
         // Render all leads
         renderBulkSendList();
 
-        // Auto-generate drafts for leads that don't have one
+        // Auto-generate drafts for leads that don't have one (3 at a time)
         const needsDraft = withEmail.filter(l => !l.draft_subject || !l.draft_body);
         if (needsDraft.length) {
             statusEl.textContent = `Generating drafts for ${needsDraft.length} lead(s)...`;
-            for (const lead of needsDraft) {
+            const CONCURRENCY = 3;
+            async function processSendDraft(lead) {
                 const itemEl = document.getElementById('bulk-send-item-' + lead.id);
                 if (itemEl) {
                     itemEl.querySelector('.bulk-send-item-draft').innerHTML = '<span class="bulk-send-item-generating">Generating draft...</span>';
@@ -402,6 +408,10 @@ async function openBulkSendModal() {
                         itemEl.querySelector('.bulk-send-item-draft').innerHTML = '<span class="bulk-send-item-error">Error: ' + esc(e.message) + '</span>';
                     }
                 }
+            }
+            for (let i = 0; i < needsDraft.length; i += CONCURRENCY) {
+                const batch = needsDraft.slice(i, i + CONCURRENCY);
+                await Promise.all(batch.map(lead => processSendDraft(lead)));
             }
         }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -183,7 +183,7 @@ async function loadLeads() {
         }
 
         tbody.innerHTML = data.leads.map(lead => `
-            <tr onclick="openLeadDetail(${lead.id})" class="clickable-row">
+            <tr class="lead-row">
                 <td class="checkbox-column" onclick="event.stopPropagation()">
                     <div class="checkbox"><input type="checkbox" class="lead-check" value="${lead.id}" id="lead-check-${lead.id}" data-has-draft="${lead.draft_subject ? '1' : ''}" onchange="updateBulkBar()"><label for="lead-check-${lead.id}"></label></div>
                 </td>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -13,11 +13,13 @@ function updateUrlParams() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
+    const companySize = document.getElementById('filterCompanySize').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.set('search', search);
     if (status) params.set('status', status);
     if (response) params.set('response', response);
+    if (companySize) params.set('company_size', companySize);
     if (sort && sort !== 'date_added_desc') params.set('sort', sort);
 
     const newUrl = params.toString()
@@ -31,6 +33,7 @@ function restoreFiltersFromUrl() {
     if (params.has('search')) document.getElementById('filterSearch').value = params.get('search');
     if (params.has('status')) document.getElementById('filterStatus').value = params.get('status');
     if (params.has('response')) document.getElementById('filterResponse').value = params.get('response');
+    if (params.has('company_size')) document.getElementById('filterCompanySize').value = params.get('company_size');
     if (params.has('sort')) document.getElementById('filterSort').value = params.get('sort');
 }
 
@@ -43,6 +46,7 @@ function saveDiscoveryToSession() {
         sessionStorage.setItem('outreach_disc_province', document.getElementById('discProvince').value);
         sessionStorage.setItem('outreach_disc_category', document.getElementById('discCategory').value);
         sessionStorage.setItem('outreach_disc_limit', document.getElementById('discLimit').value);
+        sessionStorage.setItem('outreach_disc_company_size', document.getElementById('discCompanySize').value);
     } catch (e) { /* storage full or unavailable */ }
 }
 
@@ -61,10 +65,12 @@ function restoreDiscoveryFromSession() {
         const province = sessionStorage.getItem('outreach_disc_province');
         const category = sessionStorage.getItem('outreach_disc_category');
         const limit = sessionStorage.getItem('outreach_disc_limit');
+        const companySize = sessionStorage.getItem('outreach_disc_company_size');
         if (city) document.getElementById('discCity').value = city;
         if (province) document.getElementById('discProvince').value = province;
         if (category) document.getElementById('discCategory').value = category;
         if (limit) document.getElementById('discLimit').value = limit;
+        if (companySize) document.getElementById('discCompanySize').value = companySize;
     } catch (e) { /* storage unavailable */ }
 }
 
@@ -154,11 +160,13 @@ async function loadLeads() {
     const search = document.getElementById('filterSearch').value.trim();
     const status = document.getElementById('filterStatus').value;
     const response = document.getElementById('filterResponse').value;
+    const companySize = document.getElementById('filterCompanySize').value;
     const sort = document.getElementById('filterSort').value;
 
     if (search) params.search = search;
     if (status) params.status = status;
     if (response) params.response_status = response;
+    if (companySize) params.company_size = companySize;
     if (sort) params.sort = sort;
 
     // Persist filters to URL
@@ -438,6 +446,7 @@ async function openLeadDetail(id) {
         document.getElementById('detailStatus').value = lead.status || 'new';
         document.getElementById('detailResponseStatus').value = lead.response_status || 'no_response';
 
+        document.getElementById('detailCompanySize').value = lead.company_size || '';
         document.getElementById('detailOfferSent').value = lead.offer_sent ? '1' : '0';
         document.getElementById('detailContactPageUrl').value = lead.contact_page_url || '';
         document.getElementById('detailNotes').value = lead.notes || '';
@@ -532,7 +541,7 @@ async function saveLeadDetails() {
         city: document.getElementById('detailCity').value,
         status: document.getElementById('detailStatus').value,
         response_status: document.getElementById('detailResponseStatus').value,
-
+        company_size: document.getElementById('detailCompanySize').value,
         offer_sent: document.getElementById('detailOfferSent').value,
         contact_page_url: document.getElementById('detailContactPageUrl').value,
         notes: document.getElementById('detailNotes').value,
@@ -646,28 +655,73 @@ async function searchBusinesses() {
     if (data.note) {
         notify(data.note, 'info');
     }
+
+    // AI-classify company sizes in the background
+    if (discoveryResults.length) {
+        classifyDiscoveryCompanySizes();
+    }
+}
+
+async function classifyDiscoveryCompanySizes() {
+    try {
+        const data = await api('classify_company_sizes', {
+            method: 'POST',
+            body: { businesses: discoveryResults }
+        });
+        if (data.success && data.sizes) {
+            data.sizes.forEach((size, i) => {
+                if (i < discoveryResults.length) {
+                    discoveryResults[i].company_size = size;
+                }
+            });
+            // Apply filter if one is selected
+            const sizeFilter = document.getElementById('discCompanySize').value;
+            renderDiscoveryResults();
+            saveDiscoveryToSession();
+            if (sizeFilter) {
+                notify('Company sizes classified. Filter applied.', 'success');
+            } else {
+                notify('Company sizes classified by AI.', 'success');
+            }
+        }
+    } catch (e) {
+        // Non-critical, just log
+        console.warn('Company size classification failed:', e.message);
+    }
 }
 
 function renderDiscoveryResults() {
-    document.getElementById('discoveryCount').textContent = `${discoveryResults.length} results`;
+    const sizeFilter = document.getElementById('discCompanySize').value;
+    const filtered = sizeFilter
+        ? discoveryResults.filter(biz => biz.company_size === sizeFilter)
+        : discoveryResults;
+
+    document.getElementById('discoveryCount').textContent = sizeFilter
+        ? `${filtered.length} of ${discoveryResults.length} results (filtered by ${sizeFilter})`
+        : `${discoveryResults.length} results`;
+
     const tbody = document.getElementById('discoveryTableBody');
 
-    if (!discoveryResults.length) {
-        tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No businesses found</td></tr>';
+    if (!filtered.length) {
+        tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No businesses found</td></tr>';
         return;
     }
 
-    tbody.innerHTML = discoveryResults.map((biz, i) => `
+    tbody.innerHTML = filtered.map((biz, i) => {
+        // Find original index for checkbox data
+        const origIndex = discoveryResults.indexOf(biz);
+        return `
         <tr>
-            <td><div class="checkbox"><input type="checkbox" class="disc-check" data-index="${i}" id="disc-check-${i}" checked><label for="disc-check-${i}"></label></div></td>
+            <td><div class="checkbox"><input type="checkbox" class="disc-check" data-index="${origIndex}" id="disc-check-${origIndex}" checked><label for="disc-check-${origIndex}"></label></div></td>
             <td>${esc(biz.business_name)}</td>
             <td>${biz.email ? esc(biz.email) : '<span class="text-muted">—</span>'}</td>
             <td>${biz.phone ? esc(biz.phone) : '<span class="text-muted">—</span>'}</td>
             <td>${biz.website ? '<a href="' + esc(biz.website) + '" target="_blank" rel="noopener noreferrer" class="link">Link</a>' : '<span class="text-muted">—</span>'}</td>
             <td>${esc(biz.address || '')}</td>
             <td>${esc(biz.category || '')}</td>
-        </tr>
-    `).join('');
+            <td>${biz.company_size ? '<span class="badge badge-size-' + biz.company_size + '">' + biz.company_size.charAt(0).toUpperCase() + biz.company_size.slice(1) + '</span>' : '<span class="text-muted">—</span>'}</td>
+        </tr>`;
+    }).join('');
 
     const selectAll = document.getElementById('discSelectAll');
     if (selectAll) selectAll.checked = true;

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -550,7 +550,7 @@ function updateDraftStatus(lead) {
     }
 
     if (lead.drafted_at) {
-        statusHtml += ` | Drafted: ${formatDateTime(lead.drafted_at)}`;
+        statusHtml += ` Drafted: ${formatDateTime(lead.drafted_at)}`;
     }
 
     bar.innerHTML = statusHtml;

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -631,10 +631,12 @@ async function saveLeadDetails() {
 
     try {
         const result = await api('update_lead', { method: 'POST', body: data });
-        notify(result.message, result.success ? 'success' : 'error');
         if (result.success) {
+            closeModal('leadDetailModal');
             loadLeads();
             loadStats();
+        } else {
+            notify(result.message, 'error');
         }
     } catch (e) {
         notify(e.message, 'error');
@@ -1105,12 +1107,6 @@ function formatStatus(status) {
 
 function formatActionType(type) {
     return type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-}
-
-function formatDate(dateStr) {
-    if (!dateStr) return '';
-    const d = new Date(dateStr + 'T00:00:00');
-    return d.toLocaleDateString('en-CA', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 function formatDateTime(dateStr) {

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -888,13 +888,12 @@ function togglePreview() {
     }
 }
 
-function copyDraft() {
+function copyDraft(btn) {
     const subject = document.getElementById('draftSubject').value;
     const body = document.getElementById('draftBody').value;
     const text = `Subject: ${subject}\n\n${body}`;
 
     const copied = () => {
-        const btn = event.target;
         const original = btn.textContent;
         btn.textContent = 'Copied';
         setTimeout(() => btn.textContent = original, 1000);

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -177,6 +177,16 @@
     color: var(--gray-300);
 }
 
+[data-theme="dark"] .bulk-draft-progress .btn-small {
+    background: var(--gray-700);
+    color: var(--gray-200);
+    border-color: var(--gray-600);
+}
+
+[data-theme="dark"] .bulk-draft-progress .btn-small:hover {
+    background: var(--gray-600);
+}
+
 .bulk-draft-spinner {
     width: 14px;
     height: 14px;

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -134,6 +134,7 @@
 
 .form-group textarea {
     resize: vertical;
+    max-height: 400px;
 }
 
 .full-width {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -298,7 +298,6 @@
 
 /* Status badges */
 .badge-status-new { background: var(--blue-100); color: var(--blue-700); }
-.badge-status-researching { background: var(--sky-100); color: var(--sky-700); }
 .badge-status-ready_to_contact { background: var(--amber-100); color: var(--amber-700); }
 .badge-status-draft_generated { background: var(--purple-100); color: var(--purple-700); }
 .badge-status-contacted { background: var(--purple-100); color: var(--purple-600); }

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -91,6 +91,7 @@
     gap: 12px;
     align-items: flex-end;
     flex-wrap: wrap;
+    justify-content: center;
 }
 
 .form-group {
@@ -322,6 +323,7 @@
     gap: 12px;
     align-items: flex-end;
     flex-wrap: wrap;
+    justify-content: center;
 }
 
 .filter-group {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -298,7 +298,6 @@
 
 /* Status badges */
 .badge-status-new { background: var(--blue-100); color: var(--blue-700); }
-.badge-status-ready_to_contact { background: var(--amber-100); color: var(--amber-700); }
 .badge-status-draft_generated { background: var(--purple-100); color: var(--purple-700); }
 .badge-status-contacted { background: var(--purple-100); color: var(--purple-600); }
 .badge-status-replied { background: var(--green-100); color: var(--green-700); }

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -504,9 +504,7 @@
 }
 
 .draft-status-bar {
-    padding: 8px 12px;
-    background: var(--gray-50);
-    border-radius: 6px;
+    padding: 8px 0;
     margin-bottom: 14px;
     font-size: 13px;
     display: flex;
@@ -832,7 +830,6 @@
 }
 
 [data-theme="dark"] .draft-status-bar {
-    background: var(--gray-900);
 }
 
 [data-theme="dark"] .draft-actions .btn-small {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -96,9 +96,7 @@
 .form-group {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    flex: 1;
-    min-width: 140px;
+    margin-bottom: 0;
 }
 
 .form-group-btn {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -277,6 +277,11 @@
 
 .badge-status-onboarded { background: var(--green-100); color: var(--green-800); }
 
+/* Company size badges */
+.badge-size-small { background: var(--green-100); color: var(--green-700); }
+.badge-size-medium { background: var(--amber-100); color: var(--amber-700); }
+.badge-size-large { background: var(--purple-100); color: var(--purple-700); }
+
 
 /* ─── Filters ─── */
 .filters-container {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -518,20 +518,16 @@
     gap: 8px;
     flex-wrap: nowrap;
     margin-top: 12px;
+    align-items: center;
 }
 
 .draft-actions .btn {
-    flex: 1 1 0;
+    flex: 0 0 auto;
     white-space: nowrap;
-    min-width: 0;
 }
 
-.draft-actions .btn-small {
-    flex: 0 0 auto;
-    padding: 4px 12px;
-    font-size: 0.75rem;
+.draft-actions .draft-copy-btn {
     margin-left: auto;
-    text-transform: none;
 }
 
 .draft-info {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -500,8 +500,8 @@
     flex: 0 0 auto;
     padding: 4px 12px;
     font-size: 0.75rem;
-    color: var(--gray-500);
-    text-transform: uppercase;
+    margin-left: auto;
+    text-transform: none;
 }
 
 .draft-info {
@@ -805,6 +805,10 @@
 
 [data-theme="dark"] .draft-status-bar {
     background: var(--gray-900);
+}
+
+[data-theme="dark"] .draft-actions .btn-small {
+    color: var(--white);
 }
 
 [data-theme="dark"] .modal-content::-webkit-scrollbar {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -134,6 +134,7 @@
 
 .form-group textarea {
     resize: vertical;
+    min-height: 120px;
     max-height: 400px;
 }
 

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -254,15 +254,6 @@
     border-bottom: none;
 }
 
-.clickable-row {
-    cursor: pointer;
-    transition: background 0.1s;
-}
-
-.clickable-row:hover {
-    background: var(--gray-50);
-}
-
 .leads-table-wrapper {
     overflow-x: auto;
 }
@@ -744,9 +735,6 @@
     border-bottom-color: var(--gray-700);
 }
 
-[data-theme="dark"] .clickable-row:hover {
-    background: var(--slate-253449);
-}
 
 [data-theme="dark"] .form-group input,
 [data-theme="dark"] .form-group select,

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -463,6 +463,7 @@
     display: flex;
     gap: 8px;
     flex-wrap: wrap;
+    justify-content: flex-end;
     margin-top: 8px;
 }
 

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -160,6 +160,35 @@
     background: var(--navy-1e3a5f);
 }
 
+.bulk-draft-progress {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 20px;
+    font-size: 13px;
+    color: var(--gray-500);
+    background: var(--blue-50);
+    border-bottom: 1px solid var(--gray-border);
+}
+
+[data-theme="dark"] .bulk-draft-progress {
+    background: var(--navy-1e3a5f);
+    color: var(--gray-300);
+}
+
+.bulk-draft-spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--gray-300);
+    border-top-color: var(--blue-500);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
 .checkbox-column {
     width: 36px;
     text-align: center;

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -496,17 +496,10 @@
     min-width: 0;
 }
 
-.draft-preview {
-    border: 1px solid var(--gray-border);
-    border-radius: 6px;
-    padding: 14px;
-    margin-top: 12px;
-    background: var(--gray-50);
-}
-
-.draft-preview h4 {
-    margin: 0 0 10px;
-    font-size: 13px;
+.draft-actions .btn-small {
+    flex: 0 0 auto;
+    padding: 4px 12px;
+    font-size: 0.75rem;
     color: var(--gray-500);
     text-transform: uppercase;
 }
@@ -814,9 +807,21 @@
     background: var(--gray-900);
 }
 
-[data-theme="dark"] .draft-preview {
-    background: var(--gray-900);
-    border-color: var(--gray-700);
+[data-theme="dark"] .modal-content::-webkit-scrollbar {
+    width: 8px;
+}
+
+[data-theme="dark"] .modal-content::-webkit-scrollbar-track {
+    background: var(--gray-800);
+}
+
+[data-theme="dark"] .modal-content::-webkit-scrollbar-thumb {
+    background: var(--gray-600);
+    border-radius: 4px;
+}
+
+[data-theme="dark"] .modal-content::-webkit-scrollbar-thumb:hover {
+    background: var(--gray-500);
 }
 
 [data-theme="dark"] .activity-item {

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -577,10 +577,13 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     sent_at DATETIME DEFAULT NULL,
     contact_page_url VARCHAR(500) DEFAULT NULL,
     places_id VARCHAR(255) DEFAULT NULL,
+    company_size ENUM('small','medium','large') DEFAULT NULL,
+    business_summary TEXT DEFAULT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX idx_outreach_status (status),
     INDEX idx_outreach_city (city),
-    INDEX idx_outreach_approval (approval_status)
+    INDEX idx_outreach_approval (approval_status),
+    INDEX idx_outreach_company_size (company_size)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Activity log for outreach leads

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -561,7 +561,7 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     category VARCHAR(100) DEFAULT NULL,
     city VARCHAR(100) DEFAULT NULL,
     source VARCHAR(100) DEFAULT 'manual',
-    status ENUM('new','researching','ready_to_contact','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded') DEFAULT 'new',
+    status ENUM('new','ready_to_contact','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded') DEFAULT 'new',
     response_status ENUM('no_response','positive','neutral','negative') DEFAULT 'no_response',
     approval_status ENUM('not_drafted','draft_ready','needs_review','approved','sent') DEFAULT 'not_drafted',
     date_added DATETIME DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary

- Adds a **Company Size** combobox (Small / Medium / Large) to the **Business Discovery** section that filters search results after AI automatically classifies each discovered business
- Adds a **Company Size** filter dropdown to the **Leads** section for filtering saved leads by size
- Adds an AI-powered `classify_company_sizes` API endpoint that uses OpenAI to categorize businesses based on their name, category, address, and website
- Adds `company_size` ENUM column to the `outreach_leads` database schema
- Company size is preserved when importing discovery results into leads
- Includes color-coded badges (green=small, amber=medium, purple=large) and a Company Size field in the Lead Detail modal