### PR TITLE
Fix cron CLI access check for account_purge and subscription_renewal

### DIFF
--- a/cron/account_purge.php
+++ b/cron/account_purge.php
@@ -14,10 +14,10 @@
 
 set_time_limit(120);
 
-// Only allow CLI execution
-if (php_sapi_name() !== 'cli') {
+// Only allow CLI, or CGI cron (no REMOTE_ADDR means not a web request)
+if (php_sapi_name() !== 'cli' && !empty($_SERVER['REMOTE_ADDR'])) {
     http_response_code(403);
-    die('Access denied. This script can only be run via CLI.');
+    die('Access denied. This script can only be run via CLI/cron.');
 }
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -28,11 +28,10 @@
 // Prevent timeout for long-running process
 set_time_limit(300);
 
-// Only allow CLI execution — web-based triggering (e.g. via X-Cron-Key header)
-// is intentionally not supported; use system cron instead.
-if (php_sapi_name() !== 'cli') {
+// Only allow CLI, or CGI cron (no REMOTE_ADDR means not a web request)
+if (php_sapi_name() !== 'cli' && !empty($_SERVER['REMOTE_ADDR'])) {
     http_response_code(403);
-    die('Access denied. This script can only be run via CLI.');
+    die('Access denied. This script can only be run via CLI/cron.');
 }
 
 // Load environment variables


### PR DESCRIPTION
## Summary

- The `account_purge.php` and `subscription_renewal.php` cron scripts were failing with `403 Access denied` because they used a strict `php_sapi_name() !== 'cli'` check
- The hosting cron executes scripts via CGI (not CLI), so `php_sapi_name()` returns `cgi-fcgi` instead of `cli`
- Updated both scripts to match the working `outreach_pipeline.php` check: `php_sapi_name() !== 'cli' && !empty($_SERVER['REMOTE_ADDR'])` — this allows CGI-based cron (no remote address) while still blocking direct web requests

## Test plan

- [ ] Verify account_purge and subscription_renewal crons run successfully on next scheduled execution
- [ ] Confirm scripts still reject direct browser/web access (should still return 403)

https://claude.ai/code/session_012cf2eaDwktb7LAtogwaVFG