### PR TITLE
Add expense & revenue tracking feature page

### DIFF
--- a/features/expense-revenue-tracking/index.php
+++ b/features/expense-revenue-tracking/index.php
@@ -162,7 +162,7 @@
         <div class="container">
             <div class="highlight-grid animate-on-scroll">
                 <div class="highlight-item">
-                    <h3>2 clicks</h3>
+                    <h3>10 seconds</h3>
                     <p>To record a new transaction</p>
                 </div>
                 <div class="highlight-item">
@@ -170,7 +170,7 @@
                     <p>Revenue, expense &amp; profit summaries</p>
                 </div>
                 <div class="highlight-item">
-                    <h3>0</h3>
+                    <h3>Zero</h3>
                     <p>Accounting experience required</p>
                 </div>
             </div>

--- a/features/expense-revenue-tracking/index.php
+++ b/features/expense-revenue-tracking/index.php
@@ -8,25 +8,39 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Argo">
 
-    <meta name="description" content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, and automatic categorization make bookkeeping simple for any small business.">
-    <meta name="keywords" content="expense tracking software, revenue tracking, bookkeeping software, small business expense tracker, income tracking">
+    <!-- SEO Meta Tags -->
+    <meta name="description"
+        content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, receipt archiving, and real-time profit monitoring make bookkeeping simple for any small business.">
+    <meta name="keywords"
+        content="expense tracking software, revenue tracking, bookkeeping software, small business expense tracker, income tracking, profit monitoring, receipt management, expense categorization, cash flow tracking, business expense app">
 
+    <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Expense &amp; Revenue Tracking — Argo Books">
-    <meta property="og:description" content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, and automatic categorization make bookkeeping simple for any small business.">
+    <meta property="og:description"
+        content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, and automatic categorization make bookkeeping simple for any small business.">
     <meta property="og:url" content="https://argorobots.com/features/expense-revenue-tracking/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Argo Books">
     <meta property="og:locale" content="en_CA">
+    <meta property="og:image" content="https://ogimage.io/templates/brand?title=Expense+%26+Revenue+Tracking&subtitle=Track+every+dollar+in+and+out.+Guided+forms%2C+smart+validation%2C+and+real-time+profit+monitoring.&logo=https%3A%2F%2Fargorobots.com%2Fresources%2Fimages%2Fargo-logo%2Fargo-icon.ico">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
 
+    <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Expense &amp; Revenue Tracking — Argo Books">
-    <meta name="twitter:description" content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, and automatic categorization make bookkeeping simple for any small business.">
+    <meta name="twitter:description"
+        content="Track business expenses and revenue with Argo Books. Guided forms, smart validation, and automatic categorization make bookkeeping simple.">
+    <meta name="twitter:image" content="https://ogimage.io/templates/brand?title=Expense+%26+Revenue+Tracking&subtitle=Track+every+dollar+in+and+out.+Guided+forms%2C+smart+validation%2C+and+real-time+profit+monitoring.&logo=https%3A%2F%2Fargorobots.com%2Fresources%2Fimages%2Fargo-logo%2Fargo-icon.ico">
 
+    <!-- Additional SEO Meta Tags -->
     <meta name="geo.region" content="CA-SK">
     <meta name="geo.placename" content="Canada">
 
+    <!-- Canonical URL -->
     <link rel="canonical" href="https://argorobots.com/features/expense-revenue-tracking/">
 
+    <!-- Breadcrumb Schema -->
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
@@ -58,6 +72,9 @@
     </header>
     <main>
 
+    <!-- =============================================
+         HERO SECTION
+         ============================================= -->
     <section class="hero">
         <div class="hero-bg">
             <div class="hero-gradient-orb hero-orb-1"></div>
@@ -68,8 +85,8 @@
                 <?= svg_icon('dollar', 16) ?>
                 <span>Expense &amp; Revenue Tracking</span>
             </div>
-            <h1 class="animate-fade-in">Expense &amp; Revenue Tracking</h1>
-            <p class="hero-subtitle animate-fade-in">Track every dollar coming in and going out. Categorize transactions, monitor cash flow, and keep your books accurate — all without accounting experience.</p>
+            <h1 class="animate-fade-in">Know exactly where every dollar goes — and where it comes from</h1>
+            <p class="hero-subtitle animate-fade-in">Track every expense and revenue transaction in one place. Guided forms, smart validation, and real-time profit monitoring keep your books accurate without accounting experience.</p>
             <div class="hero-ctas animate-fade-in">
                 <a href="../../downloads/" class="btn-cta btn-cta-primary">
                     <span>Get Started Free</span>
@@ -82,14 +99,447 @@
         </div>
     </section>
 
