### PR TITLE
Add website link column and pagination to admin tables

### DIFF
--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -215,6 +215,7 @@ include '../admin_header.php';
                 <tr>
                     <th class="checkbox-column"><div class="checkbox"><input type="checkbox" id="leadsSelectAll" onchange="toggleLeadCheckboxes(this)"><label for="leadsSelectAll"></label></div></th>
                     <th>Business</th>
+                    <th>Website</th>
                     <th>Email</th>
                     <th>Phone</th>
                     <th>City</th>
@@ -224,7 +225,7 @@ include '../admin_header.php';
                 </tr>
             </thead>
             <tbody id="leadsTableBody">
-                <tr><td colspan="9" class="empty-state">Loading...</td></tr>
+                <tr><td colspan="10" class="empty-state">Loading...</td></tr>
             </tbody>
         </table>
     </div>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -177,7 +177,7 @@ async function loadLeads() {
         const tbody = document.getElementById('leadsTableBody');
 
         if (!data.success || !data.leads.length) {
-            tbody.innerHTML = '<tr><td colspan="10" class="empty-state">No leads found</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="11" class="empty-state">No leads found</td></tr>';
             updateBulkBar();
             return;
         }
@@ -191,6 +191,7 @@ async function loadLeads() {
                     <strong>${esc(lead.business_name)}</strong>
                     ${lead.contact_name ? '<br><small>' + esc(lead.contact_name) + '</small>' : ''}
                 </td>
+                <td>${lead.website ? '<a href="' + esc(lead.website) + '" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' + esc(lead.website.replace(/^https?:\\/\\//, '')) + '</a>' : '<span class="text-muted">—</span>'}</td>
                 <td>${lead.email ? esc(lead.email) : '<span class="text-muted">—</span>'}</td>
                 <td>${lead.phone ? esc(lead.phone) : '<span class="text-muted">—</span>'}</td>
                 <td>${esc(lead.city || '')}</td>


### PR DESCRIPTION
## Summary
- Adds a "Website" column to the outreach leads table, displayed as a clickable link
- Adds client-side pagination (25 rows/page) to all admin data tables via a shared `TablePaginator` utility

### Tables with pagination:
- **Outreach**: leads table, discovery results table
- **Users**: user accounts table
- **Payments**: transactions, invoices, failed payments, refunded payments
- **License**: premium subscriptions, free subscription keys
- **Referral Links**: links management table

### How it works:
- `admin/pagination.js` — shared `TablePaginator` class loaded on all admin pages
- PHP-rendered tables auto-initialize via `data-paginate="25"` attribute
- JS-rendered tables (outreach) initialize the paginator after rendering
- Pagination controls show "Showing X–Y of Z" with Prev/Next buttons
- Controls auto-hide when total rows fit on one page
- Works with existing table filters (license search resets pagination)

## Test plan
- [ ] Verify "Website" column appears on outreach leads table with clickable links
- [ ] Verify pagination controls appear on all listed tables when >25 rows exist
- [ ] Verify Prev/Next buttons navigate correctly
- [ ] Verify pagination hides when ≤25 rows
- [ ] Verify license page search filter resets pagination to page 1
- [ ] Verify outreach leads table resets pagination when filters change
- [ ] Verify dark theme styling on pagination controls

https://claude.ai/code/session_01AjHJ3rXzkMVc7ddNPRGuFa