### PR TITLE
Make outreach email daily send limit configurable via environment variable

### DIFF
--- a/cron/outreach_email.php
+++ b/cron/outreach_email.php
@@ -28,7 +28,7 @@ $dotenv->load();
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../email_sender.php';
 
-define('DAILY_SEND_LIMIT', 10);
+define('DAILY_SEND_LIMIT', (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10));
 
 function logOutreach($message, $type = 'INFO') {
     $timestamp = date('Y-m-d H:i:s');


### PR DESCRIPTION
## Summary
Updated the outreach email cron job to read the daily send limit from an environment variable instead of using a hardcoded value, allowing for easier configuration across different environments without code changes.

## Key Changes
- Modified `DAILY_SEND_LIMIT` constant to read from `OUTREACH_DAILY_SEND_LIMIT` environment variable
- Defaults to 10 if the environment variable is not set, maintaining backward compatibility
- Added explicit type casting to ensure the value is treated as an integer

## Implementation Details
The change uses PHP's null coalescing operator (`??`) to provide a fallback value of 10, ensuring the application continues to work even if the environment variable is not configured. The `(int)` cast ensures type safety regardless of how the environment variable is provided.

https://claude.ai/code/session_01Y8TuBLxEWVNAi5FqGd2JzZ