### PR TITLE
Add free tier support for receipt scanning with device ID

### DIFF
--- a/api/receipt/scan.php
+++ b/api/receipt/scan.php
@@ -18,20 +18,24 @@ $dotenv->safeLoad();
 set_portal_headers();
 require_method(['POST']);
 
-// Authenticate using license key (premium feature, not tied to payment portal)
+// Authenticate using license key (premium) or device ID (free)
 // Accept X-Api-Key as a fallback for backward compatibility
 if (empty($_SERVER['HTTP_X_LICENSE_KEY']) && !empty($_SERVER['HTTP_X_API_KEY'])) {
     $_SERVER['HTTP_X_LICENSE_KEY'] = $_SERVER['HTTP_X_API_KEY'];
 }
 
 $license = authenticate_license_request();
+$deviceIdHash = null;
 if (!$license) {
-    send_error_response(401, 'Invalid or expired license key.', 'UNAUTHORIZED');
+    // Try device ID authentication for free users
+    $deviceIdHash = authenticate_device_request();
+    if (!$deviceIdHash) {
+        send_error_response(401, 'Invalid or expired license key.', 'UNAUTHORIZED');
+    }
 }
 
-// Rate limiting: 30 scans per 15 minutes per license key
-// Key by license hash (not IP) so the limit is truly per-license
-$rateLimitIdentifier = substr($license['license_key_hash'], 0, 32);
+// Rate limiting: 30 scans per 15 minutes per identity
+$rateLimitIdentifier = $license ? substr($license['license_key_hash'], 0, 32) : substr($deviceIdHash, 0, 32);
 $rateLimitKey = 'receipt_' . $rateLimitIdentifier;
 if (is_rate_limited($rateLimitIdentifier, 30, 900, $rateLimitKey)) {
     send_error_response(429, 'Rate limit exceeded. Please try again later.', 'RATE_LIMITED');

--- a/api/receipt/usage.php
+++ b/api/receipt/usage.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Receipt Scan Usage Tracking API
- * Tracks and enforces monthly scan limits for Premium tier subscribers.
- * AI Receipt Scanning is only available on the Premium plan with 500 scans/month.
+ * Tracks and enforces monthly scan limits.
+ * Free tier: 5 scans/month. Premium tier: 500 scans/month.
  */
 
 header('Content-Type: application/json');
@@ -26,9 +26,13 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 // Get JSON input
 $input = json_decode(file_get_contents('php://input'), true);
 
-if (!isset($input['license_key']) || empty($input['license_key'])) {
+// Accept either license_key (premium) or device_id (free)
+$license_key = trim($input['license_key'] ?? '');
+$device_id = trim($input['device_id'] ?? '');
+
+if (empty($license_key) && empty($device_id)) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'License key is required']);
+    echo json_encode(['success' => false, 'error' => 'Either license_key or device_id is required']);
     exit();
 }
 