+    <!-- =============================================
+         DETAIL SECTION 1: The Problem + Solution
+         Text left, image right
+         ============================================= -->
+    <section class="feature-detail-section">
+        <div class="container">
+            <div class="feature-detail animate-on-scroll">
+                <div class="feature-detail-text">
+                    <span class="section-label">The Problem</span>
+                    <h2>Spreadsheets weren't built for tracking your money</h2>
+                    <p>Most small businesses start with spreadsheets or shoebox receipts. Formulas break, transactions get missed, and you never know if you're actually profitable until it's too late. Argo Books gives you a purpose-built system for recording every purchase and every sale — with guided forms that make it impossible to miss a field.</p>
+                    <ul class="feature-checklist">
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Separate expense and revenue pages with dedicated workflows</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Guided forms with smart defaults — supplier, product, date, and amount</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Automatic validation catches missing fields before you save</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Real-time summary cards show totals, transaction counts, and returns at a glance</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="feature-detail-visual">
+                    <img src="../../resources/images/features/expenses-table.svg" alt="Argo Books expenses page showing organized expense records with supplier details, dates, totals, and status" loading="lazy">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Inline CTA 1 -->
+    <section class="inline-cta">
+        <div class="container">
+            <div class="inline-cta-inner animate-on-scroll">
+                <h3>Start tracking expenses and revenue today</h3>
+                <p>Download Argo Books and record your first transaction in under a minute. No credit card required.</p>
+                <div class="inline-cta-buttons">
+                    <a href="../../downloads/" class="btn-cta btn-cta-primary">
+                        <span>Download Free</span>
+                        <?= svg_icon('arrow-right', 18) ?>
+                    </a>
+                    <a href="../../pricing/" class="btn-cta btn-cta-outline">
+                        <span>See Pricing</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         STATS BANNER
+         ============================================= -->
+    <section class="highlight-banner">
+        <div class="container">
+            <div class="highlight-grid animate-on-scroll">
+                <div class="highlight-item">
+                    <h3>2 clicks</h3>
+                    <p>To record a new transaction</p>
+                </div>
+                <div class="highlight-item">
+                    <h3>Real-time</h3>
+                    <p>Revenue, expense &amp; profit summaries</p>
+                </div>
+                <div class="highlight-item">
+                    <h3>0</h3>
+                    <p>Accounting experience required</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         DETAIL SECTION 2: Revenue Tracking
+         Image left, text right (reversed)
+         ============================================= -->
+    <section class="feature-detail-section" style="background: var(--gray-50);">
+        <div class="container">
+            <div class="feature-detail reversed animate-on-scroll">
+                <div class="feature-detail-text">
+                    <span class="section-label">Revenue Tracking</span>
+                    <h2>See every dollar coming into your business</h2>
+                    <p>The revenue page gives you a complete view of every sale and payment you've received. Each transaction shows the customer, product or service sold, date, total, and status — all in a clean, sortable table. Summary cards at the top show your monthly revenue, total transactions, unique customers, and returns at a glance.</p>
+                    <p>Need to add a sale? Click "Add Revenue" and fill in a guided form. Argo Books auto-populates customers and products from your records, validates amounts, and links the transaction to the right customer profile — so your books stay accurate without extra effort.</p>
+                    <ul class="feature-checklist">
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Customer-linked transactions with full purchase history</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Monthly revenue, transaction count, and unique customer summaries</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Invoice generation directly from revenue records</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Return tracking built in — every refund is accounted for</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="feature-detail-visual">
+                    <img src="../../resources/images/features/revenue-table.svg" alt="Argo Books revenue page showing customer transactions with names, products, dates, totals, and completion status" loading="lazy">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         HOW IT WORKS — 3 Steps
+         ============================================= -->
+    <section class="how-it-works">
+        <div class="container">
+            <div class="section-header animate-on-scroll">
+                <span class="section-label">How It Works</span>
+                <h2 class="section-title">Three steps to organized finances</h2>
+                <p class="section-desc">From scattered records to a clear financial picture in minutes. No accounting background needed — Argo Books guides you through every step.</p>
+            </div>
+            <div class="steps-grid">
+                <div class="step-card animate-on-scroll">
+                    <div class="step-number">1</div>
+                    <h3>Record the transaction</h3>
+                    <p>Click "Add Expense" or "Add Revenue" and fill in a guided form. Suppliers, customers, and products auto-populate from your records.</p>
+                </div>
+                <div class="step-card animate-on-scroll">
+                    <div class="step-number">2</div>
+                    <h3>Argo Books validates and saves</h3>
+                    <p>Smart validation catches missing fields, verifies amounts, and links the transaction to the right supplier or customer profile automatically.</p>
+                </div>
+                <div class="step-card animate-on-scroll">
+                    <div class="step-number">3</div>
+                    <h3>See your financial picture</h3>
+                    <p>Summary cards update in real time. See monthly totals, profit margins, transaction counts, and trends — all without exporting to a spreadsheet.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Inline CTA 2 -->
+    <section class="inline-cta">
+        <div class="container">
+            <div class="inline-cta-inner animate-on-scroll">
+                <h3>Stop guessing whether you're profitable</h3>
+                <p>Real-time expense and revenue summaries mean you always know where you stand. Get started in minutes.</p>
+                <div class="inline-cta-buttons">
+                    <a href="../../downloads/" class="btn-cta btn-cta-primary">
+                        <span>Get Started Free</span>
+                        <?= svg_icon('arrow-right', 18) ?>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         DETAIL SECTION 3: Expense Tracking
+         Text left, image right
+         ============================================= -->
+    <section class="feature-detail-section">
+        <div class="container">
+            <div class="feature-detail animate-on-scroll">
+                <div class="feature-detail-text">
+                    <span class="section-label">Expense Tracking</span>
+                    <h2>Track every purchase, subscription, and cost</h2>
+                    <p>The expenses page mirrors the revenue layout — a clean, filterable table with every purchase your business has made. Each row shows the product or service, supplier, date, total, receipt status, and completion status. Summary cards show monthly spending, total transactions, receipts on file, and returns.</p>
+                    <p>Filter by supplier, date range, or amount to find any transaction instantly. Need to attach a receipt? Link it directly from the expense record, or use AI receipt scanning to auto-create the expense from a photo.</p>
+                    <ul class="feature-checklist">
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Supplier-linked expenses with full purchase history per vendor</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Receipt attachment tracking — see which expenses have receipts on file</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>AI receipt scanning creates expense records from receipt photos automatically</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Return and refund tracking keeps your net spending accurate</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="feature-detail-visual">
+                    <img src="../../resources/images/features/expense-revenue-stats.svg" alt="Argo Books financial overview showing monthly revenue vs expenses bar chart with profit tracking" loading="lazy">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         DETAIL SECTION 4: Receipt Archive
+         Image left, text right (reversed)
+         ============================================= -->
+    <section class="feature-detail-section" style="background: var(--gray-50);">
+        <div class="container">
+            <div class="feature-detail reversed animate-on-scroll">
+                <div class="feature-detail-text">
+                    <span class="section-label">Receipt Archive</span>
+                    <h2>Every receipt stored, organized, and searchable</h2>
+                    <p>Argo Books includes a dedicated receipt archive where all your receipts — both expense and revenue — are stored in one place. Each receipt card shows a thumbnail of the original document, the receipt ID, date, vendor or customer name, transaction type, and total.</p>
+                    <p>Switch between grid and list views, search by any field, and filter by type (expense or revenue). Summary cards at the top show total receipts, expense receipts, revenue receipts, and how many were created via AI scanning. It's a complete paper trail without the paper.</p>
+                    <ul class="feature-checklist">
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Grid and list views for browsing receipts visually or as a table</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Color-coded badges — green for revenue, red for expenses</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Search by receipt ID, vendor, customer, date, or amount</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>AI scan button creates new receipts from photos in seconds</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="feature-detail-visual">
+                    <img src="../../resources/images/features/receipt-archive.svg" alt="Argo Books receipt archive showing receipt cards in grid view with expense and revenue badges" loading="lazy">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         BENEFITS GRID — 6 benefit cards
+         ============================================= -->
+    <section class="benefits-section">
+        <div class="container">
+            <div class="section-header animate-on-scroll">
+                <span class="section-label">Why It Matters</span>
+                <h2 class="section-title">More than just a ledger</h2>
+                <p class="section-desc">Expense and revenue tracking in Argo Books isn't just about recording numbers — it gives you the financial clarity to make better business decisions.</p>
+            </div>
+            <div class="benefits-grid">
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon">
+                        <?= svg_icon('trending-up', 22) ?>
+                    </div>
+                    <h3>Real-time profit visibility</h3>
+                    <p>Summary cards update as you add transactions. See your monthly revenue, expenses, and net profit at any moment — no end-of-month surprises.</p>
+                </div>
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon green">
+                        <?= svg_icon('check', 22, '', 2.5) ?>
+                    </div>
+                    <h3>Guided forms prevent mistakes</h3>
+                    <p>Every transaction goes through a guided form with smart defaults and validation. Required fields are enforced, amounts are verified, and nothing gets saved with missing data.</p>
+                </div>
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon purple">
+                        <?= svg_icon('search', 22) ?>
+                    </div>
+                    <h3>Find any transaction instantly</h3>
+                    <p>Search, filter, and sort by supplier, customer, date, amount, or status. Every transaction is indexed and findable in seconds — even years later.</p>
+                </div>
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon amber">
+                        <?= svg_icon('bolt', 22) ?>
+                    </div>
+                    <h3>Two-click transaction entry</h3>
+                    <p>Auto-populated suppliers, customers, and products mean you spend seconds per transaction, not minutes. Repeat purchases are even faster with remembered defaults.</p>
+                </div>
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon cyan">
+                        <?= svg_icon('shield', 22) ?>
+                    </div>
+                    <h3>Tax-ready records all year</h3>
+                    <p>Every transaction is timestamped, categorized, and linked to receipts. When tax season arrives, your records are already organized and audit-ready.</p>
+                </div>
+                <div class="benefit-card animate-on-scroll">
+                    <div class="benefit-card-icon red">
+                        <?= svg_icon('clock', 22) ?>
+                    </div>
+                    <h3>Complete transaction history</h3>
+                    <p>Every edit, status change, and update is tracked. View the full history of any transaction to see what changed, when, and why — with undo support.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Inline CTA 3 -->
+    <section class="inline-cta">
+        <div class="container">
+            <div class="inline-cta-inner animate-on-scroll">
+                <h3>Get your finances organized in minutes</h3>
+                <p>Join small business owners who stopped guessing and started tracking with Argo Books.</p>
+                <div class="inline-cta-buttons">
+                    <a href="../../downloads/" class="btn-cta btn-cta-primary">
+                        <span>Download Free</span>
+                        <?= svg_icon('arrow-right', 18) ?>
+                    </a>
+                    <a href="../" class="btn-cta btn-cta-outline">
+                        <span>View All Features</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         USE CASES SECTION
+         ============================================= -->
+    <section class="use-cases-section">
+        <div class="container">
+            <div class="section-header animate-on-scroll">
+                <span class="section-label">Who It's For</span>
+                <h2 class="section-title">Built for the way you actually run your business</h2>
+                <p class="section-desc">Whether you sell products, provide services, or run a side hustle — expense and revenue tracking adapts to your workflow.</p>
+            </div>
+            <div class="use-cases-grid">
+                <div class="use-case-card animate-on-scroll">
+                    <h3>
+                        <?= svg_icon('users', 22) ?>
+                        Freelancers &amp; consultants
+                    </h3>
+                    <p>Track project-based income and business expenses separately. See profitability per client and keep business costs organized for tax deductions.</p>
+                </div>
+                <div class="use-case-card animate-on-scroll">
+                    <h3>
+                        <?= svg_icon('package', 22) ?>
+                        Retail &amp; e-commerce
+                    </h3>
+                    <p>Record every sale and supplier purchase. Track cost of goods, monitor margins per product, and see which suppliers cost you the most over time.</p>
+                </div>
+                <div class="use-case-card animate-on-scroll">
+                    <h3>
+                        <?= svg_icon('calendar', 22) ?>
+                        Service businesses
+                    </h3>
+                    <p>Log service revenue by customer, track material and equipment costs, and monitor profitability across different service types and time periods.</p>
+                </div>
+                <div class="use-case-card animate-on-scroll">
+                    <h3>
+                        <?= svg_icon('document', 22) ?>
+                        Side hustles &amp; startups
+                    </h3>
+                    <p>Starting small? Argo Books grows with you. Start by tracking a few transactions a week and scale to hundreds — the interface stays simple and fast.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         DETAIL SECTION 5: Privacy & Security
+         Image left, text right (reversed)
+         ============================================= -->
+    <section class="feature-detail-section" style="background: var(--gray-50);">
+        <div class="container">
+            <div class="feature-detail reversed animate-on-scroll">
+                <div class="feature-detail-text">
+                    <span class="section-label">Privacy First</span>
+                    <h2>Your financial data stays on your computer</h2>
+                    <p>Unlike cloud-based bookkeeping tools that upload your revenue and expense data to third-party servers, Argo Books is a desktop application. Your transactions, receipts, and financial records are stored locally on your device — not on someone else's cloud.</p>
+                    <p>No monthly data fees, no vendor lock-in, no worrying about what happens if the service shuts down. Your data is yours, and it stays on your machine. Export anytime to CSV, Excel, or PDF for your accountant.</p>
+                    <ul class="feature-checklist">
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Desktop app — your financial data stays on your computer</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>No third-party cloud storage of your transactions or receipts</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Export to CSV, Excel, or PDF anytime — no vendor lock-in</span>
+                        </li>
+                        <li>
+                            <?= svg_icon('check', 20) ?>
+                            <span>Works offline — record transactions without internet access</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="feature-detail-visual">
+                    <img src="../../resources/images/privacy-local-storage.svg" alt="Your data stays local — encrypted, offline-capable, no cloud" loading="lazy">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- =============================================
+         RELATED FEATURES
+         ============================================= -->
+    <section class="related-features">
+        <div class="container">
+            <div class="section-header animate-on-scroll">
+                <span class="section-label">Related Features</span>
+                <h2 class="section-title">Works great with</h2>
+                <p class="section-desc">Expense and revenue tracking is even more powerful when combined with these features.</p>
+            </div>
+            <div class="related-grid">
+                <a href="../ai-receipt-scanning/" class="related-card animate-on-scroll">
+                    <div class="related-card-icon">
+                        <?= svg_icon('receipt-scan-detail', 22) ?>
+                    </div>
+                    <h3>AI Receipt Scanning</h3>
+                    <p>Snap a photo of a receipt and let AI create the expense record for you. Every scanned receipt flows directly into your expense tracking.</p>
+                </a>
+                <a href="../predictive-analytics/" class="related-card animate-on-scroll">
+                    <div class="related-card-icon">
+                        <?= svg_icon('analytics', 22) ?>
+                    </div>
+                    <h3>Predictive Analytics</h3>
+                    <p>Your expense and revenue data powers AI forecasting. See predicted cash flow, seasonal trends, and spending patterns before they impact your bottom line.</p>
+                </a>
+                <a href="../invoicing/" class="related-card animate-on-scroll">
+                    <div class="related-card-icon">
+                        <?= svg_icon('document', 22) ?>
+                    </div>
+                    <h3>Invoicing</h3>
+                    <p>Generate professional invoices directly from revenue records. Customer details, products, and amounts auto-populate from your tracked transactions.</p>
+                </a>
+            </div>
+        </div>
+    </section>
+
     </main>
 
