### PR TITLE
Fix email outreach: exhaust cities before advancing, Canadian messaging

### DIFF
--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -523,7 +523,7 @@ Rules:
 $localInstruction
 - Do NOT refer to a \"team\", Evan is a solo developer
 - Get to the point quickly in the first sentence - say why you are emailing. Do NOT open with generic filler like \"I hope this message finds you well\" or vague flattery like \"I admire your work\"
-- Use the business name in the greeting (e.g. \"Hi LVM Landscaping\" or \"Hi [contact name]\" if available)
+- Use the business name in the greeting (e.g. \"Hi LVM Landscaping\" or \"Hi [business name]\" if available)
 
 PERSONALIZATION (this is critical):
 - If a business summary is provided, you MUST use it to make the email specific to their business. Do not write a generic email when you have summary info
@@ -539,7 +539,7 @@ PERSONALIZATION (this is critical):
 
 - Briefly describe Argo Books as a simpler alternative to QuickBooks that requires no accounting knowledge. Do NOT just say \"check it out\" without explaining what it is
 - Mention you are looking for honest feedback from small business owners
-- If appropriate, mention offering a free 1-year premium license in exchange for feedback
+- Mention offering a free 1-year premium license in exchange for feedback
 - Use a casual but professional tone
 - NEVER use placeholders like [Your Name], [Your Title], [Your Company], etc.
 - ALWAYS include the website link https://argorobots.com/ in the email body. This is required in every single email, no exceptions

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -212,7 +212,7 @@ function scrape_email_from_website($url)
  * Core business search logic. Returns array with 'businesses', 'count', 'rounds'.
  * Used by both the admin API endpoint and the cron pipeline.
  */
-function search_businesses_core($city, $province, $category, $limit, $apiKey, $excludePlaceIds = [])
+function search_businesses_core($city, $province, $category, $limit, $apiKey, $excludePlaceIds = [], $maxRounds = 5)
 {
     $location = $province ? "$city, $province" : $city;
     $businesses = [];
@@ -221,7 +221,6 @@ function search_businesses_core($city, $province, $category, $limit, $apiKey, $e
     foreach ($excludePlaceIds as $id) {
         $seenPlaceIds[trim($id)] = true;
     }
-    $maxRounds = 5;
     $roundsUsed = 0;
 
     // Stream context with timeouts for all Google API calls

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -12,6 +12,36 @@
 if (defined('OUTREACH_HELPERS_LOADED')) return;
 define('OUTREACH_HELPERS_LOADED', true);
 
+// ─── Discovery Category Pool ───
+// Used by both the cron pipeline (deterministic cycling) and search_businesses_core (random fallback for admin searches)
+const OUTREACH_CATEGORY_POOL = [
+    'restaurants', 'plumbers', 'electricians', 'dentists', 'lawyers',
+    'accountants', 'real estate agents', 'insurance agents', 'auto repair',
+    'hair salons', 'fitness gyms', 'chiropractors', 'veterinarians',
+    'cleaning services', 'landscaping', 'roofing contractors', 'HVAC',
+    'photographers', 'florists', 'bakeries', 'coffee shops', 'pet stores',
+    'daycare centers', 'tutoring services', 'martial arts studios',
+    'yoga studios', 'massage therapists', 'optometrists', 'pharmacies',
+    'printing services', 'moving companies', 'pest control', 'locksmiths',
+    'car dealerships', 'tire shops', 'furniture stores', 'jewelry stores',
+    'clothing boutiques', 'tattoo parlors', 'breweries', 'catering',
+    'wedding planners', 'interior designers', 'architects', 'surveyors',
+    'physiotherapists', 'psychologists', 'counsellors', 'notaries',
+    'bookkeepers', 'IT support', 'web design', 'marketing agencies',
+    'sign shops', 'trophy shops', 'music schools', 'dance studios',
+    'dog groomers', 'boarding kennels', 'farm equipment dealers',
+    'hardware stores', 'building supplies', 'appliance repair',
+    'upholstery services', 'tailors', 'dry cleaners', 'spas',
+    'tanning salons', 'nail salons', 'barber shops', 'optical stores',
+    'hearing aid clinics', 'home inspectors', 'appraisers',
+    'property management', 'storage facilities', 'courier services',
+    'towing services', 'glass repair', 'fencing contractors',
+    'concrete contractors', 'paving contractors', 'tree services',
+    'snow removal', 'pool services', 'septic services',
+    'garage door repair', 'security companies', 'staffing agencies',
+    'travel agencies', 'event venues', 'food trucks',
+];
+
 // ─── Activity Logging ───
 
 function log_activity($pdo, $lead_id, $action_type, $details = null)
@@ -209,35 +239,9 @@ function search_businesses_core($city, $province, $category, $limit, $apiKey, $e
         $queries[] = "$category companies in $location";
         $queries[] = "best $category in $location";
     } else {
-        // When no category provided, use a wide spread of real business categories
-        // so each round searches a different industry instead of generic synonyms
-        $categoryPool = [
-            'restaurants', 'plumbers', 'electricians', 'dentists', 'lawyers',
-            'accountants', 'real estate agents', 'insurance agents', 'auto repair',
-            'hair salons', 'fitness gyms', 'chiropractors', 'veterinarians',
-            'cleaning services', 'landscaping', 'roofing contractors', 'HVAC',
-            'photographers', 'florists', 'bakeries', 'coffee shops', 'pet stores',
-            'daycare centers', 'tutoring services', 'martial arts studios',
-            'yoga studios', 'massage therapists', 'optometrists', 'pharmacies',
-            'printing services', 'moving companies', 'pest control', 'locksmiths',
-            'car dealerships', 'tire shops', 'furniture stores', 'jewelry stores',
-            'clothing boutiques', 'tattoo parlors', 'breweries', 'catering',
-            'wedding planners', 'interior designers', 'architects', 'surveyors',
-            'physiotherapists', 'psychologists', 'counsellors', 'notaries',
-            'bookkeepers', 'IT support', 'web design', 'marketing agencies',
-            'sign shops', 'trophy shops', 'music schools', 'dance studios',
-            'dog groomers', 'boarding kennels', 'farm equipment dealers',
-            'hardware stores', 'building supplies', 'appliance repair',
-            'upholstery services', 'tailors', 'dry cleaners', 'spas',
-            'tanning salons', 'nail salons', 'barber shops', 'optical stores',
-            'hearing aid clinics', 'home inspectors', 'appraisers',
-            'property management', 'storage facilities', 'courier services',
-            'towing services', 'glass repair', 'fencing contractors',
-            'concrete contractors', 'paving contractors', 'tree services',
-            'snow removal', 'pool services', 'septic services',
-            'garage door repair', 'security companies', 'staffing agencies',
-            'travel agencies', 'event venues', 'food trucks',
-        ];
+        // When no category provided (admin dashboard searches), pick random
+        // categories from the shared pool so each round searches a different industry
+        $categoryPool = OUTREACH_CATEGORY_POOL;
         shuffle($categoryPool);
         for ($i = 0; $i < $maxRounds; $i++) {
             $queries[] = $categoryPool[$i] . " in $location";

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -507,7 +507,7 @@ function generate_draft_for_lead($pdo, $lead)
 
     $localInstruction = $isLocal
         ? "- The business is in Saskatchewan. Evan is a local Saskatchewan software developer based in Saskatoon. ALWAYS mention being local, e.g. \"I'm a local Saskatoon software developer\" or \"As a fellow Saskatchewan business\". This local connection is important, make it feel personal."
-        : "- The business is outside Saskatchewan. Evan is a Canadian software developer based in Saskatoon. Mention being a Canadian developer, NOT a local developer. Do not emphasize the Saskatchewan connection.";
+        : "- The business is outside Saskatchewan. Evan is a Canadian software developer. Say \"Canadian software developer\", do NOT say \"local\" and do NOT mention Saskatoon or Saskatchewan.";
 
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
 
@@ -515,7 +515,7 @@ About Argo Books:
 - It is like QuickBooks but way simpler, designed so you do not need any accounting knowledge at all
 - Built specifically for small businesses, not a bloated enterprise tool
 - Features include invoicing, expense tracking, and simple bookkeeping
-- Evan is an independent software developer based in Saskatoon building this specifically for small businesses
+- Evan is " . ($isLocal ? "a local independent software developer based in Saskatoon" : "a Canadian independent software developer") . " building this specifically for small businesses
 
 Rules:
 - Keep it very short (2-3 short paragraphs max, under 100 words ideally)

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -507,7 +507,7 @@ function generate_draft_for_lead($pdo, $lead)
 
     $localInstruction = $isLocal
         ? "- The business is in Saskatchewan. Evan is a local Saskatchewan software developer based in Saskatoon. ALWAYS mention being local, e.g. \"I'm a local Saskatoon software developer\" or \"As a fellow Saskatchewan business\". This local connection is important, make it feel personal."
-        : "- Evan is an independent software developer based in Saskatoon, Saskatchewan. Mention this briefly for context.";
+        : "- The business is outside Saskatchewan. Evan is a Canadian software developer based in Saskatoon. Mention being a Canadian developer, NOT a local developer. Do not emphasize the Saskatchewan connection.";
 
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
 
@@ -515,7 +515,7 @@ About Argo Books:
 - It is like QuickBooks but way simpler, designed so you do not need any accounting knowledge at all
 - Built specifically for small businesses, not a bloated enterprise tool
 - Features include invoicing, expense tracking, and simple bookkeeping
-- Evan is a local independent software developer based in Saskatoon building this specifically for small businesses
+- Evan is an independent software developer based in Saskatoon building this specifically for small businesses
 
 Rules:
 - Keep it very short (2-3 short paragraphs max, under 100 words ideally)

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -53,6 +53,7 @@ if (!flock($lockFp, LOCK_EX | LOCK_NB)) {
 
 define('DAILY_SEND_LIMIT', (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10));
 define('AUTO_APPROVE', filter_var($_ENV['OUTREACH_AUTO_APPROVE'] ?? 'true', FILTER_VALIDATE_BOOLEAN));
+define('CATEGORIES_PER_RUN', 5);
 
 // Parse CLI flags
 $args = array_slice($argv, 1);
@@ -219,15 +220,16 @@ function stepDiscover($pdo, $dryRun)
     // Determine which city to search next
     $cityIndex = (int) getState($pdo, 'current_city_index', '0');
     if ($cityIndex >= count($targetCities)) {
-        // Wrap around to start — re-search cities for new businesses
         $cityIndex = 0;
-        setState($pdo, 'current_city_index', '0');
-        setState($pdo, 'current_city_category_offset', '0');
+        if (!$dryRun) {
+            setState($pdo, 'current_city_index', '0');
+            setState($pdo, 'current_city_category_offset', '0');
+        }
         logPipeline('All cities searched. Wrapping around to start.');
     }
 
     // Track which categories we've searched for the current city.
-    // Each run searches 5 categories starting from this offset.
+    // Each run searches CATEGORIES_PER_RUN categories starting from this offset.
     // Only when we've cycled through ALL categories without finding
     // new leads do we consider the city truly exhausted.
     $categoryOffset = (int) getState($pdo, 'current_city_category_offset', '0');
@@ -236,13 +238,14 @@ function stepDiscover($pdo, $dryRun)
     $city = $target['city'];
     $province = $target['province'];
 
-    // Pick the next 5 categories to search (wrapping around the pool)
+    // Pick the next batch of categories to search (wrapping around the pool)
     $categoriesToSearch = [];
-    for ($i = 0; $i < 5; $i++) {
+    for ($i = 0; $i < CATEGORIES_PER_RUN; $i++) {
         $categoriesToSearch[] = OUTREACH_CATEGORY_POOL[($categoryOffset + $i) % $totalCategories];
     }
 
-    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", categories " . ($categoryOffset + 1) . "-" . ($categoryOffset + 5) . "/$totalCategories) ---");
+    $endCategory = min($categoryOffset + CATEGORIES_PER_RUN, $totalCategories);
+    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", categories " . ($categoryOffset + 1) . "-$endCategory/$totalCategories) ---");
     logPipeline("Searching categories: " . implode(', ', $categoriesToSearch));
 
     if ($dryRun) {
@@ -255,19 +258,23 @@ function stepDiscover($pdo, $dryRun)
     $stmt->execute();
     $existingPlaceIds = array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'places_id');
 
-    // Search each category individually and collect results
+    // Search each category individually and collect results.
+    // Pass maxRounds=1 since each category is already specific — we don't need
+    // 5 query variations per category like the admin dashboard does.
     $businesses = [];
     $roundsUsed = 0;
+    $apiErrors = 0;
 
     foreach ($categoriesToSearch as $cat) {
         if (count($businesses) >= DAILY_SEND_LIMIT) break;
 
         $remaining = DAILY_SEND_LIMIT - count($businesses);
-        $result = search_businesses_core($city, $province, $cat, $remaining, $apiKey, $existingPlaceIds);
+        $result = search_businesses_core($city, $province, $cat, $remaining, $apiKey, $existingPlaceIds, 1);
         $roundsUsed++;
 
         if (isset($result['error'])) {
             logPipeline("API error searching '$cat' in $city: {$result['error']}", 'WARN');
+            $apiErrors++;
             continue;
         }
 
@@ -280,7 +287,13 @@ function stepDiscover($pdo, $dryRun)
         }
     }
 
-    logPipeline("Discovered " . count($businesses) . " businesses with emails in $city ($roundsUsed category searches)");
+    // If every single API call failed, don't advance — retry same categories next run
+    if ($apiErrors === $roundsUsed) {
+        logPipeline("All $apiErrors API calls failed for $city. Will retry same categories next run.", 'ERROR');
+        return;
+    }
+
+    logPipeline("Discovered " . count($businesses) . " businesses with emails in $city ($roundsUsed category searches, $apiErrors errors)");
 
     // Import discovered businesses
     $imported = 0;
@@ -330,30 +343,22 @@ function stepDiscover($pdo, $dryRun)
     logPipeline("Imported $imported new leads, skipped $skipped duplicates from $city");
 
     // Advance the category offset for the next run
-    $newOffset = $categoryOffset + 5;
+    $newOffset = $categoryOffset + CATEGORIES_PER_RUN;
 
     if ($newOffset >= $totalCategories) {
         // We've cycled through every category for this city
         if ($imported === 0) {
-            // Went through all categories and found nothing new — city is exhausted
             logPipeline("All $totalCategories categories searched for $city with no new leads. City exhausted, advancing.");
             setState($pdo, 'current_city_index', (string)($cityIndex + 1));
             setState($pdo, 'current_city_category_offset', '0');
         } else {
-            // Found some leads on the last pass — reset offset and search again
             logPipeline("Completed full category cycle for $city but still finding leads. Resetting categories.");
             setState($pdo, 'current_city_category_offset', '0');
         }
     } else {
-        if ($imported > 0) {
-            // Still finding leads, advance to next batch of categories
-            logPipeline("Still finding leads in $city. Next run will search categories " . ($newOffset + 1) . "-" . min($newOffset + 5, $totalCategories) . ".");
-            setState($pdo, 'current_city_category_offset', (string)$newOffset);
-        } else {
-            // This batch found nothing, but there are more categories to try
-            logPipeline("No new leads from these categories, but " . ($totalCategories - $newOffset) . " categories remaining for $city.");
-            setState($pdo, 'current_city_category_offset', (string)$newOffset);
-        }
+        setState($pdo, 'current_city_category_offset', (string)$newOffset);
+        $nextEnd = min($newOffset + CATEGORIES_PER_RUN, $totalCategories);
+        logPipeline("Next run will search categories " . ($newOffset + 1) . "-$nextEnd/$totalCategories for $city.");
     }
 
     setState($pdo, 'last_discovery_date', date('Y-m-d'));

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -204,39 +204,9 @@ try {
 //  STEP IMPLEMENTATIONS
 // ══════════════════════════════════════════════════════════════
 
-// The category pool used for discovery. Defined here so the pipeline can
-// cycle through them deterministically instead of randomly.
-$discoveryCategoryPool = [
-    'restaurants', 'plumbers', 'electricians', 'dentists', 'lawyers',
-    'accountants', 'real estate agents', 'insurance agents', 'auto repair',
-    'hair salons', 'fitness gyms', 'chiropractors', 'veterinarians',
-    'cleaning services', 'landscaping', 'roofing contractors', 'HVAC',
-    'photographers', 'florists', 'bakeries', 'coffee shops', 'pet stores',
-    'daycare centers', 'tutoring services', 'martial arts studios',
-    'yoga studios', 'massage therapists', 'optometrists', 'pharmacies',
-    'printing services', 'moving companies', 'pest control', 'locksmiths',
-    'car dealerships', 'tire shops', 'furniture stores', 'jewelry stores',
-    'clothing boutiques', 'tattoo parlors', 'breweries', 'catering',
-    'wedding planners', 'interior designers', 'architects', 'surveyors',
-    'physiotherapists', 'psychologists', 'counsellors', 'notaries',
-    'bookkeepers', 'IT support', 'web design', 'marketing agencies',
-    'sign shops', 'trophy shops', 'music schools', 'dance studios',
-    'dog groomers', 'boarding kennels', 'farm equipment dealers',
-    'hardware stores', 'building supplies', 'appliance repair',
-    'upholstery services', 'tailors', 'dry cleaners', 'spas',
-    'tanning salons', 'nail salons', 'barber shops', 'optical stores',
-    'hearing aid clinics', 'home inspectors', 'appraisers',
-    'property management', 'storage facilities', 'courier services',
-    'towing services', 'glass repair', 'fencing contractors',
-    'concrete contractors', 'paving contractors', 'tree services',
-    'snow removal', 'pool services', 'septic services',
-    'garage door repair', 'security companies', 'staffing agencies',
-    'travel agencies', 'event venues', 'food trucks',
-];
-
 function stepDiscover($pdo, $dryRun)
 {
-    global $targetCities, $discoveryCategoryPool;
+    global $targetCities;
 
     $apiKey = $_ENV['GOOGLE_PLACES_API_KEY'] ?? '';
     if (empty($apiKey)) {
@@ -244,7 +214,7 @@ function stepDiscover($pdo, $dryRun)
         return;
     }
 
-    $totalCategories = count($discoveryCategoryPool);
+    $totalCategories = count(OUTREACH_CATEGORY_POOL);
 
     // Determine which city to search next
     $cityIndex = (int) getState($pdo, 'current_city_index', '0');
@@ -269,7 +239,7 @@ function stepDiscover($pdo, $dryRun)
     // Pick the next 5 categories to search (wrapping around the pool)
     $categoriesToSearch = [];
     for ($i = 0; $i < 5; $i++) {
-        $categoriesToSearch[] = $discoveryCategoryPool[($categoryOffset + $i) % $totalCategories];
+        $categoriesToSearch[] = OUTREACH_CATEGORY_POOL[($categoryOffset + $i) % $totalCategories];
     }
 
     logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", categories " . ($categoryOffset + 1) . "-" . ($categoryOffset + 5) . "/$totalCategories) ---");

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -52,8 +52,6 @@ if (!flock($lockFp, LOCK_EX | LOCK_NB)) {
 // ─── Configuration ───
 
 define('DAILY_SEND_LIMIT', (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10));
-define('DISCOVERY_BATCH_SIZE', (int) ($_ENV['OUTREACH_DISCOVERY_BATCH'] ?? 20));
-define('DRAFT_BATCH_SIZE', (int) ($_ENV['OUTREACH_DRAFT_BATCH'] ?? 15));
 define('AUTO_APPROVE', filter_var($_ENV['OUTREACH_AUTO_APPROVE'] ?? 'true', FILTER_VALIDATE_BOOLEAN));
 
 // Parse CLI flags
@@ -233,7 +231,6 @@ function stepDiscover($pdo, $dryRun)
 
     if ($dryRun) {
         logPipeline("[DRY RUN] Would search Google Places for businesses in $city, $province");
-        setState($pdo, 'current_city_index', (string)($cityIndex + 1));
         return;
     }
 
@@ -242,7 +239,7 @@ function stepDiscover($pdo, $dryRun)
     $stmt->execute();
     $existingPlaceIds = array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'places_id');
 
-    $result = search_businesses_core($city, $province, '', DISCOVERY_BATCH_SIZE, $apiKey, $existingPlaceIds);
+    $result = search_businesses_core($city, $province, '', DAILY_SEND_LIMIT, $apiKey, $existingPlaceIds);
 
     if (isset($result['error'])) {
         logPipeline("API error for $city: {$result['error']}. Will retry this city next run.", 'ERROR');
@@ -307,8 +304,13 @@ function stepDiscover($pdo, $dryRun)
 
     logPipeline("Imported $imported new leads, skipped $skipped duplicates from $city");
 
-    // Advance to next city for tomorrow
-    setState($pdo, 'current_city_index', (string)($cityIndex + 1));
+    // Only advance to next city if no new leads were imported (city is exhausted)
+    if ($imported === 0) {
+        logPipeline("No new leads imported from $city. Advancing to next city.");
+        setState($pdo, 'current_city_index', (string)($cityIndex + 1));
+    } else {
+        logPipeline("Still finding leads in $city. Will search here again next run.");
+    }
     setState($pdo, 'last_discovery_date', date('Y-m-d'));
     setState($pdo, 'last_discovery_city', "$city, $province");
 }
@@ -334,7 +336,7 @@ function stepGenerateDrafts($pdo, $dryRun)
         ORDER BY date_added ASC
         LIMIT ?
     ");
-    $stmt->execute([DRAFT_BATCH_SIZE]);
+    $stmt->execute([DAILY_SEND_LIMIT]);
     $leads = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     if (empty($leads)) {

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -204,9 +204,39 @@ try {
 //  STEP IMPLEMENTATIONS
 // ══════════════════════════════════════════════════════════════
 
+// The category pool used for discovery. Defined here so the pipeline can
+// cycle through them deterministically instead of randomly.
+$discoveryCategoryPool = [
+    'restaurants', 'plumbers', 'electricians', 'dentists', 'lawyers',
+    'accountants', 'real estate agents', 'insurance agents', 'auto repair',
+    'hair salons', 'fitness gyms', 'chiropractors', 'veterinarians',
+    'cleaning services', 'landscaping', 'roofing contractors', 'HVAC',
+    'photographers', 'florists', 'bakeries', 'coffee shops', 'pet stores',
+    'daycare centers', 'tutoring services', 'martial arts studios',
+    'yoga studios', 'massage therapists', 'optometrists', 'pharmacies',
+    'printing services', 'moving companies', 'pest control', 'locksmiths',
+    'car dealerships', 'tire shops', 'furniture stores', 'jewelry stores',
+    'clothing boutiques', 'tattoo parlors', 'breweries', 'catering',
+    'wedding planners', 'interior designers', 'architects', 'surveyors',
+    'physiotherapists', 'psychologists', 'counsellors', 'notaries',
+    'bookkeepers', 'IT support', 'web design', 'marketing agencies',
+    'sign shops', 'trophy shops', 'music schools', 'dance studios',
+    'dog groomers', 'boarding kennels', 'farm equipment dealers',
+    'hardware stores', 'building supplies', 'appliance repair',
+    'upholstery services', 'tailors', 'dry cleaners', 'spas',
+    'tanning salons', 'nail salons', 'barber shops', 'optical stores',
+    'hearing aid clinics', 'home inspectors', 'appraisers',
+    'property management', 'storage facilities', 'courier services',
+    'towing services', 'glass repair', 'fencing contractors',
+    'concrete contractors', 'paving contractors', 'tree services',
+    'snow removal', 'pool services', 'septic services',
+    'garage door repair', 'security companies', 'staffing agencies',
+    'travel agencies', 'event venues', 'food trucks',
+];
+
 function stepDiscover($pdo, $dryRun)
 {
-    global $targetCities;
+    global $targetCities, $discoveryCategoryPool;
 
     $apiKey = $_ENV['GOOGLE_PLACES_API_KEY'] ?? '';
     if (empty($apiKey)) {
@@ -214,20 +244,36 @@ function stepDiscover($pdo, $dryRun)
         return;
     }
 
+    $totalCategories = count($discoveryCategoryPool);
+
     // Determine which city to search next
     $cityIndex = (int) getState($pdo, 'current_city_index', '0');
     if ($cityIndex >= count($targetCities)) {
         // Wrap around to start — re-search cities for new businesses
         $cityIndex = 0;
         setState($pdo, 'current_city_index', '0');
+        setState($pdo, 'current_city_category_offset', '0');
         logPipeline('All cities searched. Wrapping around to start.');
     }
+
+    // Track which categories we've searched for the current city.
+    // Each run searches 5 categories starting from this offset.
+    // Only when we've cycled through ALL categories without finding
+    // new leads do we consider the city truly exhausted.
+    $categoryOffset = (int) getState($pdo, 'current_city_category_offset', '0');
 
     $target = $targetCities[$cityIndex];
     $city = $target['city'];
     $province = $target['province'];
 
-    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ") ---");
+    // Pick the next 5 categories to search (wrapping around the pool)
+    $categoriesToSearch = [];
+    for ($i = 0; $i < 5; $i++) {
+        $categoriesToSearch[] = $discoveryCategoryPool[($categoryOffset + $i) % $totalCategories];
+    }
+
+    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", categories " . ($categoryOffset + 1) . "-" . ($categoryOffset + 5) . "/$totalCategories) ---");
+    logPipeline("Searching categories: " . implode(', ', $categoriesToSearch));
 
     if ($dryRun) {
         logPipeline("[DRY RUN] Would search Google Places for businesses in $city, $province");
@@ -239,23 +285,32 @@ function stepDiscover($pdo, $dryRun)
     $stmt->execute();
     $existingPlaceIds = array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'places_id');
 
-    $result = search_businesses_core($city, $province, '', DAILY_SEND_LIMIT, $apiKey, $existingPlaceIds);
+    // Search each category individually and collect results
+    $businesses = [];
+    $roundsUsed = 0;
 
-    if (isset($result['error'])) {
-        logPipeline("API error for $city: {$result['error']}. Will retry this city next run.", 'ERROR');
-        return;
+    foreach ($categoriesToSearch as $cat) {
+        if (count($businesses) >= DAILY_SEND_LIMIT) break;
+
+        $remaining = DAILY_SEND_LIMIT - count($businesses);
+        $result = search_businesses_core($city, $province, $cat, $remaining, $apiKey, $existingPlaceIds);
+        $roundsUsed++;
+
+        if (isset($result['error'])) {
+            logPipeline("API error searching '$cat' in $city: {$result['error']}", 'WARN');
+            continue;
+        }
+
+        // Add new place IDs to exclude list so next category doesn't re-find them
+        foreach ($result['businesses'] as $biz) {
+            if (!empty($biz['places_id'])) {
+                $existingPlaceIds[] = $biz['places_id'];
+            }
+            $businesses[] = $biz;
+        }
     }
 
-    $businesses = $result['businesses'];
-    $count = $result['count'];
-
-    logPipeline("Discovered $count businesses with emails in $city (searched {$result['rounds']} round(s))");
-
-    if (empty($businesses)) {
-        logPipeline("No new businesses found in $city. Moving to next city.");
-        setState($pdo, 'current_city_index', (string)($cityIndex + 1));
-        return;
-    }
+    logPipeline("Discovered " . count($businesses) . " businesses with emails in $city ($roundsUsed category searches)");
 
     // Import discovered businesses
     $imported = 0;
@@ -304,13 +359,33 @@ function stepDiscover($pdo, $dryRun)
 
     logPipeline("Imported $imported new leads, skipped $skipped duplicates from $city");
 
-    // Only advance to next city if no new leads were imported (city is exhausted)
-    if ($imported === 0) {
-        logPipeline("No new leads imported from $city. Advancing to next city.");
-        setState($pdo, 'current_city_index', (string)($cityIndex + 1));
+    // Advance the category offset for the next run
+    $newOffset = $categoryOffset + 5;
+
+    if ($newOffset >= $totalCategories) {
+        // We've cycled through every category for this city
+        if ($imported === 0) {
+            // Went through all categories and found nothing new — city is exhausted
+            logPipeline("All $totalCategories categories searched for $city with no new leads. City exhausted, advancing.");
+            setState($pdo, 'current_city_index', (string)($cityIndex + 1));
+            setState($pdo, 'current_city_category_offset', '0');
+        } else {
+            // Found some leads on the last pass — reset offset and search again
+            logPipeline("Completed full category cycle for $city but still finding leads. Resetting categories.");
+            setState($pdo, 'current_city_category_offset', '0');
+        }
     } else {
-        logPipeline("Still finding leads in $city. Will search here again next run.");
+        if ($imported > 0) {
+            // Still finding leads, advance to next batch of categories
+            logPipeline("Still finding leads in $city. Next run will search categories " . ($newOffset + 1) . "-" . min($newOffset + 5, $totalCategories) . ".");
+            setState($pdo, 'current_city_category_offset', (string)$newOffset);
+        } else {
+            // This batch found nothing, but there are more categories to try
+            logPipeline("No new leads from these categories, but " . ($totalCategories - $newOffset) . " categories remaining for $city.");
+            setState($pdo, 'current_city_category_offset', (string)$newOffset);
+        }
     }
+
     setState($pdo, 'last_discovery_date', date('Y-m-d'));
     setState($pdo, 'last_discovery_city', "$city, $province");
 }

--- a/read-me/Cron jobs.md
+++ b/read-me/Cron jobs.md
@@ -87,9 +87,7 @@ php /home/argorobots/public_html/cron/account_purge.php
 |---|---|---|
 | `GOOGLE_PLACES_API_KEY` | — | Required for business discovery |
 | `OPENAI_API_KEY` | — | Required for AI draft generation |
-| `OUTREACH_DAILY_SEND_LIMIT` | 10 | Max emails sent per day |
-| `OUTREACH_DISCOVERY_BATCH` | 20 | Businesses to discover per run |
-| `OUTREACH_DRAFT_BATCH` | 15 | Drafts to generate per run |
+| `OUTREACH_DAILY_SEND_LIMIT` | 10 | Max emails sent per day (also controls discovery and draft batch sizes) |
 | `OUTREACH_AUTO_APPROVE` | true | Auto-approve generated drafts |
 
 ### CLI Flags

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -182,9 +182,7 @@ Key-value store used by the cron pipeline to track its position across runs.
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
-| `OUTREACH_DAILY_SEND_LIMIT` | `10` | Maximum emails sent per day |
-| `OUTREACH_DISCOVERY_BATCH` | `20` | Businesses to discover per city per run |
-| `OUTREACH_DRAFT_BATCH` | `15` | Drafts to generate per run |
+| `OUTREACH_DAILY_SEND_LIMIT` | `10` | Maximum emails sent per day (also controls discovery and draft batch sizes) |
 | `OUTREACH_AUTO_APPROVE` | `true` | Automatically approve generated drafts |
 
 ### Required API Keys


### PR DESCRIPTION
## Summary
- **City rotation**: Pipeline no longer advances to the next city every day. It stays on the current city until no new leads are imported (city is exhausted). This means Saskatoon gets fully exhausted first, then the rest of Saskatchewan, before moving to other provinces.
- **Canadian messaging**: Non-Saskatchewan businesses now get emails saying "Canadian software developer" instead of implying a local connection. Saskatchewan businesses still get the "local Saskatoon software developer" messaging.
- **Removed OUTREACH_DISCOVERY_BATCH and OUTREACH_DRAFT_BATCH**: These were redundant with OUTREACH_DAILY_SEND_LIMIT. Discovery and draft generation now both use DAILY_SEND_LIMIT as their batch size.

## Test plan
- [ ] Verify pipeline stays on Saskatoon when new leads are still being found
- [ ] Verify pipeline advances to Regina only after Saskatoon yields 0 new imports
- [ ] Verify non-SK draft emails use "Canadian software developer" phrasing
- [ ] Verify SK draft emails still use "local Saskatoon software developer" phrasing
- [ ] Run with `--dry-run` to confirm city doesn't advance during dry runs

https://claude.ai/code/session_01H6YitFqJGkuhXhmmQE57HR