### PR TITLE
Add Version 2.0.4 release notes to what's new page

### DIFF
--- a/whats-new/index.php
+++ b/whats-new/index.php
@@ -106,9 +106,8 @@
                         <div class="changelog-section">
                             <h4 class="section-label feature">New Features</h4>
                             <ul class="changelog-list">
-                                <li><strong>Bulk receipt management</strong> &mdash; Select and delete multiple receipts at once for faster cleanup.</li>
-                                <li><strong>Invoice template management</strong> &mdash; Browse and manage your invoice templates in a new list view with thumbnail previews.</li>
-                                <li><strong>Multi-currency accounting reports</strong> &mdash; Accounting reports now support multiple currencies with automatic USD conversion.</li>
+                                <li><strong>Invoice template management</strong> &mdash; Browse and manage your invoice templates in a new view with thumbnail previews.</li>
+                                <li><strong>Multi-currency accounting reports</strong> &mdash; Accounting reports now support multiple currencies.</li>
                             </ul>
                         </div>
                         <div class="changelog-section">
@@ -122,8 +121,8 @@
                         <div class="changelog-section">
                             <h4 class="section-label fix">Fixes</h4>
                             <ul class="changelog-list">
-                                <li>Fixed currency mixing issues in financial calculations.</li>
                                 <li>Fixed pagination arrows not updating correctly.</li>
+                                <li>Various bug fixes and stability improvements.</li>
                             </ul>
                         </div>
                     </div>

--- a/whats-new/index.php
+++ b/whats-new/index.php
@@ -91,6 +91,45 @@
     <div class="container">
         <div class="version-grid">
 
+            <!-- Version 2.0.4 -->
+            <div class="version-card">
+                <div class="version-header">
+                    <div class="version-info">
+                        <span class="version-tag">Version 2.0.4</span>
+                        <span class="date-tag">March 2026</span>
+                    </div>
+                    <?= svg_icon('chevron-down', 24, 'dropdown-arrow', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
+                </div>
+
+                <div class="version-content">
+                    <div class="changelog">
+                        <div class="changelog-section">
+                            <h4 class="section-label feature">New Features</h4>
+                            <ul class="changelog-list">
+                                <li><strong>Bulk receipt management</strong> &mdash; Select and delete multiple receipts at once for faster cleanup.</li>
+                                <li><strong>Invoice template management</strong> &mdash; Browse and manage your invoice templates in a new list view with thumbnail previews.</li>
+                                <li><strong>Multi-currency accounting reports</strong> &mdash; Accounting reports now support multiple currencies with automatic USD conversion.</li>
+                            </ul>
+                        </div>
+                        <div class="changelog-section">
+                            <h4 class="section-label enhancement">Enhancements</h4>
+                            <ul class="changelog-list">
+                                <li><strong>Undo/redo for invoice templates</strong> &mdash; Undo and redo changes when editing invoice templates.</li>
+                                <li><strong>Localized tax labels</strong> &mdash; Tax labels now automatically match your company's country.</li>
+                                <li><strong>Improved offline experience</strong> &mdash; Better detection and messaging when working offline, with a pending transaction queue so nothing is lost.</li>
+                            </ul>
+                        </div>
+                        <div class="changelog-section">
+                            <h4 class="section-label fix">Fixes</h4>
+                            <ul class="changelog-list">
+                                <li>Fixed currency mixing issues in financial calculations.</li>
+                                <li>Fixed pagination arrows not updating correctly.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Version 2.0.3 -->
             <div class="version-card">
                 <div class="version-header">


### PR DESCRIPTION
## Summary
Added the Version 2.0.4 release notes to the what's new page, documenting the latest features, enhancements, and bug fixes scheduled for March 2026.

## Changes
- Added a new version card for Version 2.0.4 at the top of the version grid
- Documented new features:
  - Invoice template management with thumbnail previews
  - Multi-currency support for accounting reports
- Documented enhancements:
  - Undo/redo functionality for invoice template editing
  - Localized tax labels based on company country
  - Improved offline experience with pending transaction queue
- Documented bug fixes:
  - Fixed pagination arrow updates
  - Various stability improvements

## Implementation Details
- Follows the existing version card structure and styling conventions
- Uses the same changelog section markup with feature, enhancement, and fix labels
- Positioned as the latest version entry above Version 2.0.3
- Includes proper SVG icon integration for the dropdown arrow

https://claude.ai/code/session_016m9oMhMJEE9vqQZGLbYgJY