+    <!-- CTA + Footer Wrapper -->
     <div class="dark-section-wrapper">
+        <!-- CTA Section -->
         <section class="cta-section">
             <div class="container">
                 <div class="cta-card animate-on-scroll">
-                    <h2>Ready to get started?</h2>
-                    <p>Download Argo Books for free and see the difference for yourself.</p>
+                    <h2>Ready to take control of your finances?</h2>
+                    <p>Download Argo Books and start tracking expenses and revenue today. Free to get started — no credit card, no trial period.</p>
                     <div class="cta-buttons">
                         <a href="../../downloads/" class="btn-cta btn-cta-primary">
                             <span>Download for Free</span>
@@ -114,6 +564,7 @@
                 threshold: 0.1,
                 rootMargin: '0px 0px -50px 0px'
             };
+
             const observer = new IntersectionObserver((entries) => {
                 entries.forEach(entry => {
                     if (entry.isIntersecting) {
@@ -121,6 +572,7 @@
                     }
                 });
             }, observerOptions);
+
             document.querySelectorAll('.animate-on-scroll').forEach(el => {
                 observer.observe(el);
             });

--- a/resources/images/features/expense-revenue-stats.svg
+++ b/resources/images/features/expense-revenue-stats.svg
@@ -49,7 +49,7 @@
 
   <!-- Net profit summary -->
   <text x="56" y="172" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#64748b">Net Profit This Month</text>
