### PR TITLE
Migrate email sending from Brevo to Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ cp ".env - sandbox" .env
 |------|---------|
 | `index.php` | Homepage / main entry point |
 | `db_connect.php` | Database connection, AES-256-GCM encryption helpers |
-| `email_sender.php` | All email sending logic (SMTP via Amazon SES) |
+| `email_sender.php` | All email sending logic (SMTP via Resend) |
 | `license_functions.php` | License key generation and validation |
 | `statistics.php` | Page view tracking (include in each page) |
 | `mysql_schema.sql` | Full database schema |
@@ -137,7 +137,7 @@ Files excluded from deployment: `.git`, `.github`, `README.md`, `composer.json`,
 | Stripe | Payments | `STRIPE_` |
 | PayPal | Payments | `PAYPAL_` |
 | Square | Payments | `SQUARE_` |
-| Amazon SES | Email relay (SMTP) | `SMTP_` |
+| Resend | Email relay (SMTP) | `SMTP_` |
 | Google OAuth | Social login | `GOOGLE_` |
 | OpenAI | AI features | `OPENAI_` |
 | Azure Document Intelligence | Receipt scanning | `AZURE_` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ cp ".env - sandbox" .env
 |------|---------|
 | `index.php` | Homepage / main entry point |
 | `db_connect.php` | Database connection, AES-256-GCM encryption helpers |
-| `email_sender.php` | All email sending logic (SMTP via Brevo) |
+| `email_sender.php` | All email sending logic (SMTP via Amazon SES) |
 | `license_functions.php` | License key generation and validation |
 | `statistics.php` | Page view tracking (include in each page) |
 | `mysql_schema.sql` | Full database schema |
@@ -137,7 +137,7 @@ Files excluded from deployment: `.git`, `.github`, `README.md`, `composer.json`,
 | Stripe | Payments | `STRIPE_` |
 | PayPal | Payments | `PAYPAL_` |
 | Square | Payments | `SQUARE_` |
-| Brevo | Email relay | `SMTP_` |
+| Amazon SES | Email relay (SMTP) | `SMTP_` |
 | Google OAuth | Social login | `GOOGLE_` |
 | OpenAI | AI features | `OPENAI_` |
 | Azure Document Intelligence | Receipt scanning | `AZURE_` |

--- a/api/invoice/invoice_email_sender.php
+++ b/api/invoice/invoice_email_sender.php
@@ -2,7 +2,7 @@
 /**
  * Invoice Email Sender
  *
- * Handles sending invoice emails via SMTP relay (Brevo) when configured,
+ * Handles sending invoice emails via SMTP relay (Amazon SES) when configured,
  * with fallback to PHP's native mail() function.
  */
 

--- a/api/invoice/invoice_email_sender.php
+++ b/api/invoice/invoice_email_sender.php
@@ -2,7 +2,7 @@
 /**
  * Invoice Email Sender
  *
- * Handles sending invoice emails via SMTP relay (Amazon SES) when configured,
+ * Handles sending invoice emails via SMTP relay (Resend) when configured,
  * with fallback to PHP's native mail() function.
  */
 

