### PR TITLE
Exclude dropdown items from header link color styling

### DIFF
--- a/resources/header/dark.css
+++ b/resources/header/dark.css
@@ -16,7 +16,7 @@ header .header-inner .logo {
   content: url(../../resources/images/argo-logo/argo-logo-black.png);
 }
 
-header .header-inner .menu-container ul li a {
+header .header-inner .menu-container ul li a:not(.dropdown-item) {
   color: var(--black) !important;
 }
 

--- a/resources/header/style.css
+++ b/resources/header/style.css
@@ -75,7 +75,7 @@ header.sticky .header-inner .logo {
   content: url(../../resources/images/argo-logo/argo-logo-black.png);
 }
 
-header.sticky .header-inner .menu-container ul li a {
+header.sticky .header-inner .menu-container ul li a:not(.dropdown-item) {
   color: var(--gray-900) !important;
 }
 


### PR DESCRIPTION
## Summary
Updated header link color selectors to exclude dropdown menu items from the dark theme styling, preventing unintended color application to dropdown navigation elements.

## Key Changes
- Modified CSS selector in `resources/header/dark.css` to use `:not(.dropdown-item)` pseudo-class on header menu links
- Applied the same selector change to `resources/header/style.css` for sticky header state
- This ensures dropdown items maintain their own styling and are not overridden by the parent link color rules

## Implementation Details
The changes use the CSS `:not()` pseudo-class to create a more specific selector that targets only regular navigation links while excluding elements with the `dropdown-item` class. This prevents the `color: var(--black)` and `color: var(--gray-900)` rules from affecting dropdown menu items, allowing them to use their own styling rules instead.

https://claude.ai/code/session_01SBqx2LKjp5F6fRvoVvPshR