-  <text x="544" y="172" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#10b981" text-anchor="end">+$4,165.38</text>
+  <text x="544" y="172" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#10b981" text-anchor="end">+$4,166</text>
 
   <!-- Mini bar chart area -->
   <text x="56" y="210" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1e293b">Monthly Breakdown</text>

--- a/resources/images/features/expense-revenue-stats.svg
+++ b/resources/images/features/expense-revenue-stats.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 500" fill="none">
+  <defs>
+    <linearGradient id="bgGrad2" x1="0" y1="0" x2="600" y2="500" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#eff6ff"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+    <filter id="cardShadow2" x="-10%" y="-5%" width="120%" height="115%">
+      <feDropShadow dx="0" dy="4" stdDeviation="12" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="600" height="500" rx="24" fill="url(#bgGrad2)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.03" stroke="#3b82f6" stroke-width="1">
+    <line x1="0" y1="100" x2="600" y2="100"/><line x1="0" y1="200" x2="600" y2="200"/>
+    <line x1="0" y1="300" x2="600" y2="300"/><line x1="0" y1="400" x2="600" y2="400"/>
+    <line x1="100" y1="0" x2="100" y2="500"/><line x1="200" y1="0" x2="200" y2="500"/>
+    <line x1="300" y1="0" x2="300" y2="500"/><line x1="400" y1="0" x2="400" y2="500"/>
+    <line x1="500" y1="0" x2="500" y2="500"/>
+  </g>
+
+  <!-- Main card -->
+  <g filter="url(#cardShadow2)">
+    <rect x="32" y="24" width="536" height="452" rx="16" fill="white"/>
+  </g>
+
+  <!-- Revenue stat card -->
+  <rect x="56" y="48" width="240" height="80" rx="12" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  <!-- Green up arrow circle -->
+  <circle cx="88" cy="88" r="20" fill="#ecfdf5"/>
+  <path d="M82 92 L88 82 L94 92" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="88" y1="82" x2="88" y2="96" stroke="#10b981" stroke-width="2.5" stroke-linecap="round"/>
+  <text x="120" y="80" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#10b981">$16,936</text>
+  <text x="120" y="100" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">Monthly Revenue</text>
+
+  <!-- Expense stat card -->
+  <rect x="310" y="48" width="240" height="80" rx="12" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  <!-- Red down arrow circle -->
+  <circle cx="342" cy="88" r="20" fill="#fef2f2"/>
+  <path d="M336 84 L342 94 L348 84" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="342" y1="80" x2="342" y2="94" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+  <text x="374" y="80" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#ef4444">$12,770</text>
+  <text x="374" y="100" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">Monthly Expenses</text>
+
+  <!-- Divider -->
+  <line x1="56" y1="148" x2="544" y2="148" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Net profit summary -->
+  <text x="56" y="172" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#64748b">Net Profit This Month</text>
+  <text x="544" y="172" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#10b981" text-anchor="end">+$4,165.38</text>
+
+  <!-- Mini bar chart area -->
+  <text x="56" y="210" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1e293b">Monthly Breakdown</text>
+
+  <!-- Chart bars - Revenue (green) vs Expenses (red) side by side -->
+  <!-- Jan -->
+  <rect x="76" y="260" width="16" height="120" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="94" y="300" width="16" height="80" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="93" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Jan</text>
+
+  <!-- Feb -->
+  <rect x="132" y="240" width="16" height="140" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="150" y="290" width="16" height="90" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="149" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Feb</text>
+
+  <!-- Mar -->
+  <rect x="188" y="230" width="16" height="150" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="206" y="280" width="16" height="100" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="205" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Mar</text>
+
+  <!-- Apr -->
+  <rect x="244" y="270" width="16" height="110" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="262" y="310" width="16" height="70" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="261" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Apr</text>
+
+  <!-- May -->
+  <rect x="300" y="250" width="16" height="130" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="318" y="295" width="16" height="85" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="317" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">May</text>
+
+  <!-- Jun -->
+  <rect x="356" y="235" width="16" height="145" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="374" y="275" width="16" height="105" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="373" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Jun</text>
+
+  <!-- Jul -->
+  <rect x="412" y="245" width="16" height="135" rx="3" fill="#10b981" opacity="0.8"/>
+  <rect x="430" y="285" width="16" height="95" rx="3" fill="#ef4444" opacity="0.6"/>
+  <text x="429" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Jul</text>
+
+  <!-- Aug (current - highlighted) -->
+  <rect x="468" y="225" width="16" height="155" rx="3" fill="#10b981"/>
+  <rect x="486" y="270" width="16" height="110" rx="3" fill="#ef4444" opacity="0.8"/>
+  <text x="485" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#1e293b" font-weight="600" text-anchor="middle">Aug</text>
+
+  <!-- Legend -->
+  <rect x="56" y="420" width="10" height="10" rx="2" fill="#10b981"/>
+  <text x="72" y="429" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#64748b">Revenue</text>
+  <rect x="126" y="420" width="10" height="10" rx="2" fill="#ef4444" opacity="0.7"/>
+  <text x="142" y="429" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#64748b">Expenses</text>
+
+  <!-- Profit indicator -->
+  <text x="544" y="429" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#10b981" font-weight="600" text-anchor="end">Profitable 8/8 months</text>
+</svg>