--- a/cron/lib/imap_helpers.php
+++ b/cron/lib/imap_helpers.php
@@ -116,14 +116,14 @@ function imap_is_autoresponder($rawHeaders, $subject = '')
 
 /**
  * Check if a message looks like a delivery bounce or complaint notification.
- * Detects Amazon SES bounces and generic MAILER-DAEMON DSNs.
+ * Detects Resend/SES bounces and generic MAILER-DAEMON DSNs.
  */
 function imap_is_bounce($senderEmail, $subject = '')
 {
     $senderEmail = strtolower(trim($senderEmail));
 
-    // SES-specific senders
-    if (str_contains($senderEmail, '@amazonses.com') || str_contains($senderEmail, '@email-smtp.amazonaws.com')) {
+    // Resend uses SES infrastructure; bounces can come from either sender domain
+    if (str_contains($senderEmail, '@resend.com') || str_contains($senderEmail, '@amazonses.com') || str_contains($senderEmail, '@email-smtp.amazonaws.com')) {
         return true;
     }
     // Generic postmaster/mailer-daemon bounces

--- a/cron/lib/imap_helpers.php
+++ b/cron/lib/imap_helpers.php
@@ -122,9 +122,16 @@ function imap_is_bounce($senderEmail, $subject = '')
 {
     $senderEmail = strtolower(trim($senderEmail));
 
-    // Resend uses SES infrastructure; bounces can come from either sender domain
-    if (str_contains($senderEmail, '@resend.com') || str_contains($senderEmail, '@amazonses.com') || str_contains($senderEmail, '@email-smtp.amazonaws.com')) {
-        return true;
+    // Resend uses SES infrastructure; bounces can come from either provider.
+    // Exact-domain match (not substring) to avoid false positives from addresses
+    // like user@resend.com.example.com.
+    $atPos = strrpos($senderEmail, '@');
+    $domain = $atPos !== false ? substr($senderEmail, $atPos + 1) : '';
+    $bounceDomains = ['resend.com', 'amazonses.com', 'email-smtp.amazonaws.com'];
+    foreach ($bounceDomains as $d) {
+        if ($domain === $d || str_ends_with($domain, '.' . $d)) {
+            return true;
+        }
     }
     // Generic postmaster/mailer-daemon bounces
     if (preg_match('/^(mailer-daemon|postmaster|complaints|bounce|bounces)@/i', $senderEmail)) {

--- a/cron/lib/imap_helpers.php
+++ b/cron/lib/imap_helpers.php
@@ -113,3 +113,67 @@ function imap_is_autoresponder($rawHeaders, $subject = '')
     }
     return false;
 }
+
+/**
+ * Check if a message looks like a delivery bounce or complaint notification.
+ * Detects Amazon SES bounces and generic MAILER-DAEMON DSNs.
+ */
+function imap_is_bounce($senderEmail, $subject = '')
+{
+    $senderEmail = strtolower(trim($senderEmail));
+
+    // SES-specific senders
+    if (str_contains($senderEmail, '@amazonses.com') || str_contains($senderEmail, '@email-smtp.amazonaws.com')) {
+        return true;
+    }
+    // Generic postmaster/mailer-daemon bounces
+    if (preg_match('/^(mailer-daemon|postmaster|complaints|bounce|bounces)@/i', $senderEmail)) {
+        return true;
+    }
+    // Subject-based detection for bounces that come from other return paths
+    if (preg_match('/(delivery status notification|undelivered mail|mail delivery failed|returned mail|failure notice|delivery failure)/i', $subject)) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Fetch the plain-text body of a message by UID.
+ * Returns empty string if unavailable.
+ */
+function imap_fetch_body_text($imap, $uid)
+{
+    $body = @imap_fetchbody($imap, $uid, 1, FT_UID | FT_PEEK);
+    if (empty($body)) {
+        $body = @imap_body($imap, imap_msgno($imap, $uid), FT_PEEK);
+    }
+    return $body ?: '';
+}
+
+/**
+ * Parse the bounced recipient address from a DSN/bounce body.
+ * Looks for Final-Recipient or Original-Recipient headers, then falls back
+ * to the first email address mentioned after a failure indicator.
+ */
+function imap_parse_bounced_address($body)
+{
+    if (empty($body)) return null;
+
+    // Standard DSN: "Final-Recipient: rfc822; user@example.com"
+    if (preg_match('/^(Final-Recipient|Original-Recipient):\s*(?:rfc822;\s*)?([^\s<>]+@[^\s<>]+)/mi', $body, $m)) {
+        $addr = trim($m[2], " \t\r\n<>.,;");
+        if (filter_var($addr, FILTER_VALIDATE_EMAIL)) {
+            return strtolower($addr);
+        }
+    }
+
+    // Fallback: "failed recipient: user@example.com" or "<user@example.com>"
+    if (preg_match('/(?:failed|undeliverable|rejected|could not be delivered)[^@\n]{0,60}<?([a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,})>?/i', $body, $m)) {
+        $addr = strtolower(trim($m[1]));
+        if (filter_var($addr, FILTER_VALIDATE_EMAIL)) {
+            return $addr;
+        }
+    }
+
+    return null;
+}

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -82,7 +82,7 @@ function send_outreach_lead($pdo, $lead)
     // Replace plain URL with a clickable "argorobots.com" link that carries the tracking param
     $sourceCode = 'outreach-' . $id;
     $trackedUrl = 'https://argorobots.com/?source=' . $sourceCode;
-    $anchorHtml = '<a href="' . htmlspecialchars($trackedUrl) . '">argorobots.com</a>';
+    $anchorHtml = '<a href="' . htmlspecialchars($trackedUrl) . '" style="color:#3b82f6;text-decoration:underline">argorobots.com</a>';
 
     $escapedBody = htmlspecialchars($lead['draft_body']);
     $escapedBody = preg_replace('#https?://argorobots\.com/?(?![\w?])#', $anchorHtml, $escapedBody);

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -105,14 +105,6 @@ function send_outreach_lead($pdo, $lead)
 
     $htmlBody = '<p>' . nl2br($escapedBody) . '</p>';
 
-    // Ask Brevo (and other relays that honor these) to skip link/open tracking
-    // so the URL preview stays clean — these are undocumented-but-known Brevo headers.
-    $extraHeaders = [
-        'X-Mailin-Track-Clicks' => '0',
-        'X-Mailin-Track-Opens' => '0',
-        'X-Mailin-Track' => '0',
-    ];
-
     $result = send_styled_email(
         $email,
         $lead['draft_subject'],
@@ -120,8 +112,7 @@ function send_outreach_lead($pdo, $lead)
         '',
         'contact@argorobots.com',
         'Argo Books',
-        'contact@argorobots.com',
-        $extraHeaders
+        'contact@argorobots.com'
     );
 
     if ($result) {

--- a/cron/reply_checker.php
+++ b/cron/reply_checker.php
@@ -80,7 +80,7 @@ try {
     $selectStmt = $pdo->prepare("SELECT id, business_name, sent_at FROM outreach_leads WHERE LOWER(email) = ? AND status = 'contacted' AND sent_at IS NOT NULL LIMIT 1");
     $updateStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'replied' WHERE id = ? AND status = 'contacted'");
     $suppressStmt = $pdo->prepare("INSERT IGNORE INTO email_suppressions (email, context, reason, source_id) VALUES (?, 'outreach', ?, ?)");
-    $leadByEmailStmt = $pdo->prepare("SELECT id FROM outreach_leads WHERE LOWER(email) = ? LIMIT 1");
+    $leadByEmailStmt = $pdo->prepare("SELECT id FROM outreach_leads WHERE LOWER(email) = ? ORDER BY sent_at DESC, id DESC LIMIT 1");
     $markNotInterestedStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'not_interested' WHERE id = ? AND status NOT IN ('replied','interested','not_interested','onboarded')");
 
     foreach ($messages as $msg) {

--- a/cron/reply_checker.php
+++ b/cron/reply_checker.php
@@ -74,13 +74,42 @@ try {
 
     $matched = 0;
     $skipped_auto = 0;
+    $bounces = 0;
     $no_match = 0;
 
     $selectStmt = $pdo->prepare("SELECT id, business_name, sent_at FROM outreach_leads WHERE LOWER(email) = ? AND status = 'contacted' AND sent_at IS NOT NULL LIMIT 1");
     $updateStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'replied' WHERE id = ? AND status = 'contacted'");
+    $suppressStmt = $pdo->prepare("INSERT IGNORE INTO email_suppressions (email, context, reason, source_id) VALUES (?, 'outreach', ?, ?)");
+    $leadByEmailStmt = $pdo->prepare("SELECT id FROM outreach_leads WHERE LOWER(email) = ? LIMIT 1");
+    $markNotInterestedStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'not_interested' WHERE id = ? AND status NOT IN ('replied','interested','not_interested','onboarded')");
 
     foreach ($messages as $msg) {
         if (empty($msg['sender_email'])) continue;
+
+        // Bounce / complaint handling — add bounced address to suppression list
+        if (imap_is_bounce($msg['sender_email'], $msg['subject'])) {
+            $body = imap_fetch_body_text($imap, $msg['uid']);
+            $bouncedAddr = imap_parse_bounced_address($body);
+
+            if ($bouncedAddr) {
+                $leadByEmailStmt->execute([$bouncedAddr]);
+                $leadRow = $leadByEmailStmt->fetch();
+                $leadId = $leadRow['id'] ?? null;
+
+                $suppressStmt->execute([$bouncedAddr, 'Auto-suppressed from bounce: ' . substr($msg['subject'], 0, 100), $leadId]);
+
+                if ($leadId) {
+                    $markNotInterestedStmt->execute([$leadId]);
+                    log_activity($pdo, $leadId, 'bounce_received',
+                        'Auto-suppressed after bounce from ' . $msg['sender_email'] . ' for address ' . $bouncedAddr);
+                }
+                $bounces++;
+                logReply('Bounce: ' . $bouncedAddr . ' (from ' . $msg['sender_email'] . ') — added to suppression list');
+            } else {
+                logReply('Bounce-looking message from ' . $msg['sender_email'] . ' but could not parse bounced address; skipping');
+            }
+            continue;
+        }
 
         if (imap_is_autoresponder($msg['headers_raw'], $msg['subject'])) {
             $skipped_auto++;
@@ -113,7 +142,7 @@ try {
 
     imap_close($imap);
 
-    logReply("Run complete. Matched: $matched | Auto-responders skipped: $skipped_auto | No match: $no_match");
+    logReply("Run complete. Matched: $matched | Bounces: $bounces | Auto-responders skipped: $skipped_auto | No match: $no_match");
     logReply('=== Reply Checker Complete ===');
 
 } catch (Exception $e) {

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -199,7 +199,7 @@ Email sending uses the shared SMTP configuration defined in `/smtp_mailer.php`:
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `SMTP_HOST` | SMTP server (e.g. `smtp-relay.brevo.com`) |
+| `SMTP_HOST` | SMTP server (Amazon SES, e.g. `email-smtp.us-east-2.amazonaws.com`) |
 | `SMTP_PORT` | Port (default: `587`) |
 | `SMTP_USERNAME` | Login |
 | `SMTP_PASSWORD` | Password |

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -199,10 +199,10 @@ Email sending uses the shared SMTP configuration defined in `/smtp_mailer.php`:
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `SMTP_HOST` | SMTP server (Amazon SES, e.g. `email-smtp.us-east-2.amazonaws.com`) |
+| `SMTP_HOST` | SMTP server (Resend: `smtp.resend.com`) |
 | `SMTP_PORT` | Port (default: `587`) |
-| `SMTP_USERNAME` | Login |
-| `SMTP_PASSWORD` | Password |
+| `SMTP_USERNAME` | Always the literal string `resend` |
+| `SMTP_PASSWORD` | Resend API key (starts with `re_`) |
 | `SMTP_FROM_EMAIL` | Sender address (default: `noreply@argorobots.com`) |
 | `SMTP_FROM_NAME` | Sender name (default: `Argo Books`) |
 

--- a/smtp_mailer.php
+++ b/smtp_mailer.php
@@ -7,11 +7,11 @@ use PHPMailer\PHPMailer\PHPMailer;
  * Returns null if SMTP is not configured (SMTP_HOST not set), allowing callers to
  * fall back to PHP's mail() function.
  *
- * Required .env variables for SMTP (Amazon SES):
- *   SMTP_HOST     - SES SMTP endpoint (e.g. email-smtp.us-east-2.amazonaws.com)
+ * Required .env variables for SMTP (Resend):
+ *   SMTP_HOST     - Resend SMTP endpoint (smtp.resend.com)
  *   SMTP_PORT     - SMTP port (default: 587)
- *   SMTP_USERNAME - SES SMTP credentials username (starts with AKIA)
- *   SMTP_PASSWORD - SES SMTP credentials password
+ *   SMTP_USERNAME - Always the literal string "resend"
+ *   SMTP_PASSWORD - Resend API key (starts with re_)
  *
  * Optional:
  *   SMTP_FROM_EMAIL - Default sender email (default: noreply@argorobots.com)

--- a/smtp_mailer.php
+++ b/smtp_mailer.php
@@ -7,11 +7,11 @@ use PHPMailer\PHPMailer\PHPMailer;
  * Returns null if SMTP is not configured (SMTP_HOST not set), allowing callers to
  * fall back to PHP's mail() function.
  *
- * Required .env variables for SMTP:
- *   SMTP_HOST     - SMTP server hostname (e.g. smtp-relay.brevo.com)
+ * Required .env variables for SMTP (Amazon SES):
+ *   SMTP_HOST     - SES SMTP endpoint (e.g. email-smtp.us-east-2.amazonaws.com)
  *   SMTP_PORT     - SMTP port (default: 587)
- *   SMTP_USERNAME - SMTP login username
- *   SMTP_PASSWORD - SMTP login password
+ *   SMTP_USERNAME - SES SMTP credentials username (starts with AKIA)
+ *   SMTP_PASSWORD - SES SMTP credentials password
  *
  * Optional:
  *   SMTP_FROM_EMAIL - Default sender email (default: noreply@argorobots.com)


### PR DESCRIPTION
## Summary
- Replaces Brevo SMTP with Resend (`smtp.resend.com`) across all outgoing email — outreach, invoices, and transactional — eliminating Brevo's `sendibt3.com` link-wrapping so recipients see clean `argorobots.com` URLs.
- Removes the tracking-header hack added for Brevo; Resend honors unmodified links by default.
- Extends bounce detection to recognize `@resend.com` senders in addition to Amazon SES/MAILER-DAEMON DSNs (Resend runs on SES infrastructure, so bounces can surface from either domain).
- Styles the `argorobots.com` anchor in outreach emails with inline `#3b82f6` (brand blue) so email clients don't render it as the default purple visited-link color.
- Updates docs (`CLAUDE.md`, `read-me/Email outreach.md`) and code comments to reference Resend.

## Deployment
- Server `.env` must be updated to: `SMTP_HOST=smtp.resend.com`, `SMTP_USERNAME=resend`, `SMTP_PASSWORD=<resend API key>`.
- DNS already verified in Resend (DKIM + `send` subdomain MX/TXT on argorobots.com).

## Test plan
- [x] Send outreach email to self — verify link hover shows clean `argorobots.com/?source=outreach-X` with no `sendibt3.com` wrapper
- [x] Verify link renders in brand blue, not purple
- [ ] Reply to outreach email → confirm `reply_checker.php` cron promotes lead to `replied` within 1 hour
- [ ] Send test bounce (to a nonexistent address) → confirm `email_suppressions` row created and lead marked `not_interested`
- [ ] Verify invoice emails still deliver (uses same SMTP config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)