### PR TITLE
Add theme-aware Chart.js text color support

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -30,6 +30,13 @@ $base_path = $in_subdir ? '../' : '';
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+    <script>
+        // Set Chart.js default text color based on current theme
+        (function() {
+            var theme = document.documentElement.getAttribute('data-theme') || 'light';
+            Chart.defaults.color = theme === 'dark' ? '#ffffff' : '#666666';
+        })();
+    </script>
     <script src="<?php echo $base_path; ?>../resources/notifications/notifications.js" defer></script>
     <script src="<?php echo $base_path; ?>pagination.js" defer></script>
 
@@ -171,6 +178,21 @@ $base_path = $in_subdir ? '../' : '';
                     var next = current === 'dark' ? 'light' : 'dark';
                     document.documentElement.setAttribute('data-theme', next);
                     localStorage.setItem('admin-theme', next);
+
+                    // Update Chart.js default text color and re-render all charts
+                    if (typeof Chart !== 'undefined') {
+                        Chart.defaults.color = next === 'dark' ? '#ffffff' : '#666666';
+                        Object.values(Chart.instances).forEach(function(chart) {
+                            chart.options.scales && Object.values(chart.options.scales).forEach(function(scale) {
+                                if (scale.ticks) scale.ticks.color = Chart.defaults.color;
+                                if (scale.title) scale.title.color = Chart.defaults.color;
+                            });
+                            if (chart.options.plugins && chart.options.plugins.legend && chart.options.plugins.legend.labels) {
+                                chart.options.plugins.legend.labels.color = Chart.defaults.color;
+                            }
+                            chart.update();
+                        });
+                    }
                 }
 
                 const menu = document.getElementById('menu');

--- a/admin/index.php
+++ b/admin/index.php
@@ -279,7 +279,7 @@ const sharedTooltip = {
 
 const sharedScaleX = {
     grid: { display: false },
-    ticks: { color: '#94a3b8', font: { size: 10 }, maxRotation: 45 }
+    ticks: { font: { size: 10 }, maxRotation: 45 }
 };
 
 // 1. MRR Line Chart
@@ -315,7 +315,7 @@ new Chart(document.getElementById('mrrChart').getContext('2d'), {
             x: sharedScaleX,
             y: {
                 grid: { color: 'rgba(148, 163, 184, 0.1)' },
-                ticks: { color: '#94a3b8', font: { size: 11 }, callback: v => '$' + v.toLocaleString() }
+                ticks: { font: { size: 11 }, callback: v => '$' + v.toLocaleString() }
             }
         }
     }
@@ -354,7 +354,7 @@ new Chart(document.getElementById('cumulativeChart').getContext('2d'), {
             x: sharedScaleX,
             y: {
                 grid: { color: 'rgba(148, 163, 184, 0.1)' },
-                ticks: { color: '#94a3b8', font: { size: 11 }, callback: v => '$' + v.toLocaleString() }
+                ticks: { font: { size: 11 }, callback: v => '$' + v.toLocaleString() }
             }
         }
     }
@@ -398,7 +398,7 @@ new Chart(document.getElementById('licensesChart').getContext('2d'), {
             y: {
                 stacked: true,
                 grid: { color: 'rgba(148, 163, 184, 0.1)' },
-                ticks: { color: '#94a3b8', font: { size: 11 }, stepSize: 1 }
+                ticks: { font: { size: 11 }, stepSize: 1 }
             }
         }
     }
@@ -437,7 +437,7 @@ new Chart(document.getElementById('churnChart').getContext('2d'), {
             x: sharedScaleX,
             y: {
                 grid: { color: 'rgba(148, 163, 184, 0.1)' },
-                ticks: { color: '#94a3b8', font: { size: 11 }, callback: v => v + '%' },
+                ticks: { font: { size: 11 }, callback: v => v + '%' },
                 min: 0
             }
         }


### PR DESCRIPTION
## Summary
This PR implements dynamic theme support for Chart.js charts in the admin dashboard. Charts now automatically adapt their text colors based on the current theme (light/dark mode) and update in real-time when the theme is toggled.

## Key Changes
- **Theme-aware Chart.js initialization**: Added a script in `admin_header.php` that sets Chart.js default text color based on the current theme on page load
- **Dynamic chart updates on theme toggle**: Enhanced the `toggleTheme()` function to update all active Chart.js instances when the theme changes, including:
  - Default text color
  - Scale tick colors (x and y axes)
  - Scale title colors
  - Legend label colors
- **Removed hardcoded colors**: Removed hardcoded `#94a3b8` color values from all chart tick configurations in `admin/index.php` to allow Chart.js defaults to apply

## Implementation Details
- Uses `Chart.defaults.color` to set the global default text color (`#ffffff` for dark theme, `#666666` for light theme)
- Iterates through all Chart.js instances using `Chart.instances` to update their configurations when theme changes
- Updates scale ticks, scale titles, and legend labels to use the new theme-appropriate colors
- Calls `chart.update()` on each chart to re-render with the new colors
- Maintains backward compatibility by checking if Chart.js is loaded before attempting updates

https://claude.ai/code/session_01NEAQ4yQsBDRgkugMrCt8gq