--- a/resources/images/features/receipt-archive.svg
+++ b/resources/images/features/receipt-archive.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 500" fill="none">
+  <defs>
+    <linearGradient id="bgGrad3" x1="0" y1="0" x2="600" y2="500" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f5f3ff"/>
+      <stop offset="100%" stop-color="#eff6ff"/>
+    </linearGradient>
+    <filter id="cardShadow3" x="-10%" y="-5%" width="120%" height="115%">
+      <feDropShadow dx="0" dy="4" stdDeviation="12" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+    <filter id="receiptShadow" x="-10%" y="-5%" width="120%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#000" flood-opacity="0.06"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="600" height="500" rx="24" fill="url(#bgGrad3)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.03" stroke="#8b5cf6" stroke-width="1">
+    <line x1="0" y1="100" x2="600" y2="100"/><line x1="0" y1="200" x2="600" y2="200"/>
+    <line x1="0" y1="300" x2="600" y2="300"/><line x1="0" y1="400" x2="600" y2="400"/>
+    <line x1="100" y1="0" x2="100" y2="500"/><line x1="200" y1="0" x2="200" y2="500"/>
+    <line x1="300" y1="0" x2="300" y2="500"/><line x1="400" y1="0" x2="400" y2="500"/>
+    <line x1="500" y1="0" x2="500" y2="500"/>
+  </g>
+
+  <!-- Main card -->
+  <g filter="url(#cardShadow3)">
+    <rect x="32" y="24" width="536" height="452" rx="16" fill="white"/>
+  </g>
+
+  <!-- Title -->
+  <text x="56" y="60" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#1e293b">Receipt Archive</text>
+
+  <!-- Summary stats row -->
+  <!-- Total Receipts -->
+  <rect x="56" y="76" width="116" height="52" rx="10" fill="#eff6ff" stroke="#dbeafe" stroke-width="1"/>
+  <text x="68" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#3b82f6">3</text>
+  <text x="68" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Total Receipts</text>
+
+  <!-- Expense Receipts -->
+  <rect x="182" y="76" width="116" height="52" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="194" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#ef4444">2</text>
+  <text x="194" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Expense Receipts</text>
+
+  <!-- Revenue Receipts -->
+  <rect x="308" y="76" width="116" height="52" rx="10" fill="#ecfdf5" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="320" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#10b981">1</text>
+  <text x="320" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Revenue Receipts</text>
+
+  <!-- AI Scanned -->
+  <rect x="434" y="76" width="116" height="52" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="446" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#1e293b">0</text>
+  <text x="446" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">AI Scanned</text>
+
+  <!-- Search + AI Scan button row -->
+  <rect x="56" y="148" width="180" height="28" rx="7" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <circle cx="72" cy="162" r="5" fill="none" stroke="#94a3b8" stroke-width="1.2"/>
+  <line x1="75.5" y1="165.5" x2="78" y2="168" stroke="#94a3b8" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="84" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8">Search receipts...</text>
+
+  <rect x="436" y="148" width="114" height="28" rx="7" fill="#3b82f6"/>
+  <text x="493" y="162" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">+ AI Scan Receipt</text>
+
+  <!-- Receipt cards grid -->
+  <!-- Receipt 1 -->
+  <g filter="url(#receiptShadow)">
+    <rect x="56" y="192" width="156" height="260" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  </g>
+  <!-- Receipt image placeholder (thermal receipt look) -->
+  <rect x="64" y="200" width="140" height="140" rx="6" fill="#fafafa"/>
+  <text x="134" y="240" font-family="monospace" font-size="8" fill="#94a3b8" text-anchor="middle">TEND        $ 3.00</text>
+  <text x="134" y="256" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">ACCOUNT #  9874564</text>
+  <text x="134" y="268" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">APPROVAL #  3326544</text>
+  <text x="134" y="280" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">REF #  131231331</text>
+  <text x="134" y="292" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">TRANS ID  5646464616</text>
+  <text x="134" y="304" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">VALIDATION  16545</text>
+  <text x="134" y="322" font-family="monospace" font-size="6" fill="#64748b" text-anchor="middle">* * *</text>
+  <!-- Receipt info -->
+  <rect x="64" y="348" width="140" height="2" rx="1" fill="#eff6ff"/>
+  <text x="72" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="700" fill="#1e293b">#RCP-2026-00001</text>
+  <text x="160" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="8" fill="#94a3b8">Mar 22</text>
+  <text x="72" y="384" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">ComputeHub Distributors</text>
+  <!-- Expense badge -->
+  <rect x="72" y="394" width="44" height="16" rx="3" fill="#fef2f2"/>
+  <text x="94" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600" fill="#ef4444" text-anchor="middle">Expense</text>
+  <text x="196" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#1e293b" text-anchor="end">$2,355.87</text>
+
+  <!-- Receipt 2 -->
+  <g filter="url(#receiptShadow)">
+    <rect x="222" y="192" width="156" height="260" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  </g>
+  <rect x="230" y="200" width="140" height="140" rx="6" fill="#fafafa"/>
+  <text x="300" y="240" font-family="monospace" font-size="8" fill="#94a3b8" text-anchor="middle">TEND        $ 3.00</text>
+  <text x="300" y="256" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">ACCOUNT #  9874564</text>
+  <text x="300" y="268" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">APPROVAL #  3326544</text>
+  <text x="300" y="280" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">REF #  131231331</text>
+  <text x="300" y="292" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">TRANS ID  5646464616</text>
+  <text x="300" y="304" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">VALIDATION  16545</text>
+  <text x="300" y="322" font-family="monospace" font-size="6" fill="#64748b" text-anchor="middle">* * *</text>
+  <rect x="230" y="348" width="140" height="2" rx="1" fill="#ecfdf5"/>
+  <text x="238" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="700" fill="#1e293b">#RCP-2026-00003</text>
+  <text x="328" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="8" fill="#94a3b8">Mar 10</text>
+  <text x="238" y="384" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Amanda Foster</text>
+  <!-- Revenue badge -->
+  <rect x="238" y="394" width="48" height="16" rx="3" fill="#ecfdf5"/>
+  <text x="262" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600" fill="#10b981" text-anchor="middle">Revenue</text>
+  <text x="362" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#1e293b" text-anchor="end">$3,418.53</text>
+
+  <!-- Receipt 3 -->
+  <g filter="url(#receiptShadow)">
+    <rect x="388" y="192" width="156" height="260" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1"/>
+  </g>
+  <rect x="396" y="200" width="140" height="140" rx="6" fill="#fafafa"/>
+  <text x="466" y="240" font-family="monospace" font-size="8" fill="#94a3b8" text-anchor="middle">TEND        $ 3.00</text>
+  <text x="466" y="256" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">ACCOUNT #  9874564</text>
+  <text x="466" y="268" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">APPROVAL #  3326544</text>
+  <text x="466" y="280" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">REF #  131231331</text>
+  <text x="466" y="292" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">TRANS ID  5646464616</text>
+  <text x="466" y="304" font-family="monospace" font-size="7" fill="#94a3b8" text-anchor="middle">VALIDATION  16545</text>
+  <text x="466" y="322" font-family="monospace" font-size="6" fill="#64748b" text-anchor="middle">* * *</text>
+  <rect x="396" y="348" width="140" height="2" rx="1" fill="#eff6ff"/>
+  <text x="404" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="700" fill="#1e293b">#RCP-2026-00002</text>
+  <text x="496" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="8" fill="#94a3b8">Mar 8</text>
+  <text x="404" y="384" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">CloudSoft Inc</text>
+  <rect x="404" y="394" width="44" height="16" rx="3" fill="#fef2f2"/>
+  <text x="426" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600" fill="#ef4444" text-anchor="middle">Expense</text>
+  <text x="528" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#1e293b" text-anchor="end">$1,643.18</text>
+</svg>

