### PR TITLE
Migrate API authentication from API keys to license keys

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -265,6 +265,9 @@ php_value upload_max_filesize 10M
     # Provider connect/disconnect: /api/portal/connect/{provider}
     RewriteRule ^api/portal/connect/(stripe|paypal|square)/?$ api/portal/connect.php?provider=$1 [L,QSA]
 
+    # Telemetry data upload
+    RewriteRule ^api/data/upload/?$ api/data/upload.php [L,QSA]
+
     # --- Avalonia (cross-platform) download routes ---
 
     # Versioned: /download/avalonia/2.1.0/win

--- a/api/data/upload.php
+++ b/api/data/upload.php
@@ -25,7 +25,7 @@ define('MAX_FILENAME_LENGTH', 255);
 function checkRateLimit($authIdentifier = null)
 {
     // Use auth identifier in rate limiting to prevent key sharing abuse
-    $api_key = $authIdentifier ?? $_SERVER['HTTP_X_API_KEY'] ?? 'unknown';
+    $api_key = $authIdentifier ?? $_SERVER['HTTP_X_LICENSE_KEY'] ?? 'unknown';
     $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
     $rate_key = md5($api_key . $ip); // Combine auth identifier and IP for rate limiting
     $rate_file = sys_get_temp_dir() . '/upload_rate_' . $rate_key;
@@ -101,7 +101,7 @@ function logSecurityEvent($event, $details = '')
         'timestamp' => date('Y-m-d H:i:s'),
         'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
         'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
-        'api_key_provided' => !empty($_SERVER['HTTP_X_API_KEY']),
+        'license_key_provided' => !empty($_SERVER['HTTP_X_LICENSE_KEY']),
         'event' => $event,
         'details' => $details
     ];
@@ -117,18 +117,18 @@ try {
         exit;
     }
 
-    // Authenticate request FIRST (using portal API key)
-    $company = authenticate_portal_request();
-    if (!$company) {
+    // Authenticate request using license key (the desktop app sends its license key)
+    $license = authenticate_license_request();
+    if (!$license) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
-        logSecurityEvent('invalid_api_key');
+        logSecurityEvent('invalid_license_key');
         exit;
     }
 
-    // Rate limiting check — use company ID so Bearer-auth requests get a proper bucket
-    $companyId = is_array($company) ? ($company['id'] ?? null) : null;
-    if (!checkRateLimit($companyId ? 'company:' . $companyId : null)) {
+    // Rate limiting check — use subscription ID for rate limiting bucket
+    $subscriptionId = $license['subscription_id'] ?? null;
+    if (!checkRateLimit($subscriptionId ? 'subscription:' . $subscriptionId : null)) {
         http_response_code(429);
         echo json_encode(['error' => 'Rate limit exceeded']);
         logSecurityEvent('rate_limit_exceeded');


### PR DESCRIPTION
## Summary
This PR updates the upload API authentication mechanism to use license keys instead of API keys, aligning with the desktop application's authentication model. The changes reflect a shift from portal-based API key authentication to license-based authentication for telemetry data uploads.

## Key Changes
- **Authentication method**: Replaced `authenticate_portal_request()` with `authenticate_license_request()` to validate requests using license keys instead of API keys
- **HTTP header**: Changed from `HTTP_X_API_KEY` to `HTTP_X_LICENSE_KEY` throughout the codebase
- **Rate limiting**: Updated to use subscription ID (`subscription:` prefix) instead of company ID (`company:` prefix) for rate limit bucketing
- **Security logging**: Updated log field from `api_key_provided` to `license_key_provided` for consistency
- **Routing**: Added `.htaccess` rewrite rule to properly route telemetry data upload requests to `api/data/upload.php`
- **Error messages**: Updated security event logging to reference `invalid_license_key` instead of `invalid_api_key`

## Implementation Details
- The rate limiting mechanism now uses the subscription ID from the license object to create distinct rate limit buckets per subscription
- All references to the old API key header have been systematically replaced with the license key header
- The authentication flow maintains the same security posture while adapting to the new license-based model

https://claude.ai/code/session_01UHX4vyeuGco2FDcwMGgz9K