@@ -38,7 +42,6 @@ if (!isset($input['action']) || !in_array($input['action'], ['check', 'increment
     exit();
 }
 
-$license_key = trim($input['license_key']);
 $action = $input['action'];
 
 // Load database connection and pricing config
@@ -46,37 +49,48 @@ require_once __DIR__ . '/../../db_connect.php';
 require_once __DIR__ . '/../../config/pricing.php';
 
 /**
- * Determine tier and validate license key
- * @param PDO $pdo
- * @param string $license_key
- * @return array|null Returns ['tier' => 'premium', 'limit' => N] for valid premium keys,
- *                    or null if invalid
+ * Determine tier and validate identity.
+ * Premium users (license key) get 500 scans/month.
+ * Free users (device ID) get the configured free monthly limit.
  */
-function validateAndGetTier($pdo, $license_key) {
-    // Check if it's a Premium key (starts with PREM-)
-    if (strpos($license_key, 'PREM-') === 0) {
-        // Check premium_subscription_keys table (unredeemed promo keys)
-        $stmt = $pdo->prepare("SELECT id FROM premium_subscription_keys WHERE subscription_key = ?");
-        $stmt->execute([$license_key]);
-        if ($stmt->fetch()) {
-            $config = get_pricing_config();
-            return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit']];
+function validateAndGetTier($pdo, $license_key, $device_id) {
+    $config = get_pricing_config();
+
+    if (!empty($license_key)) {
+        // Check if it's a Premium key (starts with PREM-)
+        if (strpos($license_key, 'PREM-') === 0) {
+            // Check premium_subscription_keys table (unredeemed promo keys)
+            $stmt = $pdo->prepare("SELECT id FROM premium_subscription_keys WHERE subscription_key = ?");
+            $stmt->execute([$license_key]);
+            if ($stmt->fetch()) {
+                return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit'], 'identifier' => $license_key];
+            }
+
+            // Check premium_subscriptions table for active subscriptions
+            $stmt = $pdo->prepare("
+                SELECT id FROM premium_subscriptions
+                WHERE subscription_id = ?
+                AND status IN ('active', 'cancelled')
+                AND end_date > NOW()
+            ");
+            $stmt->execute([$license_key]);
+            if ($stmt->fetch()) {
+                return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit'], 'identifier' => $license_key];
+            }
         }
 
-        // Check premium_subscriptions table for active subscriptions
-        $stmt = $pdo->prepare("
-            SELECT id FROM premium_subscriptions
-            WHERE subscription_id = ?
-            AND status IN ('active', 'cancelled')
-            AND end_date > NOW()
-        ");
+        // Check free license keys table
+        $stmt = $pdo->prepare("SELECT id FROM license_keys WHERE license_key = ?");
         $stmt->execute([$license_key]);
         if ($stmt->fetch()) {
-            $config = get_pricing_config();
-            return ['tier' => 'premium', 'limit' => $config['receipt_scan_monthly_limit']];
+            return ['tier' => 'free', 'limit' => $config['free_receipt_scan_monthly_limit'], 'identifier' => $license_key];
         }
+    }
 
-        return null;
+    if (!empty($device_id)) {
+        // Free tier via device ID
+        $identifier = 'device_' . hash('sha256', $device_id);
+        return ['tier' => 'free', 'limit' => $config['free_receipt_scan_monthly_limit'], 'identifier' => $identifier];
     }
 
     return null;
@@ -149,8 +163,8 @@ function buildResponse($scan_count, $monthly_limit, $tier, $can_scan = null) {
 }
 
 try {
-    // Validate license key and get tier
-    $tierInfo = validateAndGetTier($pdo, $license_key);
+    // Validate identity and get tier
+    $tierInfo = validateAndGetTier($pdo, $license_key, $device_id);
 
     if (!$tierInfo) {
         http_response_code(401);
@@ -160,9 +174,10 @@ try {
 
     $tier = $tierInfo['tier'];
     $monthly_limit = $tierInfo['limit'];
+    $identifier = $tierInfo['identifier'];
 
     // Get or create usage record
-    $usage = getOrCreateUsageRecord($pdo, $license_key, $monthly_limit);
+    $usage = getOrCreateUsageRecord($pdo, $identifier, $monthly_limit);
     $scan_count = $usage['scan_count'];
     // Use the limit from the tier info (in case it changed)
     $monthly_limit = $tierInfo['limit'];
@@ -191,7 +206,7 @@ try {
             SET scan_count = scan_count + 1
             WHERE license_key = ? AND usage_month = ?
         ");
-        $stmt->execute([$license_key, $usage_month]);
+        $stmt->execute([$identifier, $usage_month]);
 
         // Return updated status
         $new_scan_count = $scan_count + 1;

--- a/config/plans.json
+++ b/config/plans.json
@@ -16,7 +16,8 @@
             {"label": "Real-time analytics"},
             {"label": "Receipt management"},
             {"label": "5 invoices / month"},
-            {"label": "AI spreadsheet import", "detail": "100/month"}
+            {"label": "AI spreadsheet import", "detail": "100/month"},
+            {"label": "AI receipt scanning", "detail": "5/month"}
         ]
     },
     "premium": {

--- a/config/pricing.php
+++ b/config/pricing.php
@@ -11,9 +11,10 @@
  *   PREMIUM_YEARLY_PRICE        - Premium yearly subscription (default: 100.00)
  *   PROCESSING_FEE_PERCENT      - Payment processing fee percentage (default: 2.90)
  *   PROCESSING_FEE_FIXED        - Payment processing fixed fee in CAD (default: 0.30)
- *   RECEIPT_SCAN_MONTHLY_LIMIT  - Monthly receipt scan limit for premium tier (default: 500)
- *   AI_IMPORT_MONTHLY_LIMIT     - Monthly AI import limit for all users (default: 100)
- *   FREE_INVOICE_MONTHLY_LIMIT  - Monthly invoice send limit for free tier (default: 5)
+ *   RECEIPT_SCAN_MONTHLY_LIMIT       - Monthly receipt scan limit for premium tier (default: 500)
+ *   FREE_RECEIPT_SCAN_MONTHLY_LIMIT  - Monthly receipt scan limit for free tier (default: 5)
+ *   AI_IMPORT_MONTHLY_LIMIT          - Monthly AI import limit for all users (default: 100)
+ *   FREE_INVOICE_MONTHLY_LIMIT       - Monthly invoice send limit for free tier (default: 5)
  */
 
 /**
@@ -39,9 +40,10 @@ function get_pricing_config() {
         'premium_yearly_price'  => _pricing_parse_env('PREMIUM_YEARLY_PRICE', 100.00),
         'processing_fee_percent' => _pricing_parse_env('PROCESSING_FEE_PERCENT', 2.90),
         'processing_fee_fixed'   => _pricing_parse_env('PROCESSING_FEE_FIXED', 0.30),
-        'receipt_scan_monthly_limit' => _pricing_parse_int_env('RECEIPT_SCAN_MONTHLY_LIMIT', 500),
-        'ai_import_monthly_limit'    => _pricing_parse_int_env('AI_IMPORT_MONTHLY_LIMIT', 100),
-        'free_invoice_monthly_limit' => _pricing_parse_int_env('FREE_INVOICE_MONTHLY_LIMIT', 5),
+        'receipt_scan_monthly_limit'      => _pricing_parse_int_env('RECEIPT_SCAN_MONTHLY_LIMIT', 500),
+        'free_receipt_scan_monthly_limit' => _pricing_parse_int_env('FREE_RECEIPT_SCAN_MONTHLY_LIMIT', 5),
+        'ai_import_monthly_limit'         => _pricing_parse_int_env('AI_IMPORT_MONTHLY_LIMIT', 100),
+        'free_invoice_monthly_limit'      => _pricing_parse_int_env('FREE_INVOICE_MONTHLY_LIMIT', 5),
         'currency'              => 'CAD',
     ];
 


### PR DESCRIPTION
## Summary
This PR extends the receipt scanning usage tracking API to support both free and premium tiers, allowing free users to scan receipts using a device ID instead of requiring a license key.

## Key Changes

- **Dual authentication support**: The API now accepts either a `license_key` (for premium users) or a `device_id` (for free users), instead of requiring a license key
- **Free tier implementation**: Free users get 5 scans/month (configurable via `FREE_RECEIPT_SCAN_MONTHLY_LIMIT`), while premium users retain 500 scans/month
- **Updated validation logic**: `validateAndGetTier()` now handles both premium license keys and free device IDs, returning appropriate limits for each tier
- **Device ID hashing**: Free tier users are tracked via SHA256-hashed device IDs to maintain privacy while enabling usage tracking
- **Configuration updates**: Added `free_receipt_scan_monthly_limit` to pricing config with a default of 5 scans/month
- **Plans documentation**: Updated `plans.json` to reflect that free tier users now have access to AI receipt scanning (5/month)
- **Improved error messages**: Updated validation error to indicate either authentication method is acceptable

## Implementation Details

- Free users are identified by hashing their device ID with SHA256, prefixed with `device_` to distinguish from license key identifiers
- The usage tracking system uses a unified `identifier` field that works for both license keys and hashed device IDs
- Premium license keys are validated against both `premium_subscription_keys` (unredeemed promo keys) and `premium_subscriptions` (active subscriptions) tables
- Free license keys are also supported as a third authentication method for backward compatibility
- All tier information (tier type, monthly limit, identifier) is returned from the validation function for consistent usage tracking

https://claude.ai/code/session_0143AS4HVFNSejCjLqRGwAcC