--- a/resources/images/features/receipt-archive.svg
+++ b/resources/images/features/receipt-archive.svg
@@ -105,6 +105,9 @@
   <!-- Revenue badge -->
   <rect x="238" y="394" width="48" height="16" rx="3" fill="#ecfdf5"/>
   <text x="262" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600" fill="#10b981" text-anchor="middle">Revenue</text>
+  <!-- AI badge -->
+  <rect x="290" y="394" width="22" height="16" rx="3" fill="#eff6ff"/>
+  <text x="301" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600" fill="#3b82f6" text-anchor="middle">AI</text>
   <text x="362" y="405" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#1e293b" text-anchor="end">$3,418.53</text>
 
   <!-- Receipt 3 -->

--- a/resources/images/features/receipt-archive.svg
+++ b/resources/images/features/receipt-archive.svg
@@ -34,24 +34,24 @@
 
   <!-- Summary stats row -->
   <!-- Total Receipts -->
-  <rect x="56" y="76" width="116" height="56" rx="10" fill="#eff6ff" stroke="#dbeafe" stroke-width="1"/>
-  <text x="114" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#3b82f6" text-anchor="middle">3</text>
-  <text x="114" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Total Receipts</text>
+  <rect x="56" y="76" width="116" height="62" rx="10" fill="#eff6ff" stroke="#dbeafe" stroke-width="1"/>
+  <text x="114" y="106" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#3b82f6" text-anchor="middle">3</text>
+  <text x="114" y="126" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Total Receipts</text>
 
   <!-- Expense Receipts -->
