### PR TITLE
Remove unused CSS, PHP, and JS code

### DIFF
--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -52,15 +52,6 @@ body.menu-open::after {
   text-align: center;
 }
 
-.input-button-wrapper {
-  display: flex;
-  gap: 10px;
-}
-
-.input-button-wrapper input {
-  flex: 1;
-}
-
 /* Header */
 .admin-header {
   background: var(--white);
@@ -980,20 +971,6 @@ tbody tr:hover {
   /* Make checkboxes visible on mobile */
   .checkbox-column {
     min-width: 50px;
-  }
-}
-
-@media (max-width: 600px) {
-  .input-button-wrapper {
-    flex-direction: column;
-  }
-
-  .input-button-wrapper input {
-    width: 100%;
-  }
-
-  .input-button-wrapper button {
-    width: 100%;
   }
 }
 

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -483,12 +483,6 @@
     margin-bottom: 12px;
 }
 
-.detail-meta {
-    font-size: 12px;
-    color: var(--gray-400);
-    margin: 12px 0 8px;
-}
-
 .detail-actions {
     display: flex;
     gap: 8px;
@@ -871,8 +865,7 @@
     border-bottom-color: var(--gray-700);
 }
 
-[data-theme="dark"] .gray-border,
-[data-theme="dark"] .detail-meta {
+[data-theme="dark"] .gray-border {
     color: var(--gray-500);
 }
 

--- a/portal/main.js
+++ b/portal/main.js
@@ -29,8 +29,6 @@ document.addEventListener("DOMContentLoaded", function () {
   // Payment method selection
   var methodButtons = document.querySelectorAll(".method-btn");
   var formContainer = document.getElementById("payment-form-container");
-  var selectedMethod = null;
-
   methodButtons.forEach(function (btn) {
     btn.addEventListener("click", function () {
       var method = this.getAttribute("data-method");
@@ -41,7 +39,6 @@ document.addEventListener("DOMContentLoaded", function () {
       });
       this.classList.add("active");
 
-      selectedMethod = method;
       if (formContainer) formContainer.style.display = "block";
 
       initializeMethod(method);
@@ -64,7 +61,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Auto-initialize if only one payment method
   if (config.singleMethod && formContainer) {
-    selectedMethod = config.singleMethod;
     initializeMethod(config.singleMethod);
   }
 

--- a/webhooks/paypal-subscription.php
+++ b/webhooks/paypal-subscription.php
@@ -140,18 +140,9 @@ function handleSubscriptionActivated($resource) {
     global $pdo;
 
     $paypalSubscriptionId = $resource['id'] ?? '';
-    $status = $resource['status'] ?? '';
-    $customId = $resource['custom_id'] ?? ''; // We set this as user_ID during creation
 
     if (empty($paypalSubscriptionId)) {
         throw new Exception("Missing subscription ID in activated event");
-    }
-
-    // Extract user_id from custom_id (format: user_123)
-    // Currently used only for logging context; subscription is matched by paypal_subscription_id below
-    $userId = null;
-    if (preg_match('/^user_(\d+)$/', $customId, $matches)) {
-        $userId = intval($matches[1]);
     }
 
     // Check if we already have this subscription in our database


### PR DESCRIPTION
## Summary
- Remove `.input-button-wrapper` CSS rules from admin stylesheet (never referenced in any HTML/PHP/JS)
- Remove `.detail-meta` CSS rules from outreach stylesheet (never referenced in any HTML/PHP/JS)
- Remove unused `$status` and `$userId` variables from PayPal subscription webhook handler
- Remove unused `selectedMethod` JS variable from portal payment flow

All items verified with project-wide grep to confirm zero references outside their definitions. Dynamically-generated badge classes (e.g., `badge-<?= $status ?>`) were checked and correctly excluded.

## Test plan
- [ ] Admin dashboard pages render correctly (no visual regressions from CSS removal)
- [ ] Outreach page renders correctly
- [ ] Portal payment flow works (Stripe, PayPal, Square method selection)
- [ ] PayPal subscription activation webhook processes correctly