-  <rect x="182" y="76" width="116" height="56" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-  <text x="240" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#ef4444" text-anchor="middle">2</text>
-  <text x="240" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Expense Receipts</text>
+  <rect x="182" y="76" width="116" height="62" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="240" y="106" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#ef4444" text-anchor="middle">2</text>
+  <text x="240" y="126" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Expense Receipts</text>
 
   <!-- Revenue Receipts -->
-  <rect x="308" y="76" width="116" height="56" rx="10" fill="#ecfdf5" stroke="#bbf7d0" stroke-width="1"/>
-  <text x="366" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#10b981" text-anchor="middle">1</text>
-  <text x="366" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Revenue Receipts</text>
+  <rect x="308" y="76" width="116" height="62" rx="10" fill="#ecfdf5" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="366" y="106" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#10b981" text-anchor="middle">1</text>
+  <text x="366" y="126" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Revenue Receipts</text>
 
   <!-- AI Scanned -->
-  <rect x="434" y="76" width="116" height="56" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="492" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#1e293b" text-anchor="middle">0</text>
-  <text x="492" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">AI Scanned</text>
+  <rect x="434" y="76" width="116" height="62" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="492" y="106" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#1e293b" text-anchor="middle">1</text>
+  <text x="492" y="126" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">AI Scanned</text>
 
   <!-- Search + AI Scan button row -->
   <rect x="56" y="148" width="180" height="28" rx="7" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>

--- a/resources/images/features/receipt-archive.svg
+++ b/resources/images/features/receipt-archive.svg
@@ -34,24 +34,24 @@
 
   <!-- Summary stats row -->
   <!-- Total Receipts -->
-  <rect x="56" y="76" width="116" height="52" rx="10" fill="#eff6ff" stroke="#dbeafe" stroke-width="1"/>
-  <text x="68" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#3b82f6">3</text>
-  <text x="68" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Total Receipts</text>
+  <rect x="56" y="76" width="116" height="56" rx="10" fill="#eff6ff" stroke="#dbeafe" stroke-width="1"/>
+  <text x="114" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#3b82f6" text-anchor="middle">3</text>
+  <text x="114" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Total Receipts</text>
 
   <!-- Expense Receipts -->
-  <rect x="182" y="76" width="116" height="52" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-  <text x="194" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#ef4444">2</text>
-  <text x="194" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Expense Receipts</text>
+  <rect x="182" y="76" width="116" height="56" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="240" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#ef4444" text-anchor="middle">2</text>
+  <text x="240" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Expense Receipts</text>
 
   <!-- Revenue Receipts -->
-  <rect x="308" y="76" width="116" height="52" rx="10" fill="#ecfdf5" stroke="#bbf7d0" stroke-width="1"/>
-  <text x="320" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#10b981">1</text>
-  <text x="320" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">Revenue Receipts</text>
+  <rect x="308" y="76" width="116" height="56" rx="10" fill="#ecfdf5" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="366" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#10b981" text-anchor="middle">1</text>
+  <text x="366" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">Revenue Receipts</text>
 
   <!-- AI Scanned -->
-  <rect x="434" y="76" width="116" height="52" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="446" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#1e293b">0</text>
-  <text x="446" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b">AI Scanned</text>
+  <rect x="434" y="76" width="116" height="56" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="492" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#1e293b" text-anchor="middle">0</text>
+  <text x="492" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#64748b" text-anchor="middle">AI Scanned</text>
 
   <!-- Search + AI Scan button row -->
   <rect x="56" y="148" width="180" height="28" rx="7" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>

--- a/resources/images/features/revenue-table.svg
+++ b/resources/images/features/revenue-table.svg
@@ -1,0 +1,161 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 500" fill="none">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="600" y2="500" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#eff6ff"/>
+      <stop offset="100%" stop-color="#f0fdf4"/>
+    </linearGradient>
+    <filter id="cardShadow" x="-10%" y="-5%" width="120%" height="115%">
+      <feDropShadow dx="0" dy="4" stdDeviation="12" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="600" height="500" rx="24" fill="url(#bgGrad)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.03" stroke="#3b82f6" stroke-width="1">
+    <line x1="0" y1="100" x2="600" y2="100"/><line x1="0" y1="200" x2="600" y2="200"/>
+    <line x1="0" y1="300" x2="600" y2="300"/><line x1="0" y1="400" x2="600" y2="400"/>
+    <line x1="100" y1="0" x2="100" y2="500"/><line x1="200" y1="0" x2="200" y2="500"/>
+    <line x1="300" y1="0" x2="300" y2="500"/><line x1="400" y1="0" x2="400" y2="500"/>
+    <line x1="500" y1="0" x2="500" y2="500"/>
+  </g>
+
+  <!-- Decorative circles -->
+  <circle cx="80" cy="60" r="35" fill="#10b981" opacity="0.04"/>
+  <circle cx="530" cy="440" r="40" fill="#3b82f6" opacity="0.04"/>
+
+  <!-- Main card -->
+  <g filter="url(#cardShadow)">
+    <rect x="32" y="24" width="536" height="452" rx="16" fill="white"/>
+  </g>
+
+  <!-- Page title -->
+  <text x="56" y="60" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700" fill="#1e293b">Revenue</text>
+
+  <!-- Search bar -->
+  <rect x="56" y="72" width="180" height="30" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <circle cx="72" cy="87" r="6" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+  <line x1="76.5" y1="91.5" x2="80" y2="95" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="86" y="92" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">Search revenue...</text>
+
+  <!-- Filter button -->
+  <rect x="244" y="72" width="72" height="30" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <line x1="262" y1="83" x2="276" y2="83" stroke="#64748b" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="265" y1="87" x2="273" y2="87" stroke="#64748b" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="267" y1="91" x2="271" y2="91" stroke="#64748b" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="282" y="87" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="#475569" dominant-baseline="central">Filter</text>
+
+  <!-- Add Revenue button -->
+  <rect x="432" y="72" width="118" height="30" rx="8" fill="#10b981"/>
+  <text x="491" y="87" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">+ Add Revenue</text>
+
+  <!-- Table header -->
+  <rect x="46" y="114" width="508" height="28" rx="0" fill="#f8fafc"/>
+  <line x1="46" y1="142" x2="554" y2="142" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="56" y="132" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8" font-weight="600">CUSTOMER</text>
+  <text x="190" y="132" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8" font-weight="600">PRODUCT / SERVICE</text>
+  <text x="350" y="132" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8" font-weight="600">DATE</text>
+  <text x="430" y="132" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8" font-weight="600">TOTAL</text>
+  <text x="498" y="132" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94a3b8" font-weight="600">STATUS</text>
+
+  <!-- Row 1 -->
+  <!-- Avatar -->
+  <circle cx="68" cy="162" r="12" fill="#3b82f6"/>
+  <text x="68" y="162" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">NG</text>
+  <text x="86" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Nicole Garcia</text>
+  <text x="190" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">DesignSuite Pro</text>
+  <text x="350" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-22-2026</text>
+  <text x="430" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$485.00</text>
+  <rect x="498" y="154" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="164" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="180" x2="554" y2="180" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 2 -->
+  <circle cx="68" cy="196" r="12" fill="#8b5cf6"/>
+  <text x="68" y="196" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">MT</text>
+  <text x="86" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Michael Torres</text>
+  <text x="190" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">Data Migration Service</text>
+  <text x="350" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-19-2026</text>
+  <text x="430" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$4,453.28</text>
+  <rect x="498" y="188" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="198" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="214" x2="554" y2="214" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 3 -->
+  <circle cx="68" cy="230" r="12" fill="#10b981"/>
+  <text x="68" y="230" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">SM</text>
+  <text x="86" y="234" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Sarah Mitchell</text>
+  <text x="190" y="234" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">ProBook 7400 Laptop</text>
+  <text x="350" y="234" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-16-2026</text>
+  <text x="430" y="234" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$1,537.60</text>
+  <rect x="498" y="222" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="232" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="248" x2="554" y2="248" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 4 -->
+  <circle cx="68" cy="264" r="12" fill="#f59e0b"/>
+  <text x="68" y="264" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">RT</text>
+  <text x="86" y="268" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Rachel Thompson</text>
+  <text x="190" y="268" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">WorkStation 7010</text>
+  <text x="350" y="268" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-14-2026</text>
+  <text x="430" y="268" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$1,132.75</text>
+  <rect x="498" y="256" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="266" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="282" x2="554" y2="282" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 5 -->
+  <circle cx="68" cy="298" r="12" fill="#ef4444"/>
+  <text x="68" y="298" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">AF</text>
+  <text x="86" y="302" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Amanda Foster</text>
+  <text x="190" y="302" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">Server Setup &amp; Config</text>
+  <text x="350" y="302" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-10-2026</text>
+  <text x="430" y="302" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$3,400.68</text>
+  <rect x="498" y="290" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="316" x2="554" y2="316" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 6 -->
+  <circle cx="68" cy="332" r="12" fill="#06b6d4"/>
+  <text x="68" y="332" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">CB</text>
+  <text x="86" y="336" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Christopher Brown</text>
+  <text x="190" y="336" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">Network Assessment</text>
+  <text x="350" y="336" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-08-2026</text>
+  <text x="430" y="336" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$2,833.90</text>
+  <rect x="498" y="324" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="334" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="350" x2="554" y2="350" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 7 -->
+  <circle cx="68" cy="366" r="12" fill="#6366f1"/>
+  <text x="68" y="366" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">JW</text>
+  <text x="86" y="370" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">James Wilson</text>
+  <text x="190" y="370" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">CloudOffice Premium</text>
+  <text x="350" y="370" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-05-2026</text>
+  <text x="430" y="370" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$1,068.79</text>
+  <rect x="498" y="358" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="384" x2="554" y2="384" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Row 8 -->
+  <circle cx="68" cy="400" r="12" fill="#ec4899"/>
+  <text x="68" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="white" text-anchor="middle" dominant-baseline="central">JA</text>
+  <text x="86" y="404" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#1e293b" font-weight="500">Jennifer Adams</text>
+  <text x="190" y="404" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">IT Support Contract</text>
+  <text x="350" y="404" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#64748b">03-02-2026</text>
+  <text x="430" y="404" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#10b981" font-weight="600">$2,024.22</text>
+  <rect x="498" y="392" width="52" height="20" rx="4" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="524" y="402" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#16a34a" text-anchor="middle" dominant-baseline="central">Completed</text>
+  <line x1="46" y1="418" x2="554" y2="418" stroke="#f1f5f9" stroke-width="1"/>
+
+  <!-- Bottom pagination bar -->
+  <line x1="46" y1="424" x2="554" y2="424" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="56" y="448" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">1-10 of 90 revenues</text>
+
+  <!-- Pagination -->
+  <rect x="472" y="434" width="24" height="24" rx="6" fill="#10b981"/>
+  <text x="484" y="446" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">1</text>
+  <text x="506" y="450" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">2</text>
+  <text x="524" y="450" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">3</text>
+  <text x="542" y="450" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94a3b8">&#8250;</text>
+</svg>


### PR DESCRIPTION
## Summary

- Built out the previously skeleton expense & revenue tracking feature page to match the quality and structure of the AI receipt scanning and AI spreadsheet import pages
- Created 3 new SVG illustrations matching the app UI: revenue table (with customer avatars), expense-vs-revenue bar chart with profit tracking, and receipt archive grid view
- Page includes: hero section, 4 detail sections (problem/solution, revenue tracking, expense tracking with stats chart, receipt archive), stats banner, how-it-works steps, 6 benefit cards, 4 use case cards, privacy section, related features, and final CTA

## Test plan

- [ ] Verify the page renders correctly at desktop, tablet, and mobile breakpoints
- [ ] Confirm all 3 SVG illustrations render properly in major browsers
- [ ] Check that scroll animations trigger correctly on all sections
- [ ] Verify all internal links (downloads, pricing, related features) point to correct pages
- [ ] Confirm the page matches the visual style and structure of the AI receipt scanning and AI spreadsheet import feature pages

https://claude.ai/code/session_01NQu7XPFT7wvjtyaQMrAWLG