### PR TITLE
Migrate all database access from mysqli to PDO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ cp ".env - sandbox" .env
 
 - MySQL with InnoDB, `utf8mb4`
 - Database name: `argo_books`
-- Connection via PDO in `db_connect.php`
+- Connection via PDO in `db_connect.php` (global `$pdo`; `PDO::ATTR_ERRMODE` is `ERRMODE_EXCEPTION`, default fetch mode is `FETCH_ASSOC`)
 - Schema file: `mysql_schema.sql` — update this when adding/modifying tables
 
 Key table groups:
@@ -98,16 +98,19 @@ Rules for any code that sends email:
 - SMTP config lives in `.env` under `SMTP_*` (see `smtp_mailer.php` docblock). In production and sandbox, `SMTP_HOST=smtp.resend.com`, `SMTP_USERNAME=resend`, `SMTP_PASSWORD` is the Resend API key.
 - For local development, set up MailHog (see `/read-me/Local email setup.md`) so mail() fallback works without hitting real inboxes.
 
-## Database Access — Two Interfaces
+## Database Access
 
-`db_connect.php` exports **both** a global `$pdo` (PDO) **and** a `get_db_connection()` function that returns a `mysqli` instance. Different layers of the codebase use different interfaces:
+All DB queries go through the global `$pdo` (PDO with `ATTR_ERRMODE => ERRMODE_EXCEPTION`, default fetch mode `FETCH_ASSOC`, `ATTR_EMULATE_PREPARES => false`). At script top-level, `$pdo` is already in scope once `db_connect.php` is required. Inside functions, declare `global $pdo;` before use.
 
-- **PDO (`$pdo`)**: newer code — `pricing/`, `webhooks/`, `cron/`, most of `admin/`
-- **mysqli (`get_db_connection()`)**: `community/*`, `admin/website-stats/*`, `api/portal/*`, `api/google/*`
+Conventions:
 
-The two interfaces are syntactically incompatible (`prepare/execute/fetch` vs `prepare/bind_param/get_result`). When editing a file, **match what's already there** — don't switch mid-file.
+- Always use prepared statements for any query touching user input. Pass params as an array to `execute([...])`; don't concatenate into SQL.
+- `$stmt->fetch()` returns `false` when there's no row — check that explicitly instead of treating it as an existence test.
+- PDO throws `PDOException` on error. Wrap in try/catch only at boundaries where you want a specific user-facing error response; otherwise let it bubble to the global handler.
+- For INSERT/UPDATE/DELETE, `$stmt->rowCount()` gives affected rows and `$pdo->lastInsertId()` gives the new id.
+- Transactions: `$pdo->beginTransaction()` / `$pdo->commit()` / `$pdo->rollBack()` (note the capital B).
 
-A future migration to PDO-everywhere is planned but out of scope for day-to-day changes — don't start converting files unless that's the explicit task.
+The old `mysqli` interface (`get_db_connection()`) was removed in the PDO migration — don't reintroduce it.
 
 ## Layout (Header / Footer)
 
@@ -136,12 +139,9 @@ Shared flat-file rate limiting helpers (`is_rate_limited`, `record_rate_limit_at
 
 ## Known Deferred Refactors
 
-Two pieces of consistent-but-dated state exist in the codebase. Don't "helpfully" clean them up mid-feature:
+One piece of consistent-but-dated state exists in the codebase. Don't "helpfully" clean it up mid-feature:
 
-- **`community/`, `api/portal/`, `api/google/`, and `admin/website-stats/` still use mysqli** via `get_db_connection()`. A full PDO migration is planned but not started.
-- **~150 `require_once` / `include_once` calls use relative paths** (not `__DIR__`-prefixed). The convention in new code is absolute paths, but the bulk conversion is pending.
-
-Both are low-risk in their current state. Leave them unless the task is explicitly the migration.
+- **~150 `require_once` / `include_once` calls use relative paths** (not `__DIR__`-prefixed). The convention in new code is absolute paths, but the bulk conversion is pending. Leave them unless the task is explicitly the migration.
 
 ## Cron Jobs
 
@@ -184,7 +184,7 @@ Files excluded from deployment: `.git`, `.github`, `README.md`, `composer.json`,
 - Admin requires TOTP 2FA — secret stored in `admin_users` table
 - Sensitive portal data encrypted with AES-256-GCM (`db_connect.php`)
 - `.htaccess` blocks direct access to `.env`, `.sql`, log files
-- Always sanitize user input; use PDO prepared statements (already the convention)
+- Always sanitize user input; use PDO prepared statements (`$pdo->prepare(...)->execute([...])`) for every SQL query touching user input — never concatenate into SQL
 - Rate limiting via flat files in `/resources/rate_limits/` (gitignored)
 
 ## Third-Party Services

--- a/admin/login.php
+++ b/admin/login.php
@@ -37,10 +37,8 @@ if (isset($_SESSION['awaiting_2fa']) && $_SESSION['awaiting_2fa'] === true) {
                 unset($_SESSION['temp_username']);
 
                 // Update last login time
-                $db = get_db_connection();
-                $stmt = $db->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
-                $stmt->bind_param('s', $username);
-                $stmt->execute();
+                $stmt = $pdo->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
+                $stmt->execute([$username]);
 
                 header('Location: index.php');
                 exit;
@@ -66,12 +64,9 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
     }
 
     if (empty($error)) {
-        $db = get_db_connection();
-        $stmt = $db->prepare('SELECT * FROM admin_users WHERE LOWER(username) = LOWER(?)');
-        $stmt->bind_param('s', $username);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
+        $stmt = $pdo->prepare('SELECT * FROM admin_users WHERE LOWER(username) = LOWER(?)');
+        $stmt->execute([$username]);
+        $user = $stmt->fetch();
 
         if ($user && password_verify($password, $user['password_hash'])) {
             $actual_username = $user['username']; // Get actual username with correct case
@@ -88,9 +83,8 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
                 $_SESSION['admin_username'] = $actual_username;
 
                 // Update last login time
-                $stmt = $db->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
-                $stmt->bind_param('s', $actual_username);
-                $stmt->execute();
+                $stmt = $pdo->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
+                $stmt->execute([$actual_username]);
 
                 header('Location: index.php');
                 exit;

--- a/admin/referral-links/index.php
+++ b/admin/referral-links/index.php
@@ -14,8 +14,6 @@ $page_description = "Create and manage referral links to track ad/sponsor perfor
 
 // Handle form submissions
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $db = get_db_connection();
-
     if (isset($_POST['action'])) {
         if ($_POST['action'] === 'create') {
             $source_code = trim($_POST['source_code']);
@@ -23,10 +21,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $description = trim($_POST['description']);
             $target_url = trim($_POST['target_url']);
 
-            $stmt = $db->prepare('INSERT INTO referral_links (source_code, name, description, target_url) VALUES (?, ?, ?, ?)');
-            $stmt->bind_param('ssss', $source_code, $name, $description, $target_url);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('INSERT INTO referral_links (source_code, name, description, target_url) VALUES (?, ?, ?, ?)');
+            $stmt->execute([$source_code, $name, $description, $target_url]);
 
             $_SESSION['success_message'] = 'Referral link created successfully!';
             header('Location: index.php');
@@ -38,10 +34,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $target_url = trim($_POST['target_url']);
             $is_active = isset($_POST['is_active']) ? 1 : 0;
 
-            $stmt = $db->prepare('UPDATE referral_links SET name = ?, description = ?, target_url = ?, is_active = ? WHERE id = ?');
-            $stmt->bind_param('sssii', $name, $description, $target_url, $is_active, $id);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('UPDATE referral_links SET name = ?, description = ?, target_url = ?, is_active = ? WHERE id = ?');
+            $stmt->execute([$name, $description, $target_url, $is_active, $id]);
 
             $_SESSION['success_message'] = 'Referral link updated successfully!';
             header('Location: index.php');
@@ -49,10 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } elseif ($_POST['action'] === 'delete') {
             $id = (int)$_POST['id'];
 
-            $stmt = $db->prepare('DELETE FROM referral_links WHERE id = ?');
-            $stmt->bind_param('i', $id);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('DELETE FROM referral_links WHERE id = ?');
+            $stmt->execute([$id]);
 
             $_SESSION['success_message'] = 'Referral link deleted successfully!';
             header('Location: index.php');
@@ -64,7 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // Function to get all referral links
 function get_referral_links()
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
         SELECT
             rl.*,
@@ -75,10 +67,10 @@ function get_referral_links()
         GROUP BY rl.id
         ORDER BY total_visits DESC, rl.created_at DESC";
 
-    $result = $db->query($query);
+    $stmt = $pdo->query($query);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
@@ -88,7 +80,7 @@ function get_referral_links()
 // Function to get referral visits by source
 function get_visits_by_source($limit = 10)
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
         SELECT
             source_code,
@@ -100,24 +92,21 @@ function get_visits_by_source($limit = 10)
         ORDER BY visit_count DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
-    $stmt->close();
     return $data;
 }
 
 // Function to get visits over time by source
 function get_visits_over_time($period = 'day', $limit = 30, $source_code = null)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     $sql_period = '';
     $display_format = '';
@@ -149,8 +138,8 @@ function get_visits_over_time($period = 'day', $limit = 30, $source_code = null)
             ORDER BY period DESC
             LIMIT ?";
 
-        $stmt = $db->prepare($query);
-        $stmt->bind_param('si', $source_code, $limit);
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([$source_code, $limit]);
     } else {
         $query = "
             SELECT
@@ -163,26 +152,22 @@ function get_visits_over_time($period = 'day', $limit = 30, $source_code = null)
             ORDER BY period DESC
             LIMIT ?";
 
-        $stmt = $db->prepare($query);
-        $stmt->bind_param('i', $limit);
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([$limit]);
     }
 
-    $stmt->execute();
-    $result = $stmt->get_result();
-
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
-    $stmt->close();
     return $data;
 }
 
 // Function to get geographic distribution
 function get_referral_countries($limit = 10)
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
         SELECT
             country_code,
@@ -194,17 +179,14 @@ function get_referral_countries($limit = 10)
         ORDER BY visit_count DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
-    $stmt->close();
     return $data;
 }
 

--- a/admin/reports/handle_report.php
+++ b/admin/reports/handle_report.php
@@ -32,16 +32,11 @@ if (!in_array($action, ['delete', 'ban', 'dismiss', 'reset_username', 'clear_bio
 }
 
 try {
-    $db = get_db_connection();
-
     // Get admin user ID from community_users table (may be null if admin is only in admin_users)
-    $stmt = $db->prepare('SELECT id FROM community_users WHERE email = ? AND role = "admin" LIMIT 1');
+    $stmt = $pdo->prepare('SELECT id FROM community_users WHERE email = ? AND role = "admin" LIMIT 1');
     $admin_email = $_SESSION['admin_email'] ?? '';
-    $stmt->bind_param('s', $admin_email);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $admin_user = $result->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$admin_email]);
+    $admin_user = $stmt->fetch();
 
     $admin_user_id = $admin_user ? $admin_user['id'] : null;
 
@@ -57,24 +52,19 @@ try {
 
         // Delete the content
         if ($content_type === 'post') {
-            $stmt = $db->prepare('DELETE FROM community_posts WHERE id = ?');
+            $stmt = $pdo->prepare('DELETE FROM community_posts WHERE id = ?');
         } else {
-            $stmt = $db->prepare('DELETE FROM community_comments WHERE id = ?');
+            $stmt = $pdo->prepare('DELETE FROM community_comments WHERE id = ?');
         }
-        $stmt->bind_param('i', $content_id);
 
-        if (!$stmt->execute()) {
-            $stmt->close();
+        if (!$stmt->execute([$content_id])) {
             echo json_encode(['success' => false, 'message' => 'Failed to delete content']);
             exit;
         }
-        $stmt->close();
 
         // Mark report as resolved
-        $stmt = $db->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "content_deleted" WHERE id = ?');
-        $stmt->bind_param('ii', $admin_user_id, $report_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "content_deleted" WHERE id = ?');
+        $stmt->execute([$admin_user_id, $report_id]);
 
         echo json_encode(['success' => true, 'message' => 'Content deleted successfully']);
 
@@ -116,12 +106,9 @@ try {
         // For permanent, expires_at remains null
 
         // Get user details for email
-        $stmt = $db->prepare('SELECT username, email FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT username, email FROM community_users WHERE id = ?');
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             echo json_encode(['success' => false, 'message' => 'User not found']);
@@ -130,28 +117,24 @@ try {
 
         // Insert ban record (banned_by can be NULL if admin is not in community_users)
         if ($expires_at) {
-            $stmt = $db->prepare('INSERT INTO user_bans (user_id, banned_by, ban_reason, ban_duration, expires_at) VALUES (?, ?, ?, ?, ?)');
-            $stmt->bind_param('iisss', $user_id, $admin_user_id, $ban_reason, $ban_duration, $expires_at);
+            $stmt = $pdo->prepare('INSERT INTO user_bans (user_id, banned_by, ban_reason, ban_duration, expires_at) VALUES (?, ?, ?, ?, ?)');
+            $ban_params = [$user_id, $admin_user_id, $ban_reason, $ban_duration, $expires_at];
         } else {
-            $stmt = $db->prepare('INSERT INTO user_bans (user_id, banned_by, ban_reason, ban_duration) VALUES (?, ?, ?, ?)');
-            $stmt->bind_param('iiss', $user_id, $admin_user_id, $ban_reason, $ban_duration);
+            $stmt = $pdo->prepare('INSERT INTO user_bans (user_id, banned_by, ban_reason, ban_duration) VALUES (?, ?, ?, ?)');
+            $ban_params = [$user_id, $admin_user_id, $ban_reason, $ban_duration];
         }
 
-        if (!$stmt->execute()) {
-            $stmt->close();
+        if (!$stmt->execute($ban_params)) {
             echo json_encode(['success' => false, 'message' => 'Failed to ban user']);
             exit;
         }
-        $stmt->close();
 
         // Mark current report as resolved
-        $stmt = $db->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "user_banned" WHERE id = ?');
-        $stmt->bind_param('ii', $admin_user_id, $report_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "user_banned" WHERE id = ?');
+        $stmt->execute([$admin_user_id, $report_id]);
 
         // Mark all other pending reports for this user as resolved
-        $stmt = $db->prepare('UPDATE content_reports r
+        $stmt = $pdo->prepare('UPDATE content_reports r
             LEFT JOIN community_posts p ON r.content_type = "post" AND r.content_id = p.id
             LEFT JOIN community_comments c ON r.content_type = "comment" AND r.content_id = c.id
             SET r.status = "resolved",
@@ -165,10 +148,8 @@ try {
                 (r.content_type = "comment" AND c.user_id = ?) OR
                 (r.content_type = "user" AND r.content_id = ?)
             )');
-        $stmt->bind_param('iiiii', $admin_user_id, $report_id, $user_id, $user_id, $user_id);
-        $stmt->execute();
-        $affected_reports = $stmt->affected_rows;
-        $stmt->close();
+        $stmt->execute([$admin_user_id, $report_id, $user_id, $user_id, $user_id]);
+        $affected_reports = $stmt->rowCount();
 
         // Send ban notification email
         send_ban_notification_email($user['email'], $user['username'], $ban_reason, $ban_duration, $expires_at);
@@ -182,14 +163,11 @@ try {
 
     } elseif ($action === 'dismiss') {
         // Mark report as dismissed
-        $stmt = $db->prepare('UPDATE content_reports SET status = "dismissed", resolved_by = ?, resolved_at = NOW(), resolution_action = "dismissed" WHERE id = ?');
-        $stmt->bind_param('ii', $admin_user_id, $report_id);
+        $stmt = $pdo->prepare('UPDATE content_reports SET status = "dismissed", resolved_by = ?, resolved_at = NOW(), resolution_action = "dismissed" WHERE id = ?');
 
-        if ($stmt->execute()) {
-            $stmt->close();
+        if ($stmt->execute([$admin_user_id, $report_id])) {
             echo json_encode(['success' => true, 'message' => 'Report dismissed successfully']);
         } else {
-            $stmt->close();
             echo json_encode(['success' => false, 'message' => 'Failed to dismiss report']);
             exit;
         }
@@ -205,12 +183,9 @@ try {
         }
 
         // Get user details before making changes
-        $stmt = $db->prepare('SELECT username, email FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT username, email FROM community_users WHERE id = ?');
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             echo json_encode(['success' => false, 'message' => 'User not found']);
@@ -226,13 +201,11 @@ try {
         // Check if username already exists (very unlikely but let's be safe)
         $attempts = 0;
         while ($attempts < 5) {
-            $stmt = $db->prepare('SELECT id FROM community_users WHERE username = ?');
-            $stmt->bind_param('s', $random_username);
-            $stmt->execute();
-            $result = $stmt->get_result();
-            $stmt->close();
+            $stmt = $pdo->prepare('SELECT id FROM community_users WHERE username = ?');
+            $stmt->execute([$random_username]);
+            $existing = $stmt->fetch();
 
-            if ($result->num_rows === 0) {
+            if ($existing === false) {
                 break;
             }
 
@@ -241,32 +214,23 @@ try {
         }
 
         // Update username in community_users table
-        $stmt = $db->prepare('UPDATE community_users SET username = ? WHERE id = ?');
-        $stmt->bind_param('si', $random_username, $user_id);
+        $stmt = $pdo->prepare('UPDATE community_users SET username = ? WHERE id = ?');
 
-        if (!$stmt->execute()) {
-            $stmt->close();
+        if (!$stmt->execute([$random_username, $user_id])) {
             echo json_encode(['success' => false, 'message' => 'Failed to reset username']);
             exit;
         }
-        $stmt->close();
 
         // Update username across all posts and comments
-        $stmt = $db->prepare('UPDATE community_posts SET user_name = ? WHERE user_id = ?');
-        $stmt->bind_param('si', $random_username, $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_posts SET user_name = ? WHERE user_id = ?');
+        $stmt->execute([$random_username, $user_id]);
 
-        $stmt = $db->prepare('UPDATE community_comments SET user_name = ? WHERE user_id = ?');
-        $stmt->bind_param('si', $random_username, $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_comments SET user_name = ? WHERE user_id = ?');
+        $stmt->execute([$random_username, $user_id]);
 
         // Mark report as resolved
-        $stmt = $db->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "username_reset" WHERE id = ?');
-        $stmt->bind_param('ii', $admin_user_id, $report_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "username_reset" WHERE id = ?');
+        $stmt->execute([$admin_user_id, $report_id]);
 
         // Send email notification to user
         send_username_reset_email($user_email, $old_username, $random_username, $violation_type, $additional_details);
@@ -284,12 +248,9 @@ try {
         }
 
         // Get user details before making changes
-        $stmt = $db->prepare('SELECT username, email FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT username, email FROM community_users WHERE id = ?');
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             echo json_encode(['success' => false, 'message' => 'User not found']);
@@ -300,21 +261,16 @@ try {
         $user_email = $user['email'];
 
         // Clear the bio
-        $stmt = $db->prepare('UPDATE community_users SET bio = NULL WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
+        $stmt = $pdo->prepare('UPDATE community_users SET bio = NULL WHERE id = ?');
 
-        if (!$stmt->execute()) {
-            $stmt->close();
+        if (!$stmt->execute([$user_id])) {
             echo json_encode(['success' => false, 'message' => 'Failed to clear bio']);
             exit;
         }
-        $stmt->close();
 
         // Mark report as resolved
-        $stmt = $db->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "bio_cleared" WHERE id = ?');
-        $stmt->bind_param('ii', $admin_user_id, $report_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE content_reports SET status = "resolved", resolved_by = ?, resolved_at = NOW(), resolution_action = "bio_cleared" WHERE id = ?');
+        $stmt->execute([$admin_user_id, $report_id]);
 
         // Send email notification to user
         send_bio_cleared_email($user_email, $username, $violation_type, $additional_details);

--- a/admin/reports/index.php
+++ b/admin/reports/index.php
@@ -20,7 +20,7 @@ $content_type_filter = $_GET['content_type'] ?? 'all';
 // Function to get all reports with filters
 function get_reports($status = 'pending', $content_type = 'all')
 {
-    $db = get_db_connection();
+    global $pdo;
     $reports = [];
 
     $query = 'SELECT
@@ -73,33 +73,28 @@ function get_reports($status = 'pending', $content_type = 'all')
     )
     WHERE 1=1';
 
-    $types = '';
     $params = [];
 
     if ($status !== 'all') {
         $query .= ' AND r.status = ?';
-        $types .= 's';
         $params[] = $status;
     }
 
     if ($content_type !== 'all') {
         $query .= ' AND r.content_type = ?';
-        $types .= 's';
         $params[] = $content_type;
     }
 
     $query .= ' ORDER BY r.created_at DESC';
 
     if (!empty($params)) {
-        $stmt = $db->prepare($query);
-        $stmt->bind_param($types, ...$params);
-        $stmt->execute();
-        $result = $stmt->get_result();
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
     } else {
-        $result = $db->query($query);
+        $stmt = $pdo->query($query);
     }
 
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $reports[] = $row;
     }
 
@@ -109,11 +104,11 @@ function get_reports($status = 'pending', $content_type = 'all')
 // Get reports count by status
 function get_reports_count_by_status()
 {
-    $db = get_db_connection();
+    global $pdo;
     $counts = ['pending' => 0, 'resolved' => 0, 'dismissed' => 0];
 
-    $result = $db->query('SELECT status, COUNT(*) as count FROM content_reports GROUP BY status');
-    while ($row = $result->fetch_assoc()) {
+    $stmt = $pdo->query('SELECT status, COUNT(*) as count FROM content_reports GROUP BY status');
+    while ($row = $stmt->fetch()) {
         $counts[$row['status']] = $row['count'];
     }
 

--- a/admin/settings/2fa.php
+++ b/admin/settings/2fa.php
@@ -10,13 +10,10 @@ require_once __DIR__ . '/totp.php';
  */
 function get_user_by_username($username)
 {
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT * FROM admin_users WHERE LOWER(username) = LOWER(?)');
-    $stmt->bind_param('s', $username);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $user = $result->fetch_assoc();
-    $stmt->close();
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT * FROM admin_users WHERE LOWER(username) = LOWER(?)');
+    $stmt->execute([$username]);
+    $user = $stmt->fetch();
     return $user;
 }
 
@@ -35,15 +32,12 @@ function save_2fa_secret($username, $secret)
     try {
         // Encrypt the 2FA secret before storing to protect against DB compromise
         $encrypted_secret = portal_encrypt($secret);
-        $db = get_db_connection();
-        $stmt = $db->prepare('UPDATE admin_users SET two_factor_secret = ?, two_factor_enabled = 1 WHERE username = ?');
-        $stmt->bind_param('ss', $encrypted_secret, $user['username']);
-        if (!$stmt->execute()) {
-            error_log("2FA setup failed: DB update error - " . $stmt->error);
-            $stmt->close();
+        global $pdo;
+        $stmt = $pdo->prepare('UPDATE admin_users SET two_factor_secret = ?, two_factor_enabled = 1 WHERE username = ?');
+        if (!$stmt->execute([$encrypted_secret, $user['username']])) {
+            error_log("2FA setup failed: DB update error");
             return false;
         }
-        $stmt->close();
         return true;
     } catch (Exception $e) {
         error_log("2FA setup failed: " . $e->getMessage());
@@ -63,11 +57,9 @@ function disable_2fa($username)
     if (!$user) return false;
 
     try {
-        $db = get_db_connection();
-        $stmt = $db->prepare('UPDATE admin_users SET two_factor_secret = NULL, two_factor_enabled = 0 WHERE username = ?');
-        $stmt->bind_param('s', $user['username']);
-        $success = $stmt->execute() && $stmt->affected_rows > 0;
-        $stmt->close();
+        global $pdo;
+        $stmt = $pdo->prepare('UPDATE admin_users SET two_factor_secret = NULL, two_factor_enabled = 0 WHERE username = ?');
+        $success = $stmt->execute([$user['username']]) && $stmt->rowCount() > 0;
         return $success;
     } catch (Exception $e) {
         return false;

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -35,18 +35,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_action'])) {
     $selected_ids = $_POST['selected_ids'] ?? [];
 
     if (!empty($selected_ids)) {
-        $db = get_db_connection();
         $success_count = 0;
         $fail_count = 0;
 
         if ($action === 'delete') {
             foreach ($selected_ids as $user_id) {
-                $stmt = $db->prepare('DELETE FROM community_users WHERE id = ?');
-                $stmt->bind_param('i', $user_id);
-                
-                if ($stmt->execute()) {
-                    $success_count++;
-                } else {
+                $stmt = $pdo->prepare('DELETE FROM community_users WHERE id = ?');
+
+                try {
+                    if ($stmt->execute([$user_id])) {
+                        $success_count++;
+                    } else {
+                        $fail_count++;
+                    }
+                } catch (Exception $e) {
                     $fail_count++;
                 }
             }
@@ -65,18 +67,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_action'])) {
         } elseif ($action === 'unban') {
             foreach ($selected_ids as $user_id) {
                 // Deactivate all active bans for this user
-                $stmt = $db->prepare('UPDATE user_bans SET is_active = 0, unbanned_at = NOW(), unbanned_by = NULL WHERE user_id = ? AND is_active = 1');
-                $stmt->bind_param('i', $user_id);
-                
-                if ($stmt->execute() && $stmt->affected_rows > 0) {
+                $stmt = $pdo->prepare('UPDATE user_bans SET is_active = 0, unbanned_at = NOW(), unbanned_by = NULL WHERE user_id = ? AND is_active = 1');
+
+                if ($stmt->execute([$user_id]) && $stmt->rowCount() > 0) {
                     // Get user info for email
-                    $stmt2 = $db->prepare('SELECT username, email FROM community_users WHERE id = ?');
-                    $stmt2->bind_param('i', $user_id);
-                    $stmt2->execute();
-                    $result = $stmt2->get_result();
-                    $user = $result->fetch_assoc();
-                    $stmt2->close();
-                    
+                    $stmt2 = $pdo->prepare('SELECT username, email FROM community_users WHERE id = ?');
+                    $stmt2->execute([$user_id]);
+                    $user = $stmt2->fetch();
+
                     if ($user) {
                         send_unban_notification_email($user['email'], $user['username']);
                         $success_count++;
@@ -112,30 +110,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_action'])) {
 // Function to get all users with optional filters
 function get_all_users($search = '', $date_from = '', $date_to = '', $ban_status = 'all')
 {
-    $db = get_db_connection();
+    global $pdo;
     $users = [];
 
     $query = 'SELECT u.* FROM community_users u WHERE 1=1';
-    $types = '';
     $params = [];
 
     if (!empty($search)) {
         $query .= ' AND (u.username LIKE ? OR u.email LIKE ?)';
         $search_param = '%' . $search . '%';
-        $types .= 'ss';
         $params[] = $search_param;
         $params[] = $search_param;
     }
 
     if (!empty($date_from)) {
         $query .= ' AND DATE(u.created_at) >= ?';
-        $types .= 's';
         $params[] = $date_from;
     }
 
     if (!empty($date_to)) {
         $query .= ' AND DATE(u.created_at) <= ?';
-        $types .= 's';
         $params[] = $date_to;
     }
 
@@ -149,19 +143,17 @@ function get_all_users($search = '', $date_from = '', $date_to = '', $ban_status
     $query .= ' ORDER BY u.created_at DESC';
 
     if (!empty($params)) {
-        $stmt = $db->prepare($query);
-        $stmt->bind_param($types, ...$params);
-        $stmt->execute();
-        $result = $stmt->get_result();
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
 
-        while ($row = $result->fetch_assoc()) {
+        while ($row = $stmt->fetch()) {
             $row['is_banned'] = is_user_banned($row['id']);
             $users[] = $row;
         }
     } else {
-        $result = $db->query($query);
+        $stmt = $pdo->query($query);
 
-        while ($row = $result->fetch_assoc()) {
+        while ($row = $stmt->fetch()) {
             $row['is_banned'] = is_user_banned($row['id']);
             $users[] = $row;
         }
@@ -207,7 +199,6 @@ if (!empty($date_preset) && $date_preset !== 'custom') {
 $users = get_all_users($search, $date_from, $date_to, $ban_status);
 
 // Get user statistics for dashboard
-$db = get_db_connection();
 
 // Total users
 $total_users = count($users);

--- a/admin/website-stats/index.php
+++ b/admin/website-stats/index.php
@@ -38,7 +38,7 @@ function get_period_formatting($period)
  */
 function get_stats_by_period($table, $period = 'month', $limit = 12, $where_clause = '')
 {
-    $db = get_db_connection();
+    global $pdo;
     list($sql_period, $display_format) = get_period_formatting($period);
 
     $where = $where_clause ? "WHERE $where_clause" : '';
@@ -53,17 +53,14 @@ function get_stats_by_period($table, $period = 'month', $limit = 12, $where_clau
         ORDER BY period DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
-    $stmt->close();
     return $data;
 }
 
@@ -82,7 +79,7 @@ function get_registrations_by_period($period = 'month', $limit = 12)
 // Function to get page view statistics
 function get_page_views_by_period($period = 'month', $limit = 12)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     $sql_period = '';
     $display_format = '';
@@ -116,33 +113,30 @@ function get_page_views_by_period($period = 'month', $limit = 12)
         ORDER BY period DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
-    $stmt->close();
     return $data;
 }
 
 // Function to get community post views
 function get_community_post_views()
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             SUM(views) as total_views,
             AVG(views) as avg_views_per_post,
             MAX(views) as most_viewed
         FROM community_posts";
 
-    $result = $db->query($query);
-    $data = $result->fetch_assoc();
+    $stmt = $pdo->query($query);
+    $data = $stmt->fetch();
 
     return $data;
 }
@@ -150,19 +144,19 @@ function get_community_post_views()
 // Function to get community activity by post type
 function get_community_post_types()
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             post_type,
             COUNT(*) as count,
             SUM(views) as total_views
         FROM community_posts
         GROUP BY post_type";
 
-    $result = $db->query($query);
+    $stmt = $pdo->query($query);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
@@ -172,9 +166,9 @@ function get_community_post_types()
 // Function to get geographic distribution of users by page views
 function get_user_countries($limit = 10)
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             country_code,
             COUNT(DISTINCT ip_address) as count
         FROM statistics
@@ -183,17 +177,13 @@ function get_user_countries($limit = 10)
         ORDER BY count DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
-
-    $stmt->close();
 
     return $data;
 }
@@ -201,9 +191,9 @@ function get_user_countries($limit = 10)
 // Function to get downloads by country
 function get_downloads_by_country($limit = 10)
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             country_code,
             COUNT(*) as download_count
         FROM statistics
@@ -212,17 +202,13 @@ function get_downloads_by_country($limit = 10)
         ORDER BY download_count DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
-
-    $stmt->close();
 
     return $data;
 }
@@ -230,9 +216,9 @@ function get_downloads_by_country($limit = 10)
 // Function to get browser/platform statistics
 function get_user_agents()
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             CASE
                 WHEN user_agent LIKE '%Chrome%' THEN 'Chrome'
                 WHEN user_agent LIKE '%Firefox%' THEN 'Firefox'
@@ -247,10 +233,10 @@ function get_user_agents()
         GROUP BY browser
         ORDER BY count DESC";
 
-    $result = $db->query($query);
+    $stmt = $pdo->query($query);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 
@@ -260,17 +246,17 @@ function get_user_agents()
 // Function to get conversion rate data
 function get_conversion_data()
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Get total downloads (from statistics table)
     $download_query = "SELECT COUNT(*) as count FROM statistics WHERE event_type IN ('download_win', 'download_mac', 'download_linux', 'download_avalonia')";
-    $download_result = $db->query($download_query);
-    $downloads = $download_result->fetch_assoc()['count'];
+    $download_stmt = $pdo->query($download_query);
+    $downloads = $download_stmt->fetch()['count'];
 
     // Get total registrations
     $reg_query = "SELECT COUNT(*) as count FROM community_users";
-    $reg_result = $db->query($reg_query);
-    $registrations = $reg_result->fetch_assoc()['count'];
+    $reg_stmt = $pdo->query($reg_query);
+    $registrations = $reg_stmt->fetch()['count'];
 
     return [
         'downloads' => $downloads,
@@ -281,9 +267,9 @@ function get_conversion_data()
 // Function to get most active users
 function get_most_active_users($limit = 5)
 {
-    $db = get_db_connection();
+    global $pdo;
     $query = "
-        SELECT 
+        SELECT
             u.username,
             u.email,
             COUNT(DISTINCT p.id) as post_count,
@@ -297,13 +283,11 @@ function get_most_active_users($limit = 5)
         ORDER BY activity_score DESC
         LIMIT ?";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param('i', $limit);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$limit]);
 
     $data = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $data[] = $row;
     }
 

--- a/api/google/callback.php
+++ b/api/google/callback.php
@@ -30,29 +30,23 @@ if (empty($state) || empty($code)) {
 }
 
 // Validate state token against google_oauth_states table
-$db = get_db_connection();
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'SELECT device_id_hash FROM google_oauth_states
      WHERE state_token = ? AND expires_at > NOW()
      LIMIT 1'
 );
-$stmt->bind_param('s', $state);
-$stmt->execute();
-$row = $stmt->get_result()->fetch_assoc();
-$stmt->close();
+$stmt->execute([$state]);
+$row = $stmt->fetch();
 
 if (!$row) {
-    $db->close();
     showResult(false, 'Invalid or expired authorization state. Please try again from the app.');
 }
 
 $deviceIdHash = $row['device_id_hash'];
 
 // Clean up used state token
-$stmt = $db->prepare('DELETE FROM google_oauth_states WHERE state_token = ?');
-$stmt->bind_param('s', $state);
-$stmt->execute();
-$stmt->close();
+$stmt = $pdo->prepare('DELETE FROM google_oauth_states WHERE state_token = ?');
+$stmt->execute([$state]);
 
 // Exchange authorization code for tokens
 $clientId = $_ENV['GOOGLE_CLIENT_ID'] ?? '';
@@ -81,7 +75,6 @@ $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 $curlError = curl_error($ch);
 
 if ($response === false || $httpCode !== 200) {
-    $db->close();
     error_log('Google token exchange failed (HTTP ' . $httpCode . '): ' . ($response ?: $curlError));
     showResult(false, 'Failed to complete Google authorization. Please try again.');
 }
@@ -92,7 +85,6 @@ $refreshToken = $tokenData['refresh_token'] ?? '';
 $expiresIn = $tokenData['expires_in'] ?? 3600;
 
 if (empty($accessToken)) {
-    $db->close();
     showResult(false, 'Invalid token response from Google.');
 }
 
@@ -102,7 +94,7 @@ $encryptedRefresh = !empty($refreshToken) ? google_encrypt($refreshToken) : null
 $expiresAt = date('Y-m-d H:i:s', time() + $expiresIn);
 
 // Store tokens in database
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'INSERT INTO google_oauth_tokens (device_id_hash, google_access_token, google_refresh_token, google_token_expires)
      VALUES (?, ?, ?, ?)
      ON DUPLICATE KEY UPDATE
@@ -110,10 +102,7 @@ $stmt = $db->prepare(
         google_refresh_token = COALESCE(VALUES(google_refresh_token), google_refresh_token),
         google_token_expires = VALUES(google_token_expires)'
 );
-$stmt->bind_param('ssss', $deviceIdHash, $encryptedAccess, $encryptedRefresh, $expiresAt);
-$stmt->execute();
-$stmt->close();
-$db->close();
+$stmt->execute([$deviceIdHash, $encryptedAccess, $encryptedRefresh, $expiresAt]);
 
 showResult(true, 'Google Sheets connected successfully!');
 

--- a/api/google/google-helper.php
+++ b/api/google/google-helper.php
@@ -36,19 +36,16 @@ function authenticate_google_request(): ?array
  */
 function get_google_tokens(array $authContext): ?array
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Query device-based tokens
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'SELECT google_access_token, google_refresh_token, google_token_expires
          FROM google_oauth_tokens WHERE device_id_hash = ? LIMIT 1'
     );
-    $stmt->bind_param('s', $authContext['device_id_hash']);
-    $stmt->execute();
-    $row = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$authContext['device_id_hash']]);
+    $row = $stmt->fetch();
 
-    $db->close();
     return $row ?: null;
 }
 
@@ -57,16 +54,13 @@ function get_google_tokens(array $authContext): ?array
  */
 function update_google_access_token(array $authContext, string $encryptedAccessToken, string $expiresAt): void
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'UPDATE google_oauth_tokens SET google_access_token = ?, google_token_expires = ? WHERE device_id_hash = ?'
     );
-    $stmt->bind_param('sss', $encryptedAccessToken, $expiresAt, $authContext['device_id_hash']);
 
-    $stmt->execute();
-    $stmt->close();
-    $db->close();
+    $stmt->execute([$encryptedAccessToken, $expiresAt, $authContext['device_id_hash']]);
 }
 
 /**
@@ -74,16 +68,13 @@ function update_google_access_token(array $authContext, string $encryptedAccessT
  */
 function clear_google_tokens(array $authContext): void
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'DELETE FROM google_oauth_tokens WHERE device_id_hash = ?'
     );
-    $stmt->bind_param('s', $authContext['device_id_hash']);
 
-    $stmt->execute();
-    $stmt->close();
-    $db->close();
+    $stmt->execute([$authContext['device_id_hash']]);
 }
 
 /**
@@ -92,23 +83,18 @@ function clear_google_tokens(array $authContext): void
  */
 function store_google_oauth_state(array $authContext, string $state): void
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Clean up expired states for this device
-    $stmt = $db->prepare('DELETE FROM google_oauth_states WHERE device_id_hash = ? OR expires_at < NOW()');
-    $stmt->bind_param('s', $authContext['device_id_hash']);
-    $stmt->execute();
-    $stmt->close();
+    $stmt = $pdo->prepare('DELETE FROM google_oauth_states WHERE device_id_hash = ? OR expires_at < NOW()');
+    $stmt->execute([$authContext['device_id_hash']]);
 
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'INSERT INTO google_oauth_states (state_token, device_id_hash, expires_at)
          VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 10 MINUTE))'
     );
-    $stmt->bind_param('ss', $state, $authContext['device_id_hash']);
 
-    $stmt->execute();
-    $stmt->close();
-    $db->close();
+    $stmt->execute([$state, $authContext['device_id_hash']]);
 }
 
 /**

--- a/api/portal/checkout.php
+++ b/api/portal/checkout.php
@@ -201,13 +201,10 @@ function handle_square_checkout(array $invoice, int $amountCents, string $curren
 
     // For Square with OAuth, the payment is processed using the business's access token.
     // Get the encrypted access token from the company record.
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT square_access_token, square_location_id FROM portal_companies WHERE id = ? LIMIT 1');
-    $stmt->bind_param('i', $invoice['company_id']);
-    $stmt->execute();
-    $company = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
-    $db->close();
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT square_access_token, square_location_id FROM portal_companies WHERE id = ? LIMIT 1');
+    $stmt->execute([$invoice['company_id']]);
+    $company = $stmt->fetch();
 
     if (empty($company['square_access_token'])) {
         send_error_response(400, 'Square is not properly configured for this business.', 'SQUARE_NOT_CONFIGURED');

--- a/api/portal/company-name.php
+++ b/api/portal/company-name.php
@@ -42,25 +42,13 @@ if (mb_strlen($companyName) > 255) {
 
 $companyId = $company['id'];
 
-$db = get_db_connection();
-$stmt = $db->prepare('UPDATE portal_companies SET company_name = ? WHERE id = ?');
-if ($stmt === false) {
-    error_log('Portal company name update DB prepare error: ' . $db->error);
-    $db->close();
+try {
+    $stmt = $pdo->prepare('UPDATE portal_companies SET company_name = ? WHERE id = ?');
+    $stmt->execute([$companyName, $companyId]);
+} catch (\PDOException $e) {
+    error_log('Portal company name update DB error: ' . $e->getMessage());
     send_error_response(500, 'Failed to update company name. Please try again.', 'DB_ERROR');
 }
-$stmt->bind_param('si', $companyName, $companyId);
-
-if (!$stmt->execute()) {
-    $error = $stmt->error;
-    $stmt->close();
-    $db->close();
-    error_log('Portal company name update DB error: ' . $error);
-    send_error_response(500, 'Failed to update company name. Please try again.', 'DB_ERROR');
-}
-
-$stmt->close();
-$db->close();
 
 send_json_response(200, [
     'success' => true,

--- a/api/portal/connect-callback.php
+++ b/api/portal/connect-callback.php
@@ -42,21 +42,17 @@ if (empty($state)) {
 }
 
 // Verify the CSRF state token and look up the company
-$db = get_db_connection();
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'SELECT os.id AS state_id, os.company_id, pc.company_name
      FROM portal_oauth_states os
      JOIN portal_companies pc ON os.company_id = pc.id
      WHERE os.state_token = ? AND os.provider = ? AND os.expires_at > NOW()
      LIMIT 1'
 );
-$stmt->bind_param('ss', $state, $provider);
-$stmt->execute();
-$oauthState = $stmt->get_result()->fetch_assoc();
-$stmt->close();
+$stmt->execute([$state, $provider]);
+$oauthState = $stmt->fetch();
 
 if (!$oauthState) {
-    $db->close();
     show_result_page(false, 'Invalid or expired authorization state. Please try connecting again from Argo Books.');
     exit;
 }
@@ -73,38 +69,31 @@ try {
     switch ($provider) {
         case 'stripe':
             $callbackUrl = "$callbackBase/api/portal/connect/callback/stripe";
-            $result = handle_stripe_callback($db, $companyId, $is_production, $isRefresh, $callbackUrl, $state);
+            $result = handle_stripe_callback($pdo, $companyId, $is_production, $isRefresh, $callbackUrl, $state);
             if ($result === 'redirect') {
                 // Onboarding incomplete — keep the state token alive for the next callback
-                $db->close();
                 exit;
             }
             break;
         case 'paypal':
-            handle_paypal_callback($db, $companyId, $code, $is_production);
+            handle_paypal_callback($pdo, $companyId, $code, $is_production);
             break;
         case 'square':
-            handle_square_callback($db, $companyId, $code, $is_production);
+            handle_square_callback($pdo, $companyId, $code, $is_production);
             break;
     }
 
     // Delete the used state token (and clean up expired ones)
-    $stmt = $db->prepare('DELETE FROM portal_oauth_states WHERE id = ?');
-    $stmt->bind_param('i', $stateId);
-    $stmt->execute();
-    $stmt->close();
-    $db->query('DELETE FROM portal_oauth_states WHERE expires_at <= NOW()');
+    $stmt = $pdo->prepare('DELETE FROM portal_oauth_states WHERE id = ?');
+    $stmt->execute([$stateId]);
+    $pdo->query('DELETE FROM portal_oauth_states WHERE expires_at <= NOW()');
 
-    $db->close();
     show_result_page(true, ucfirst($provider) . ' has been connected successfully!', $companyName);
 } catch (Exception $e) {
     // Clean up state token even on failure
-    $stmt = $db->prepare('DELETE FROM portal_oauth_states WHERE id = ?');
-    $stmt->bind_param('i', $stateId);
-    $stmt->execute();
-    $stmt->close();
+    $stmt = $pdo->prepare('DELETE FROM portal_oauth_states WHERE id = ?');
+    $stmt->execute([$stateId]);
 
-    $db->close();
     error_log("OAuth callback error ($provider): " . $e->getMessage());
     show_result_page(false, 'Failed to complete connection: ' . $e->getMessage());
 }
@@ -114,7 +103,7 @@ try {
  * Retrieves the Express account, checks onboarding status, and saves email if complete.
  * Returns 'redirect' if onboarding is incomplete and the user was redirected back to Stripe.
  */
-function handle_stripe_callback(mysqli $db, int $companyId, bool $is_production, bool $isRefresh, string $callbackUrl, string $state): ?string
+function handle_stripe_callback(PDO $db, int $companyId, bool $is_production, bool $isRefresh, string $callbackUrl, string $state): ?string
 {
     $secretKey = $is_production
         ? ($_ENV['STRIPE_LIVE_SECRET_KEY'] ?? '')
@@ -123,10 +112,8 @@ function handle_stripe_callback(mysqli $db, int $companyId, bool $is_production,
 
     // Look up the stored Stripe account ID for this company
     $stmt = $db->prepare('SELECT stripe_account_id FROM portal_companies WHERE id = ?');
-    $stmt->bind_param('i', $companyId);
-    $stmt->execute();
-    $row = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$companyId]);
+    $row = $stmt->fetch();
 
     $stripeAccountId = $row['stripe_account_id'] ?? '';
     if (empty($stripeAccountId)) {
@@ -159,9 +146,7 @@ function handle_stripe_callback(mysqli $db, int $companyId, bool $is_production,
          SET stripe_email = ?, updated_at = NOW()
          WHERE id = ?'
     );
-    $stmt->bind_param('si', $email, $companyId);
-    $stmt->execute();
-    $stmt->close();
+    $stmt->execute([$email, $companyId]);
 
     return null;
 }
@@ -170,7 +155,7 @@ function handle_stripe_callback(mysqli $db, int $companyId, bool $is_production,
  * Handle PayPal OAuth callback.
  * Exchanges the authorization code for tokens, then retrieves the merchant/payer ID and email.
  */
-function handle_paypal_callback(mysqli $db, int $companyId, string $code, bool $is_production): void
+function handle_paypal_callback(PDO $db, int $companyId, string $code, bool $is_production): void
 {
     $clientId = $is_production
         ? $_ENV['PAYPAL_LIVE_CLIENT_ID']
@@ -247,16 +232,14 @@ function handle_paypal_callback(mysqli $db, int $companyId, string $code, bool $
          SET paypal_merchant_id = ?, paypal_email = ?, updated_at = NOW()
          WHERE id = ?'
     );
-    $stmt->bind_param('ssi', $payerId, $email, $companyId);
-    $stmt->execute();
-    $stmt->close();
+    $stmt->execute([$payerId, $email, $companyId]);
 }
 
 /**
  * Handle Square OAuth callback.
  * Exchanges the authorization code for access token, merchant ID, and location.
  */
-function handle_square_callback(mysqli $db, int $companyId, string $code, bool $is_production): void
+function handle_square_callback(PDO $db, int $companyId, string $code, bool $is_production): void
 {
     $appId = $is_production
         ? ($_ENV['SQUARE_LIVE_APP_ID'] ?? '')
@@ -360,9 +343,7 @@ function handle_square_callback(mysqli $db, int $companyId, string $code, bool $
              square_email = ?, updated_at = NOW()
          WHERE id = ?'
     );
-    $stmt->bind_param('ssssi', $merchantId, $encryptedAccessToken, $locationId, $email, $companyId);
-    $stmt->execute();
-    $stmt->close();
+    $stmt->execute([$merchantId, $encryptedAccessToken, $locationId, $email, $companyId]);
 }
 
 /**

--- a/api/portal/connect.php
+++ b/api/portal/connect.php
@@ -47,19 +47,16 @@ function initiate_connect(array $company, string $provider): void
     $state = bin2hex(random_bytes(32));
 
     // Store state in DB with 10-minute expiry
-    $db = get_db_connection();
+    global $pdo;
     $expiresAt = date('Y-m-d H:i:s', time() + 600);
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'INSERT INTO portal_oauth_states (company_id, provider, state_token, expires_at)
          VALUES (?, ?, ?, ?)'
     );
-    $stmt->bind_param('isss', $company['id'], $provider, $state, $expiresAt);
-    $stmt->execute();
-    $stmt->close();
+    $stmt->execute([$company['id'], $provider, $state, $expiresAt]);
 
     // Clean up expired states
-    $db->query('DELETE FROM portal_oauth_states WHERE expires_at <= NOW()');
-    $db->close();
+    $pdo->query('DELETE FROM portal_oauth_states WHERE expires_at <= NOW()');
 
     $authUrl = '';
 
@@ -77,15 +74,11 @@ function initiate_connect(array $company, string $provider): void
 
                 // Check if this company already has a Stripe Express account
                 $stripeAccountId = null;
-                $dbCheck = get_db_connection();
-                $stmtCheck = $dbCheck->prepare(
+                $stmtCheck = $pdo->prepare(
                     'SELECT stripe_account_id FROM portal_companies WHERE id = ?'
                 );
-                $stmtCheck->bind_param('i', $company['id']);
-                $stmtCheck->execute();
-                $row = $stmtCheck->get_result()->fetch_assoc();
-                $stmtCheck->close();
-                $dbCheck->close();
+                $stmtCheck->execute([$company['id']]);
+                $row = $stmtCheck->fetch();
 
                 if (!empty($row['stripe_account_id'])) {
                     // Verify the stored account exists and matches the current mode (live vs test)
@@ -103,14 +96,10 @@ function initiate_connect(array $company, string $provider): void
                     }
 
                     if (!$stripeAccountId) {
-                        $dbClear = get_db_connection();
-                        $stmtClear = $dbClear->prepare(
+                        $stmtClear = $pdo->prepare(
                             'UPDATE portal_companies SET stripe_account_id = NULL, stripe_email = NULL, updated_at = NOW() WHERE id = ?'
                         );
-                        $stmtClear->bind_param('i', $company['id']);
-                        $stmtClear->execute();
-                        $stmtClear->close();
-                        $dbClear->close();
+                        $stmtClear->execute([$company['id']]);
                     }
                 }
 
@@ -126,14 +115,10 @@ function initiate_connect(array $company, string $provider): void
                     $stripeAccountId = $account->id;
 
                     // Store the account ID immediately
-                    $dbStore = get_db_connection();
-                    $stmtStore = $dbStore->prepare(
+                    $stmtStore = $pdo->prepare(
                         'UPDATE portal_companies SET stripe_account_id = ?, updated_at = NOW() WHERE id = ?'
                     );
-                    $stmtStore->bind_param('si', $stripeAccountId, $company['id']);
-                    $stmtStore->execute();
-                    $stmtStore->close();
-                    $dbStore->close();
+                    $stmtStore->execute([$stripeAccountId, $company['id']]);
                 }
 
                 // Create an Account Link for Express onboarding
@@ -203,47 +188,41 @@ function initiate_connect(array $company, string $provider): void
  */
 function disconnect_provider(array $company, string $provider): void
 {
-    $db = get_db_connection();
+    global $pdo;
 
     switch ($provider) {
         case 'stripe':
-            $stmt = $db->prepare(
+            $stmt = $pdo->prepare(
                 'UPDATE portal_companies SET stripe_account_id = NULL, stripe_email = NULL, updated_at = NOW() WHERE id = ?'
             );
             break;
         case 'paypal':
-            $stmt = $db->prepare(
+            $stmt = $pdo->prepare(
                 'UPDATE portal_companies SET paypal_merchant_id = NULL, paypal_email = NULL, updated_at = NOW() WHERE id = ?'
             );
             break;
         case 'square':
-            $stmt = $db->prepare(
+            $stmt = $pdo->prepare(
                 'UPDATE portal_companies SET square_merchant_id = NULL, square_access_token = NULL, square_location_id = NULL, square_email = NULL, updated_at = NOW() WHERE id = ?'
             );
             break;
     }
 
-    $stmt->bind_param('i', $company['id']);
-    if (!$stmt->execute()) {
-        $error = $stmt->error;
-        $stmt->close();
-        $db->close();
-        error_log('Portal disconnect DB error (' . $provider . '): ' . $error);
+    try {
+        $stmt->execute([$company['id']]);
+    } catch (\PDOException $e) {
+        error_log('Portal disconnect DB error (' . $provider . '): ' . $e->getMessage());
         send_error_response(500, 'Failed to disconnect ' . $provider . '. Please try again.', 'DISCONNECT_FAILED');
     }
-    $stmt->close();
 
     // Re-fetch company to return the updated connected providers state
-    $stmtRefresh = $db->prepare(
+    $stmtRefresh = $pdo->prepare(
         'SELECT stripe_account_id, stripe_email, paypal_merchant_id, paypal_email,
                 square_merchant_id, square_email
          FROM portal_companies WHERE id = ? LIMIT 1'
     );
-    $stmtRefresh->bind_param('i', $company['id']);
-    $stmtRefresh->execute();
-    $updated = $stmtRefresh->get_result()->fetch_assoc();
-    $stmtRefresh->close();
-    $db->close();
+    $stmtRefresh->execute([$company['id']]);
+    $updated = $stmtRefresh->fetch();
 
     $connectedProviders = [
         'stripeConnected' => !empty($updated['stripe_account_id']),

--- a/api/portal/invoices.php
+++ b/api/portal/invoices.php
@@ -45,19 +45,17 @@ function handle_publish_invoice(): void
         send_error_response(400, 'Missing required fields: ' . implode(', ', $missing), 'MISSING_FIELDS');
     }
 
-    $db = get_db_connection();
+    global $pdo;
     $companyId = $company['id'];
     $invoiceId = $data['invoiceId'];
 
     // Check if invoice already exists (update vs create)
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'SELECT id, invoice_token, customer_token FROM portal_invoices
          WHERE company_id = ? AND invoice_id = ? LIMIT 1'
     );
-    $stmt->bind_param('is', $companyId, $invoiceId);
-    $stmt->execute();
-    $existing = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$companyId, $invoiceId]);
+    $existing = $stmt->fetch();
 
     $invoiceToken = $existing['invoice_token'] ?? generate_portal_token();
     $customerToken = $existing['customer_token'] ?? '';
@@ -66,15 +64,13 @@ function handle_publish_invoice(): void
     $customerEmail = $data['customerEmail'] ?? '';
     if (empty($customerToken) && !empty($customerEmail)) {
         // Check if this customer already has a token with this company
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'SELECT customer_token FROM portal_invoices
              WHERE company_id = ? AND customer_email = ? AND customer_token != ""
              LIMIT 1'
         );
-        $stmt->bind_param('is', $companyId, $customerEmail);
-        $stmt->execute();
-        $existingCustomer = $stmt->get_result()->fetch_assoc();
-        $stmt->close();
+        $stmt->execute([$companyId, $customerEmail]);
+        $existingCustomer = $stmt->fetch();
 
         $customerToken = $existingCustomer['customer_token'] ?? generate_portal_token();
     } elseif (empty($customerToken)) {
@@ -96,7 +92,7 @@ function handle_publish_invoice(): void
 
     if ($existing) {
         // Update existing invoice
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'UPDATE portal_invoices SET
                 customer_name = ?, customer_email = ?, invoice_data = ?,
                 status = ?, total_amount = ?, balance_due = ?,
@@ -104,17 +100,16 @@ function handle_publish_invoice(): void
                 updated_at = NOW()
              WHERE company_id = ? AND invoice_id = ?'
         );
-        $stmt->bind_param(
-            'ssssddssiis',
+        $params = [
             $customerName, $customerEmail, $invoiceData,
             $status, $totalAmount, $balanceDue,
             $currency, $dueDate, $passProcessingFee,
             $companyId, $invoiceId
-        );
+        ];
     } else {
         // Create new invoice
         $environment = ($_ENV['APP_ENV'] ?? 'sandbox') === 'production' ? 'production' : 'sandbox';
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'INSERT INTO portal_invoices
              (company_id, invoice_id, invoice_token, customer_token,
               customer_name, customer_email, invoice_data,
@@ -122,24 +117,20 @@ function handle_publish_invoice(): void
               pass_processing_fee, environment, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())'
         );
-        $stmt->bind_param(
-            'isssssssddssis',
+        $params = [
             $companyId, $invoiceId, $invoiceToken, $customerToken,
             $customerName, $customerEmail, $invoiceData,
             $status, $totalAmount, $balanceDue, $currency, $dueDate,
             $passProcessingFee, $environment
-        );
+        ];
     }
 
-    if (!$stmt->execute()) {
-        $error = $stmt->error;
-        $stmt->close();
-        $db->close();
-        error_log('Portal invoice DB error: ' . $error);
+    try {
+        $stmt->execute($params);
+    } catch (\PDOException $e) {
+        error_log('Portal invoice DB error: ' . $e->getMessage());
         send_error_response(500, 'Failed to save invoice. Please try again.', 'DB_ERROR');
     }
-    $stmt->close();
-    $db->close();
 
     $invoiceUrl = site_url('/invoice/' . $invoiceToken);
     $portalUrl = site_url('/portal/' . $customerToken);

--- a/api/portal/logo.php
+++ b/api/portal/logo.php
@@ -37,12 +37,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
     // --- Delete the current logo ---
     delete_logo_file($company['company_logo_url'], $logosDir);
 
-    $db = get_db_connection();
-    $stmt = $db->prepare('UPDATE portal_companies SET company_logo_url = NULL WHERE id = ?');
-    $stmt->bind_param('i', $companyId);
-    $stmt->execute();
-    $stmt->close();
-    $db->close();
+    $stmt = $pdo->prepare('UPDATE portal_companies SET company_logo_url = NULL WHERE id = ?');
+    $stmt->execute([$companyId]);
 
     send_json_response(200, [
         'success' => true,
@@ -124,12 +120,8 @@ $assetBaseUrl = rtrim(env('SITE_URL', 'https://argorobots.com'), '/');
 $logoUrl = $assetBaseUrl . '/resources/uploads/logos/' . $filename;
 
 // Update the database
-$db = get_db_connection();
-$stmt = $db->prepare('UPDATE portal_companies SET company_logo_url = ? WHERE id = ?');
-$stmt->bind_param('si', $logoUrl, $companyId);
-$stmt->execute();
-$stmt->close();
-$db->close();
+$stmt = $pdo->prepare('UPDATE portal_companies SET company_logo_url = ? WHERE id = ?');
+$stmt->execute([$logoUrl, $companyId]);
 
 send_json_response(200, [
     'success' => true,

--- a/api/portal/payments-sync.php
+++ b/api/portal/payments-sync.php
@@ -32,25 +32,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
  */
 function handle_pull_payments(int $companyId): void
 {
+    global $pdo;
     $since = $_GET['since'] ?? null;
     $force = ($_GET['force'] ?? '0') === '1';
-
-    $db = get_db_connection();
 
     if ($force) {
         // Force re-sync: return ALL payments regardless of synced_to_argo flag.
         // Used to recover payments that were confirmed but not saved locally.
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'SELECT pp.*, pi.invoice_token, pi.customer_token
              FROM portal_payments pp
              LEFT JOIN portal_invoices pi ON pp.company_id = pi.company_id AND pp.invoice_id = pi.invoice_id
              WHERE pp.company_id = ?
              ORDER BY pp.created_at ASC'
         );
-        $stmt->bind_param('i', $companyId);
+        $params = [$companyId];
     } elseif ($since) {
         // Get payments created after the given timestamp
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'SELECT pp.*, pi.invoice_token, pi.customer_token
              FROM portal_payments pp
              LEFT JOIN portal_invoices pi ON pp.company_id = pi.company_id AND pp.invoice_id = pi.invoice_id
@@ -58,24 +57,23 @@ function handle_pull_payments(int $companyId): void
                AND (pp.synced_to_argo = 0 OR pp.created_at > ?)
              ORDER BY pp.created_at ASC'
         );
-        $stmt->bind_param('is', $companyId, $since);
+        $params = [$companyId, $since];
     } else {
         // Get all unsynced payments
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'SELECT pp.*, pi.invoice_token, pi.customer_token
              FROM portal_payments pp
              LEFT JOIN portal_invoices pi ON pp.company_id = pi.company_id AND pp.invoice_id = pi.invoice_id
              WHERE pp.company_id = ? AND pp.synced_to_argo = 0
              ORDER BY pp.created_at ASC'
         );
-        $stmt->bind_param('i', $companyId);
+        $params = [$companyId];
     }
 
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt->execute($params);
 
     $payments = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $payments[] = [
             'id' => (int) $row['id'],
             'invoiceId' => $row['invoice_id'],
@@ -92,8 +90,6 @@ function handle_pull_payments(int $companyId): void
             'createdAt' => date('c', strtotime($row['created_at'])),
         ];
     }
-    $stmt->close();
-    $db->close();
 
     send_json_response(200, [
         'success' => true,
@@ -126,24 +122,19 @@ function handle_confirm_sync(int $companyId): void
     // Sanitize IDs
     $paymentIds = array_map('intval', $paymentIds);
     $placeholders = implode(',', array_fill(0, count($paymentIds), '?'));
-    $types = str_repeat('i', count($paymentIds));
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Mark payments as synced (only for this company's payments)
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         "UPDATE portal_payments
          SET synced_to_argo = 1
          WHERE company_id = ? AND id IN ({$placeholders})"
     );
 
     $params = array_merge([$companyId], $paymentIds);
-    $types = 'i' . $types;
-    $stmt->bind_param($types, ...$params);
-    $stmt->execute();
-    $affectedRows = $stmt->affected_rows;
-    $stmt->close();
-    $db->close();
+    $stmt->execute($params);
+    $affectedRows = $stmt->rowCount();
 
     error_log("Portal sync POST: marked $affectedRows payments as synced for company=$companyId");
 

--- a/api/portal/portal-helper.php
+++ b/api/portal/portal-helper.php
@@ -57,6 +57,10 @@ function authenticate_portal_request(): ?array
 
     $apiKeyHash = hash('sha256', $providedApiKey);
     global $pdo;
+    if ($pdo === null) {
+        error_log('authenticate_portal_request: database connection unavailable');
+        return null;
+    }
 
     try {
         $stmt = $pdo->prepare('SELECT * FROM portal_companies WHERE api_key_hash = ? LIMIT 1');

--- a/api/portal/portal-helper.php
+++ b/api/portal/portal-helper.php
@@ -56,28 +56,17 @@ function authenticate_portal_request(): ?array
     }
 
     $apiKeyHash = hash('sha256', $providedApiKey);
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('SELECT * FROM portal_companies WHERE api_key_hash = ? LIMIT 1');
-    if ($stmt === false) {
-        error_log('authenticate_portal_request: DB prepare failed: ' . $db->error);
-        $db->close();
+    try {
+        $stmt = $pdo->prepare('SELECT * FROM portal_companies WHERE api_key_hash = ? LIMIT 1');
+        $stmt->execute([$apiKeyHash]);
+        $company = $stmt->fetch();
+    } catch (PDOException $e) {
+        error_log('authenticate_portal_request: DB error: ' . $e->getMessage());
         return null;
     }
 
-    $stmt->bind_param('s', $apiKeyHash);
-
-    if (!$stmt->execute()) {
-        error_log('authenticate_portal_request: DB execute failed: ' . $stmt->error);
-        $stmt->close();
-        $db->close();
-        return null;
-    }
-
-    $company = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
-
-    $db->close();
     return $company ?: null;
 }
 
@@ -227,8 +216,8 @@ function enforce_payment_rate_limit(): void
  */
 function get_invoice_by_token(string $token): ?array
 {
-    $db = get_db_connection();
-    $stmt = $db->prepare(
+    global $pdo;
+    $stmt = $pdo->prepare(
         'SELECT pi.*, pc.company_name, pc.company_logo_url,
                 pc.stripe_account_id, pc.paypal_merchant_id,
                 pc.square_merchant_id
@@ -237,12 +226,8 @@ function get_invoice_by_token(string $token): ?array
          WHERE pi.invoice_token = ?
          LIMIT 1'
     );
-    $stmt->bind_param('s', $token);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $invoice = $result->fetch_assoc();
-    $stmt->close();
-    $db->close();
+    $stmt->execute([$token]);
+    $invoice = $stmt->fetch();
 
     if ($invoice && !empty($invoice['invoice_data'])) {
         $invoice['invoice_data'] = json_decode($invoice['invoice_data'], true);
@@ -259,10 +244,10 @@ function get_invoice_by_token(string $token): ?array
  */
 function get_invoices_by_customer_token(string $customerToken): array
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Get company info from the first matching invoice
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'SELECT pi.company_id, pc.company_name, pc.company_logo_url,
                 pc.stripe_account_id, pc.paypal_merchant_id,
                 pc.square_merchant_id
@@ -271,19 +256,15 @@ function get_invoices_by_customer_token(string $customerToken): array
          WHERE pi.customer_token = ?
          LIMIT 1'
     );
-    $stmt->bind_param('s', $customerToken);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $company = $result->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$customerToken]);
+    $company = $stmt->fetch();
 
     if (!$company) {
-        $db->close();
         return ['company' => null, 'invoices' => []];
     }
 
     // Get all invoices for this customer token
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'SELECT id, invoice_id, invoice_token, customer_name, customer_email,
                 invoice_data, status, total_amount, balance_due, currency,
                 due_date, created_at, updated_at
@@ -291,19 +272,15 @@ function get_invoices_by_customer_token(string $customerToken): array
          WHERE customer_token = ?
          ORDER BY due_date ASC'
     );
-    $stmt->bind_param('s', $customerToken);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt->execute([$customerToken]);
 
     $invoices = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         if (!empty($row['invoice_data'])) {
             $row['invoice_data'] = json_decode($row['invoice_data'], true);
         }
         $invoices[] = $row;
     }
-    $stmt->close();
-    $db->close();
 
     return [
         'company' => $company,
@@ -327,7 +304,7 @@ function record_portal_payment(array $params): array
         return ['success' => false, 'error' => 'Negative amounts are only allowed for refunds'];
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     $companyId = $params['company_id'];
     $invoiceId = $params['invoice_id'];
@@ -345,7 +322,7 @@ function record_portal_payment(array $params): array
     // Use INSERT ... ON DUPLICATE KEY UPDATE to prevent race conditions on duplicate payments.
     // SCHEMA REQUIREMENT: A UNIQUE index on `provider_payment_id` is required in portal_payments
     // for this to work correctly. e.g.: ALTER TABLE portal_payments ADD UNIQUE INDEX (provider_payment_id);
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'INSERT INTO portal_payments
          (company_id, invoice_id, customer_name, amount, processing_fee,
           currency, payment_method, provider_payment_id, provider_transaction_id,
@@ -353,40 +330,33 @@ function record_portal_payment(array $params): array
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NOW())
          ON DUPLICATE KEY UPDATE id=id'
     );
-    $stmt->bind_param(
-        'issddsssssss',
-        $companyId, $invoiceId, $customerName, $amount, $processingFee,
-        $currency, $paymentMethod, $providerPaymentId, $providerTransactionId,
-        $referenceNumber, $status, $paymentEnvironment
-    );
 
-    if (!$stmt->execute()) {
-        $error = $stmt->error;
-        error_log('Portal payment DB error: ' . $error);
-        $stmt->close();
-        $db->close();
+    try {
+        $stmt->execute([
+            $companyId, $invoiceId, $customerName, $amount, $processingFee,
+            $currency, $paymentMethod, $providerPaymentId, $providerTransactionId,
+            $referenceNumber, $status, $paymentEnvironment
+        ]);
+    } catch (PDOException $e) {
+        error_log('Portal payment DB error: ' . $e->getMessage());
         return [
             'success' => false,
             'message' => 'Failed to record payment'
         ];
     }
 
-    // ON DUPLICATE KEY UPDATE sets affected_rows to 2 when a duplicate is found.
-    // affected_rows == 1 means a new row was inserted.
-    $affectedRows = $stmt->affected_rows;
-    $paymentId = $stmt->insert_id;
-    $stmt->close();
+    // ON DUPLICATE KEY UPDATE sets rowCount() to 2 when a duplicate is found.
+    // rowCount() == 1 means a new row was inserted.
+    $affectedRows = $stmt->rowCount();
+    $paymentId = $pdo->lastInsertId();
 
     if ($affectedRows !== 1 && !empty($providerPaymentId)) {
         // Duplicate payment detected — return existing reference
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'SELECT reference_number FROM portal_payments WHERE provider_payment_id = ? LIMIT 1'
         );
-        $stmt->bind_param('s', $providerPaymentId);
-        $stmt->execute();
-        $existing = $stmt->get_result()->fetch_assoc();
-        $stmt->close();
-        $db->close();
+        $stmt->execute([$providerPaymentId]);
+        $existing = $stmt->fetch();
         return [
             'success' => true,
             'reference_number' => $existing['reference_number'] ?? $referenceNumber,
@@ -399,7 +369,7 @@ function record_portal_payment(array $params): array
     // The processing fee covers payment provider costs and is not part of the invoice total.
     if ($status === 'completed') {
         $invoiceAmount = max(0, $amount - $processingFee);
-        $stmt = $db->prepare(
+        $stmt = $pdo->prepare(
             'UPDATE portal_invoices
              SET balance_due = GREATEST(0, balance_due - ?),
                  status = CASE
@@ -410,12 +380,8 @@ function record_portal_payment(array $params): array
                  updated_at = NOW()
              WHERE company_id = ? AND invoice_id = ?'
         );
-        $stmt->bind_param('dddis', $invoiceAmount, $invoiceAmount, $invoiceAmount, $companyId, $invoiceId);
-        $stmt->execute();
-        $stmt->close();
+        $stmt->execute([$invoiceAmount, $invoiceAmount, $invoiceAmount, $companyId, $invoiceId]);
     }
-
-    $db->close();
 
     return [
         'success' => true,

--- a/api/portal/portal-helper.php
+++ b/api/portal/portal-helper.php
@@ -221,6 +221,10 @@ function enforce_payment_rate_limit(): void
 function get_invoice_by_token(string $token): ?array
 {
     global $pdo;
+    if ($pdo === null) {
+        error_log('get_invoice_by_token: database connection unavailable');
+        return null;
+    }
     $stmt = $pdo->prepare(
         'SELECT pi.*, pc.company_name, pc.company_logo_url,
                 pc.stripe_account_id, pc.paypal_merchant_id,
@@ -249,6 +253,10 @@ function get_invoice_by_token(string $token): ?array
 function get_invoices_by_customer_token(string $customerToken): array
 {
     global $pdo;
+    if ($pdo === null) {
+        error_log('get_invoices_by_customer_token: database connection unavailable');
+        return ['company' => null, 'invoices' => []];
+    }
 
     // Get company info from the first matching invoice
     $stmt = $pdo->prepare(

--- a/api/portal/register.php
+++ b/api/portal/register.php
@@ -59,36 +59,28 @@ if (!empty($licenseKey)) {
 }
 // Free path: no license key, device ID is the sole identifier (already validated as non-empty)
 
-$db = get_db_connection();
-
 // Check if company already exists by owner_email
 $ownerEmail = $data['ownerEmail'] ?? '';
 if (!empty($ownerEmail)) {
-    $stmt = $db->prepare('SELECT id FROM portal_companies WHERE owner_email = ? LIMIT 1');
-    $stmt->bind_param('s', $ownerEmail);
-    $stmt->execute();
-    $existing = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT id FROM portal_companies WHERE owner_email = ? LIMIT 1');
+    $stmt->execute([$ownerEmail]);
+    $existing = $stmt->fetch();
 
     if ($existing) {
         // Rotate API key: generate new key and store its hash
         $rotatedKey = bin2hex(random_bytes(32));
         $rotatedHash = hash('sha256', $rotatedKey);
-        $rotateStmt = $db->prepare('UPDATE portal_companies SET api_key_hash = ? WHERE id = ?');
-        if ($rotateStmt === false) {
-            error_log('Portal registration failed: failed to prepare API key rotation statement: ' . $db->error);
-            $db->close();
+        try {
+            $rotateStmt = $pdo->prepare('UPDATE portal_companies SET api_key_hash = ? WHERE id = ?');
+            $rotateStmt->execute([$rotatedHash, $existing['id']]);
+            if ($rotateStmt->rowCount() <= 0) {
+                error_log('Portal registration failed: API key rotation UPDATE affected 0 rows for company ID ' . $existing['id']);
+                send_error_response(500, 'Service temporarily unavailable. Please try again later.', 'DB_ERROR');
+            }
+        } catch (PDOException $e) {
+            error_log('Portal registration failed: API key rotation error: ' . $e->getMessage());
             send_error_response(500, 'Service temporarily unavailable. Please try again later.', 'DB_ERROR');
         }
-        $rotateStmt->bind_param('si', $rotatedHash, $existing['id']);
-        if (!$rotateStmt->execute() || $rotateStmt->affected_rows <= 0) {
-            error_log('Portal registration failed: API key rotation UPDATE failed for company ID ' . $existing['id'] . ': ' . $rotateStmt->error);
-            $rotateStmt->close();
-            $db->close();
-            send_error_response(500, 'Service temporarily unavailable. Please try again later.', 'DB_ERROR');
-        }
-        $rotateStmt->close();
-        $db->close();
         send_json_response(200, [
             'success' => true,
             'api_key' => $rotatedKey,
@@ -115,31 +107,25 @@ if ($squareAccessToken !== null && $squareAccessToken !== '') {
 $squareLocationId = $data['squareLocationId'] ?? null;
 $environment = ($_ENV['APP_ENV'] ?? 'sandbox') === 'production' ? 'production' : 'sandbox';
 
-$stmt = $db->prepare(
-    'INSERT INTO portal_companies
-     (api_key_hash, company_name, company_logo_url, stripe_account_id,
-      paypal_merchant_id, square_merchant_id, square_access_token,
-      square_location_id, owner_email, environment, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())'
-);
-$stmt->bind_param(
-    'ssssssssss',
-    $apiKeyHash, $companyName, $companyLogoUrl, $stripeAccountId,
-    $paypalMerchantId, $squareMerchantId, $squareAccessToken,
-    $squareLocationId, $ownerEmail, $environment
-);
-
-if (!$stmt->execute()) {
-    $error = $stmt->error;
-    $stmt->close();
-    $db->close();
-    error_log('Portal registration DB error: ' . $error);
+try {
+    $stmt = $pdo->prepare(
+        'INSERT INTO portal_companies
+         (api_key_hash, company_name, company_logo_url, stripe_account_id,
+          paypal_merchant_id, square_merchant_id, square_access_token,
+          square_location_id, owner_email, environment, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())'
+    );
+    $stmt->execute([
+        $apiKeyHash, $companyName, $companyLogoUrl, $stripeAccountId,
+        $paypalMerchantId, $squareMerchantId, $squareAccessToken,
+        $squareLocationId, $ownerEmail, $environment
+    ]);
+} catch (PDOException $e) {
+    error_log('Portal registration DB error: ' . $e->getMessage());
     send_error_response(500, 'Failed to register company. Please try again.', 'DB_ERROR');
 }
 
-$companyId = $stmt->insert_id;
-$stmt->close();
-$db->close();
+$companyId = $pdo->lastInsertId();
 
 send_json_response(201, [
     'success' => true,

--- a/api/portal/status.php
+++ b/api/portal/status.php
@@ -19,10 +19,9 @@ if (!$company) {
 }
 
 $companyId = $company['id'];
-$db = get_db_connection();
 
 // Get invoice and payment statistics
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'SELECT
          COUNT(*) as total_invoices,
          SUM(CASE WHEN status IN ("sent", "viewed", "partial", "overdue", "pending") THEN 1 ELSE 0 END) as active_invoices,
@@ -31,25 +30,21 @@ $stmt = $db->prepare(
      FROM portal_invoices
      WHERE company_id = ?'
 );
-$stmt->bind_param('i', $companyId);
-$stmt->execute();
-$invoiceStats = $stmt->get_result()->fetch_assoc();
-$stmt->close();
+$stmt->execute([$companyId]);
+$invoiceStats = $stmt->fetch();
 
 // Get unsynced payment count
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'SELECT COUNT(*) as unsynced_count,
             COALESCE(SUM(amount), 0) as unsynced_amount
      FROM portal_payments
      WHERE company_id = ? AND synced_to_argo = 0 AND status = "completed"'
 );
-$stmt->bind_param('i', $companyId);
-$stmt->execute();
-$syncStats = $stmt->get_result()->fetch_assoc();
-$stmt->close();
+$stmt->execute([$companyId]);
+$syncStats = $stmt->fetch();
 
 // Get this month's online revenue
-$stmt = $db->prepare(
+$stmt = $pdo->prepare(
     'SELECT COALESCE(SUM(amount), 0) as monthly_revenue,
             COUNT(*) as monthly_transactions
      FROM portal_payments
@@ -57,12 +52,8 @@ $stmt = $db->prepare(
        AND YEAR(created_at) = YEAR(NOW())
        AND MONTH(created_at) = MONTH(NOW())'
 );
-$stmt->bind_param('i', $companyId);
-$stmt->execute();
-$revenueStats = $stmt->get_result()->fetch_assoc();
-$stmt->close();
-
-$db->close();
+$stmt->execute([$companyId]);
+$revenueStats = $stmt->fetch();
 
 // Determine connected payment methods
 $paymentMethods = get_available_payment_methods($company);

--- a/api/portal/webhooks/paypal.php
+++ b/api/portal/webhooks/paypal.php
@@ -122,15 +122,11 @@ switch ($eventType) {
 
         if (!empty($captureId) && $captureAmount > 0 && !empty($invoiceRef)) {
             // Look up the invoice by invoice_id to get the company_id
-            $db = get_db_connection();
-            $stmt = $db->prepare(
+            $stmt = $pdo->prepare(
                 'SELECT company_id, invoice_id, customer_name FROM portal_invoices WHERE invoice_id = ? LIMIT 1'
             );
-            $stmt->bind_param('s', $invoiceRef);
-            $stmt->execute();
-            $invoiceRecord = $stmt->get_result()->fetch_assoc();
-            $stmt->close();
-            $db->close();
+            $stmt->execute([$invoiceRef]);
+            $invoiceRecord = $stmt->fetch();
 
             if ($invoiceRecord) {
                 record_portal_payment([

--- a/api/portal/webhooks/square.php
+++ b/api/portal/webhooks/square.php
@@ -71,15 +71,11 @@ switch ($eventType) {
         $invoiceRef = $squareReferenceId ?: $squareNote;
 
         if (!empty($paymentId) && $paymentId !== 'unknown' && $squareAmount > 0 && !empty($invoiceRef)) {
-            $db = get_db_connection();
-            $stmt = $db->prepare(
+            $stmt = $pdo->prepare(
                 'SELECT company_id, invoice_id, customer_name FROM portal_invoices WHERE invoice_id = ? LIMIT 1'
             );
-            $stmt->bind_param('s', $invoiceRef);
-            $stmt->execute();
-            $invoiceRecord = $stmt->get_result()->fetch_assoc();
-            $stmt->close();
-            $db->close();
+            $stmt->execute([$invoiceRef]);
+            $invoiceRecord = $stmt->fetch();
 
             if ($invoiceRecord) {
                 record_portal_payment([

--- a/api/portal/webhooks/stripe.php
+++ b/api/portal/webhooks/stripe.php
@@ -120,22 +120,19 @@ function handle_refund(\Stripe\Charge $charge): void
         return;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Find the original payment
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'SELECT id, company_id, invoice_id, customer_name, currency
          FROM portal_payments
          WHERE provider_payment_id = ? AND status = "completed"
          LIMIT 1'
     );
-    $stmt->bind_param('s', $providerPaymentId);
-    $stmt->execute();
-    $originalPayment = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$providerPaymentId]);
+    $originalPayment = $stmt->fetch();
 
     if (!$originalPayment) {
-        $db->close();
         return;
     }
 
@@ -161,15 +158,13 @@ function handle_refund(\Stripe\Charge $charge): void
     ]);
 
     // Update the original payment status
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'UPDATE portal_payments SET status = "refunded" WHERE id = ?'
     );
-    $stmt->bind_param('i', $originalPayment['id']);
-    $stmt->execute();
-    $stmt->close();
+    $stmt->execute([$originalPayment['id']]);
 
     // Update invoice balance (add refund amount back)
-    $stmt = $db->prepare(
+    $stmt = $pdo->prepare(
         'UPDATE portal_invoices
          SET balance_due = LEAST(total_amount, balance_due + ?),
              status = CASE
@@ -179,12 +174,8 @@ function handle_refund(\Stripe\Charge $charge): void
              updated_at = NOW()
          WHERE company_id = ? AND invoice_id = ?'
     );
-    $stmt->bind_param(
-        'ddis',
+    $stmt->execute([
         $refundAmount, $refundAmount,
         $originalPayment['company_id'], $originalPayment['invoice_id']
-    );
-    $stmt->execute();
-    $stmt->close();
-    $db->close();
+    ]);
 }

--- a/community/add_comment.php
+++ b/community/add_comment.php
@@ -96,16 +96,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             if ($comment) {
                 // Connect comment to user account
-                $db = get_db_connection();
-
                 // Make sure we have a valid user ID
                 $user_id = isset($current_user['id']) ? intval($current_user['id']) : 0;
 
                 if ($user_id > 0) {
-                    $stmt = $db->prepare('UPDATE community_comments SET user_id = ? WHERE id = ?');
-                    $stmt->bind_param('ii', $user_id, $comment['id']);
-                    $stmt->execute();
-                    $stmt->close();
+                    $stmt = $pdo->prepare('UPDATE community_comments SET user_id = ? WHERE id = ?');
+                    $stmt->execute([$user_id, $comment['id']]);
                 }
 
                 $response = [

--- a/community/community_functions.php
+++ b/community/community_functions.php
@@ -8,15 +8,15 @@ require_once __DIR__ . '/../email_sender.php';
  */
 function get_all_posts()
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Join with users table to get avatar
-    $result = $db->query('SELECT p.*, u.avatar FROM community_posts p 
+    $stmt = $pdo->query('SELECT p.*, u.avatar FROM community_posts p 
                          LEFT JOIN community_users u ON p.user_id = u.id 
                          ORDER BY p.created_at DESC');
 
     $posts = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $posts[] = $row;
     }
 
@@ -31,18 +31,15 @@ function get_all_posts()
  */
 function get_post($post_id)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Join with users table to get avatar
-    $stmt = $db->prepare('SELECT p.*, u.avatar FROM community_posts p 
+    $stmt = $pdo->prepare('SELECT p.*, u.avatar FROM community_posts p 
                          LEFT JOIN community_users u ON p.user_id = u.id 
                          WHERE p.id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $post = $result->fetch_assoc();
+    $stmt->execute([$post_id]);
+    $post = $stmt->fetch();
 
-    $stmt->close();
     return $post;
 }
 
@@ -59,7 +56,7 @@ function get_post($post_id)
  */
 function add_post($user_id, $user_name, $user_email, $title, $content, $post_type)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Process @mentions if the mentions.php file exists
     $has_mentions = false;
@@ -73,15 +70,12 @@ function add_post($user_id, $user_name, $user_email, $title, $content, $post_typ
         $has_mentions = !empty($mentions);
     }
 
-    $stmt = $db->prepare('INSERT INTO community_posts 
+    $stmt = $pdo->prepare('INSERT INTO community_posts 
         (user_id, user_name, user_email, title, content, post_type, views) 
         VALUES (?, ?, ?, ?, ?, ?, 0)');
 
-    $stmt->bind_param('isssss', $user_id, $user_name, $user_email, $title, $content, $post_type);
-
-    if ($stmt->execute()) {
-        $post_id = $db->insert_id;
-        $stmt->close();
+    if ($stmt->execute([$user_id, $user_name, $user_email, $title, $content, $post_type])) {
+        $post_id = $pdo->lastInsertId();
 
         // Create notifications for mentioned users if applicable
         if ($has_mentions && function_exists('create_mention_notifications')) {
@@ -101,7 +95,6 @@ function add_post($user_id, $user_name, $user_email, $title, $content, $post_typ
         return $post_id;
     }
 
-    $stmt->close();
     return false;
 }
 
@@ -114,13 +107,11 @@ function add_post($user_id, $user_name, $user_email, $title, $content, $post_typ
  */
 function update_post_status($post_id, $status)
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('UPDATE community_posts SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
-    $stmt->bind_param('si', $status, $post_id);
-    $result = $stmt->execute();
+    $stmt = $pdo->prepare('UPDATE community_posts SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+    $result = $stmt->execute([$status, $post_id]);
 
-    $stmt->close();
     return $result;
 }
 
@@ -132,22 +123,19 @@ function update_post_status($post_id, $status)
  */
 function get_post_comments($post_id)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Join with users table to get avatar
-    $stmt = $db->prepare('SELECT c.*, u.avatar FROM community_comments c 
+    $stmt = $pdo->prepare('SELECT c.*, u.avatar FROM community_comments c 
                          LEFT JOIN community_users u ON c.user_id = u.id 
                          WHERE c.post_id = ? ORDER BY c.created_at ASC');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt->execute([$post_id]);
 
     $comments = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $comments[] = $row;
     }
 
-    $stmt->close();
     return $comments;
 }
 
@@ -159,16 +147,13 @@ function get_post_comments($post_id)
  */
 function get_comment_count($post_id)
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('SELECT COUNT(*) as count FROM community_comments WHERE post_id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT COUNT(*) as count FROM community_comments WHERE post_id = ?');
+    $stmt->execute([$post_id]);
+    $row = $stmt->fetch();
     $count = $row['count'];
 
-    $stmt->close();
     return $count;
 }
 
@@ -184,7 +169,7 @@ function get_comment_count($post_id)
  */
 function add_comment($post_id, $user_name, $user_email, $content, $user_id = null)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Process @mentions if the mentions.php file exists
     $has_mentions = false;
@@ -198,12 +183,11 @@ function add_comment($post_id, $user_name, $user_email, $content, $user_id = nul
         $has_mentions = !empty($mentions);
     }
 
-    $stmt = $db->prepare('INSERT INTO community_comments (post_id, user_name, user_email, content, votes, user_id) 
+    $stmt = $pdo->prepare('INSERT INTO community_comments (post_id, user_name, user_email, content, votes, user_id) 
                          VALUES (?, ?, ?, ?, 0, ?)');
-    $stmt->bind_param('isssi', $post_id, $user_name, $user_email, $content, $user_id);
 
-    if ($stmt->execute()) {
-        $comment_id = $db->insert_id;
+    if ($stmt->execute([$post_id, $user_name, $user_email, $content, $user_id])) {
+        $comment_id = $pdo->lastInsertId();
 
         // Get the post data
         $post = get_post($post_id);
@@ -214,13 +198,9 @@ function add_comment($post_id, $user_name, $user_email, $content, $user_id = nul
         }
 
         // Get the new comment
-        $stmt = $db->prepare('SELECT * FROM community_comments WHERE id = ?');
-        $stmt->bind_param('i', $comment_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $new_comment = $result->fetch_assoc();
-
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT * FROM community_comments WHERE id = ?');
+        $stmt->execute([$comment_id]);
+        $new_comment = $stmt->fetch();
 
         // Send notification email
         send_notification_email('new_comment', [
@@ -242,7 +222,6 @@ function add_comment($post_id, $user_name, $user_email, $content, $user_id = nul
         return $new_comment;
     }
 
-    $stmt->close();
     return false;
 }
 
@@ -256,58 +235,48 @@ function add_comment($post_id, $user_name, $user_email, $content, $user_id = nul
  */
 function vote_post($post_id, $user_email, $vote_type)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Check if user has already voted
-    $stmt = $db->prepare('SELECT vote_type FROM community_votes WHERE post_id = ? AND user_email = ?');
-    $stmt->bind_param('is', $post_id, $user_email);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $existing_vote = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT vote_type FROM community_votes WHERE post_id = ? AND user_email = ?');
+    $stmt->execute([$post_id, $user_email]);
+    $existing_vote = $stmt->fetch();
 
     if ($existing_vote) {
         // User already voted, check if they're changing their vote
         if ($existing_vote['vote_type'] == $vote_type) {
             // Remove the vote (cancel)
-            $stmt = $db->prepare('DELETE FROM community_votes WHERE post_id = ? AND user_email = ?');
-            $stmt->bind_param('is', $post_id, $user_email);
-            $stmt->execute();
+            $stmt = $pdo->prepare('DELETE FROM community_votes WHERE post_id = ? AND user_email = ?');
+            $stmt->execute([$post_id, $user_email]);
 
             $user_vote = 0;
         } else {
             // Update the vote
-            $stmt = $db->prepare('UPDATE community_votes SET vote_type = ?, created_at = CURRENT_TIMESTAMP 
+            $stmt = $pdo->prepare('UPDATE community_votes SET vote_type = ?, created_at = CURRENT_TIMESTAMP 
                                  WHERE post_id = ? AND user_email = ?');
-            $stmt->bind_param('iis', $vote_type, $post_id, $user_email);
-            $stmt->execute();
+            $stmt->execute([$vote_type, $post_id, $user_email]);
 
             $user_vote = $vote_type;
         }
     } else {
         // Add new vote
-        $stmt = $db->prepare('INSERT INTO community_votes (post_id, user_email, vote_type) 
+        $stmt = $pdo->prepare('INSERT INTO community_votes (post_id, user_email, vote_type) 
                              VALUES (?, ?, ?)');
-        $stmt->bind_param('isi', $post_id, $user_email, $vote_type);
-        $stmt->execute();
+        $stmt->execute([$post_id, $user_email, $vote_type]);
 
         $user_vote = $vote_type;
     }
 
     // Update vote count in posts table
-    $stmt = $db->prepare('SELECT SUM(vote_type) as total_votes FROM community_votes WHERE post_id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT SUM(vote_type) as total_votes FROM community_votes WHERE post_id = ?');
+    $stmt->execute([$post_id]);
+    $row = $stmt->fetch();
 
     $total_votes = $row['total_votes'] ?? 0;
 
     // Update the post's vote count
-    $stmt = $db->prepare('UPDATE community_posts SET votes = ? WHERE id = ?');
-    $stmt->bind_param('ii', $total_votes, $post_id);
-    $stmt->execute();
-
-    $stmt->close();
+    $stmt = $pdo->prepare('UPDATE community_posts SET votes = ? WHERE id = ?');
+    $stmt->execute([$total_votes, $post_id]);
 
     return [
         'new_vote_count' => $total_votes,
@@ -324,16 +293,13 @@ function vote_post($post_id, $user_email, $vote_type)
  */
 function get_user_vote($post_id, $user_email)
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('SELECT vote_type FROM community_votes WHERE post_id = ? AND user_email = ?');
-    $stmt->bind_param('is', $post_id, $user_email);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT vote_type FROM community_votes WHERE post_id = ? AND user_email = ?');
+    $stmt->execute([$post_id, $user_email]);
+    $row = $stmt->fetch();
     $vote = $row ? $row['vote_type'] : 0;
 
-    $stmt->close();
     return $vote;
 }
 
@@ -347,58 +313,48 @@ function get_user_vote($post_id, $user_email)
  */
 function vote_comment($comment_id, $user_email, $vote_type)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Check if user has already voted
-    $stmt = $db->prepare('SELECT vote_type FROM comment_votes WHERE comment_id = ? AND user_email = ?');
-    $stmt->bind_param('is', $comment_id, $user_email);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $existing_vote = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT vote_type FROM comment_votes WHERE comment_id = ? AND user_email = ?');
+    $stmt->execute([$comment_id, $user_email]);
+    $existing_vote = $stmt->fetch();
 
     if ($existing_vote) {
         // User already voted, check if they're changing their vote
         if ($existing_vote['vote_type'] == $vote_type) {
             // Remove the vote (cancel)
-            $stmt = $db->prepare('DELETE FROM comment_votes WHERE comment_id = ? AND user_email = ?');
-            $stmt->bind_param('is', $comment_id, $user_email);
-            $stmt->execute();
+            $stmt = $pdo->prepare('DELETE FROM comment_votes WHERE comment_id = ? AND user_email = ?');
+            $stmt->execute([$comment_id, $user_email]);
 
             $user_vote = 0;
         } else {
             // Update the vote
-            $stmt = $db->prepare('UPDATE comment_votes SET vote_type = ?, created_at = CURRENT_TIMESTAMP 
+            $stmt = $pdo->prepare('UPDATE comment_votes SET vote_type = ?, created_at = CURRENT_TIMESTAMP 
                                  WHERE comment_id = ? AND user_email = ?');
-            $stmt->bind_param('iis', $vote_type, $comment_id, $user_email);
-            $stmt->execute();
+            $stmt->execute([$vote_type, $comment_id, $user_email]);
 
             $user_vote = $vote_type;
         }
     } else {
         // Add new vote
-        $stmt = $db->prepare('INSERT INTO comment_votes (comment_id, user_email, vote_type) 
+        $stmt = $pdo->prepare('INSERT INTO comment_votes (comment_id, user_email, vote_type) 
                              VALUES (?, ?, ?)');
-        $stmt->bind_param('isi', $comment_id, $user_email, $vote_type);
-        $stmt->execute();
+        $stmt->execute([$comment_id, $user_email, $vote_type]);
 
         $user_vote = $vote_type;
     }
 
     // Update vote count in comments table
-    $stmt = $db->prepare('SELECT SUM(vote_type) as total_votes FROM comment_votes WHERE comment_id = ?');
-    $stmt->bind_param('i', $comment_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT SUM(vote_type) as total_votes FROM comment_votes WHERE comment_id = ?');
+    $stmt->execute([$comment_id]);
+    $row = $stmt->fetch();
 
     $total_votes = $row['total_votes'] ?? 0;
 
     // Update the comment's vote count
-    $stmt = $db->prepare('UPDATE community_comments SET votes = ? WHERE id = ?');
-    $stmt->bind_param('ii', $total_votes, $comment_id);
-    $stmt->execute();
-
-    $stmt->close();
+    $stmt = $pdo->prepare('UPDATE community_comments SET votes = ? WHERE id = ?');
+    $stmt->execute([$total_votes, $comment_id]);
 
     return [
         'new_vote_count' => $total_votes,
@@ -415,16 +371,13 @@ function vote_comment($comment_id, $user_email, $vote_type)
  */
 function get_user_comment_vote($comment_id, $user_email)
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('SELECT vote_type FROM comment_votes WHERE comment_id = ? AND user_email = ?');
-    $stmt->bind_param('is', $comment_id, $user_email);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT vote_type FROM comment_votes WHERE comment_id = ? AND user_email = ?');
+    $stmt->execute([$comment_id, $user_email]);
+    $row = $stmt->fetch();
     $vote = $row ? $row['vote_type'] : 0;
 
-    $stmt->close();
     return $vote;
 }
 

--- a/community/create_post.php
+++ b/community/create_post.php
@@ -126,20 +126,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             if ($post_id) {
                 // Connect post to user account
-                $db = get_db_connection();
-                $stmt = $db->prepare('UPDATE community_posts SET user_id = ? WHERE id = ?');
-                $stmt->bind_param('ii', $current_user['id'], $post_id);
-                $stmt->execute();
+                $stmt = $pdo->prepare('UPDATE community_posts SET user_id = ? WHERE id = ?');
+                $stmt->execute([$current_user['id'], $post_id]);
 
                 // Save bug metadata as JSON in a separate field or table if needed
                 if ($post_type === 'bug' && !empty($bug_metadata)) {
                     $metadata_json = json_encode($bug_metadata);
-                    $stmt = $db->prepare('UPDATE community_posts SET metadata = ? WHERE id = ?');
-                    $stmt->bind_param('si', $metadata_json, $post_id);
-                    $stmt->execute();
+                    $stmt = $pdo->prepare('UPDATE community_posts SET metadata = ? WHERE id = ?');
+                    $stmt->execute([$metadata_json, $post_id]);
                 }
-
-                $stmt->close();
 
                 if ($is_ajax) {
                     // Return JSON success response for AJAX

--- a/community/delete_comment.php
+++ b/community/delete_comment.php
@@ -45,16 +45,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $role = $_SESSION['role'] ?? 'user';
 
     // Get the comment to verify ownership
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT * FROM community_comments WHERE id = ?');
-    $stmt->bind_param('i', $comment_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $comment = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT * FROM community_comments WHERE id = ?');
+    $stmt->execute([$comment_id]);
+    $comment = $stmt->fetch();
 
     if (!$comment) {
         $response['message'] = 'Comment not found';
-        $stmt->close();
         echo json_encode($response);
         exit;
     }
@@ -65,27 +61,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!$can_delete) {
         $response['message'] = 'You do not have permission to delete this comment';
-        $stmt->close();
         echo json_encode($response);
         exit;
     }
 
     // Delete the comment
-    $stmt = $db->prepare('DELETE FROM community_comments WHERE id = ?');
-    $stmt->bind_param('i', $comment_id);
+    $stmt = $pdo->prepare('DELETE FROM community_comments WHERE id = ?');
 
-    if ($stmt->execute()) {
+    try {
+        $stmt->execute([$comment_id]);
         $response = [
             'success' => true,
             'message' => 'Comment deleted successfully',
             'post_id' => $comment['post_id']
         ];
-    } else {
-        error_log('Error deleting comment ' . $comment_id . ': ' . $db->error);
+    } catch (PDOException $e) {
+        error_log('Error deleting comment ' . $comment_id . ': ' . $e->getMessage());
         $response['message'] = 'Error deleting comment. Please try again.';
     }
-
-    $stmt->close();
 } else {
     $response['message'] = 'Invalid request method';
 }

--- a/community/delete_post.php
+++ b/community/delete_post.php
@@ -45,16 +45,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $role = $_SESSION['role'] ?? 'user';
 
     // Get the post to verify ownership
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT * FROM community_posts WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $post = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT * FROM community_posts WHERE id = ?');
+    $stmt->execute([$post_id]);
+    $post = $stmt->fetch();
 
     if (!$post) {
         $response['message'] = 'Post not found';
-        $stmt->close();
         echo json_encode($response);
         exit;
     }
@@ -65,26 +61,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!$can_delete) {
         $response['message'] = 'You do not have permission to delete this post.';
-        $stmt->close();
         echo json_encode($response);
         exit;
     }
 
     // Delete the post
-    $stmt = $db->prepare('DELETE FROM community_posts WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
+    $stmt = $pdo->prepare('DELETE FROM community_posts WHERE id = ?');
 
-    if ($stmt->execute()) {
+    try {
+        $stmt->execute([$post_id]);
         $response = [
             'success' => true,
             'message' => 'Post deleted successfully'
         ];
-    } else {
-        error_log('Error deleting post ' . $post_id . ': ' . $db->error);
+    } catch (PDOException $e) {
+        error_log('Error deleting post ' . $post_id . ': ' . $e->getMessage());
         $response['message'] = 'Error deleting post. Please try again.';
     }
-
-    $stmt->close();
 } else {
     $response['message'] = 'Invalid request method';
 }

--- a/community/edit_comment.php
+++ b/community/edit_comment.php
@@ -64,16 +64,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $role = $_SESSION['role'] ?? 'user';
 
     // Get the comment to verify ownership
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT * FROM community_comments WHERE id = ?');
-    $stmt->bind_param('i', $comment_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $comment = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT * FROM community_comments WHERE id = ?');
+    $stmt->execute([$comment_id]);
+    $comment = $stmt->fetch();
 
     if (!$comment) {
         $response['message'] = 'Comment not found';
-        $stmt->close();
         echo json_encode($response);
         exit;
     }
@@ -93,17 +89,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         // Update the comment with new content
-        $stmt = $db->prepare('UPDATE community_comments SET content = ? WHERE id = ?');
-        $stmt->bind_param('si', $comment_content, $comment_id);
+        $stmt = $pdo->prepare('UPDATE community_comments SET content = ? WHERE id = ?');
 
-        if ($stmt->execute()) {
+        try {
+            $stmt->execute([$comment_content, $comment_id]);
             // Get the updated comment
-            $stmt->close();
-            $stmt = $db->prepare('SELECT * FROM community_comments WHERE id = ?');
-            $stmt->bind_param('i', $comment_id);
-            $stmt->execute();
-            $result = $stmt->get_result();
-            $updated_comment = $result->fetch_assoc();
+            $stmt = $pdo->prepare('SELECT * FROM community_comments WHERE id = ?');
+            $stmt->execute([$comment_id]);
+            $updated_comment = $stmt->fetch();
 
             // Process the comment content using the proper mentions function
             $updated_comment['processed_content'] = process_mentions(htmlspecialchars($updated_comment['content']));
@@ -113,15 +106,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'message' => 'Comment updated successfully',
                 'comment' => $updated_comment
             ];
-        } else {
-            error_log('Error updating comment ' . $comment_id . ': ' . $db->error);
+        } catch (PDOException $e) {
+            error_log('Error updating comment ' . $comment_id . ': ' . $e->getMessage());
             $response['message'] = 'Error updating comment. Please try again.';
         }
     } else {
         $response['message'] = 'You do not have permission to edit this comment.';
     }
-
-    $stmt->close();
 }
 
 // Send the response

--- a/community/edit_post.php
+++ b/community/edit_post.php
@@ -62,25 +62,21 @@ if (!$can_edit_post) {
 
 // Check for metadata
 $metadata = [];
-$db = get_db_connection();
 
 // Check if metadata column exists
 $metadata_exists = false;
-$result = $db->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
-$metadata_exists = ($result->num_rows > 0);
+$result = $pdo->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
+$metadata_exists = ($result->fetch() !== false);
 
 if ($metadata_exists) {
     // Get metadata if it exists
-    $stmt = $db->prepare('SELECT metadata FROM community_posts WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT metadata FROM community_posts WHERE id = ?');
+    $stmt->execute([$post_id]);
+    $row = $stmt->fetch();
 
     if ($row && !empty($row['metadata'])) {
         $metadata = json_decode($row['metadata'], true);
     }
-    $stmt->close();
 }
 
 // Generate CSRF token if not present
@@ -136,8 +132,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (strlen($content) > 10000) {
         $error_message = 'Content is too long (maximum 10,000 characters)';
     } else {
-        $db = get_db_connection();
-
         // Check if anything actually changed before saving to history
         $has_changes = false;
 
@@ -149,11 +143,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Check if metadata changed (for bug reports)
         if ($post_type === 'bug' && $metadata_exists) {
             $current_metadata = null;
-            $stmt = $db->prepare('SELECT metadata FROM community_posts WHERE id = ?');
-            $stmt->bind_param('i', $post_id);
-            $stmt->execute();
-            $result = $stmt->get_result();
-            $row = $result->fetch_assoc();
+            $stmt = $pdo->prepare('SELECT metadata FROM community_posts WHERE id = ?');
+            $stmt->execute([$post_id]);
+            $row = $stmt->fetch();
 
             if ($row && !empty($row['metadata'])) {
                 $current_metadata = json_decode($row['metadata'], true);
@@ -169,49 +161,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // If no previous metadata but new metadata has values
                 $has_changes = true;
             }
-            $stmt->close();
         }
 
         // Only proceed if there are actual changes
         if ($has_changes) {
-            $result = $db->query("SHOW COLUMNS FROM post_edit_history LIKE 'metadata'");
+            $result = $pdo->query("SHOW COLUMNS FROM post_edit_history LIKE 'metadata'");
 
             // Get the current metadata for history
             $previous_metadata = null;
             if ($metadata_exists) {
-                $stmt = $db->prepare('SELECT metadata FROM community_posts WHERE id = ?');
-                $stmt->bind_param('i', $post_id);
-                $stmt->execute();
-                $result = $stmt->get_result();
-                $row = $result->fetch_assoc();
+                $stmt = $pdo->prepare('SELECT metadata FROM community_posts WHERE id = ?');
+                $stmt->execute([$post_id]);
+                $row = $stmt->fetch();
                 if ($row && isset($row['metadata'])) {
                     $previous_metadata = $row['metadata'];
                 }
-                $stmt->close();
             }
 
             // Save the current post to history
-            $stmt = $db->prepare('INSERT INTO post_edit_history (post_id, user_id, title, content, metadata, edited_at) 
+            $stmt = $pdo->prepare('INSERT INTO post_edit_history (post_id, user_id, title, content, metadata, edited_at) 
                                 VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)');
-            $stmt->bind_param('iisss', $post_id, $user_id, $post['title'], $post['content'], $previous_metadata);
-            $stmt->execute();
-            $stmt->close();
+            $stmt->execute([$post_id, $user_id, $post['title'], $post['content'], $previous_metadata]);
 
             // Update the post
-            $stmt = $db->prepare('UPDATE community_posts 
+            $stmt = $pdo->prepare('UPDATE community_posts 
                                 SET title = ?, content = ?, post_type = ?, updated_at = CURRENT_TIMESTAMP 
                                 WHERE id = ?');
-            $stmt->bind_param('sssi', $title, $content, $post_type, $post_id);
-            $update_success = $stmt->execute();
-            $stmt->close();
+            $update_success = $stmt->execute([$title, $content, $post_type, $post_id]);
 
             // Save bug metadata if applicable
             if ($post_type === 'bug' && !empty($bug_metadata) && $metadata_exists) {
                 $metadata_json = json_encode($bug_metadata);
-                $stmt = $db->prepare('UPDATE community_posts SET metadata = ? WHERE id = ?');
-                $stmt->bind_param('si', $metadata_json, $post_id);
-                $stmt->execute();
-                $stmt->close();
+                $stmt = $pdo->prepare('UPDATE community_posts SET metadata = ? WHERE id = ?');
+                $stmt->execute([$metadata_json, $post_id]);
             }
 
             if ($update_success) {

--- a/community/mentions/mentions.php
+++ b/community/mentions/mentions.php
@@ -59,19 +59,15 @@ function extract_mentions($content)
  */
 function get_user_id_by_username($username)
 {
-    $db = get_db_connection();
+    global $pdo;
 
-    $stmt = $db->prepare('SELECT id FROM community_users WHERE username = ? LIMIT 1');
-    $stmt->bind_param('s', $username);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare('SELECT id FROM community_users WHERE username = ? LIMIT 1');
+    $stmt->execute([$username]);
 
-    if ($row = $result->fetch_assoc()) {
-        $stmt->close();
+    if ($row = $stmt->fetch()) {
         return $row['id'];
     }
 
-    $stmt->close();
     return null;
 }
 
@@ -90,11 +86,11 @@ function create_mention_notifications($mentions, $post_id, $comment_id = 0, $aut
         return;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Check if notifications table exists, if not, create it
-    $result = $db->query("SHOW TABLES LIKE 'user_notifications'");
-    if ($result->num_rows == 0) {
+    $result = $pdo->query("SHOW TABLES LIKE 'user_notifications'");
+    if ($result->fetch() === false) {
         // Create notifications table
         $sql = "CREATE TABLE IF NOT EXISTS user_notifications (
             id INT PRIMARY KEY AUTO_INCREMENT,
@@ -107,11 +103,11 @@ function create_mention_notifications($mentions, $post_id, $comment_id = 0, $aut
             FOREIGN KEY (user_id) REFERENCES community_users(id) ON DELETE CASCADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
-        $db->query($sql);
+        $pdo->query($sql);
     }
 
     // Insert notifications for each mentioned user
-    $insert_stmt = $db->prepare("
+    $insert_stmt = $pdo->prepare("
         INSERT INTO user_notifications (user_id, type, message, link, is_read)
         VALUES (?, 'mention', ?, ?, 0)
     ");
@@ -127,16 +123,12 @@ function create_mention_notifications($mentions, $post_id, $comment_id = 0, $aut
         // Get author username
         $author_name = 'Someone';
         if ($author_id) {
-            $author_stmt = $db->prepare('SELECT username FROM community_users WHERE id = ? LIMIT 1');
-            $author_stmt->bind_param('i', $author_id);
-            $author_stmt->execute();
-            $author_result = $author_stmt->get_result();
+            $author_stmt = $pdo->prepare('SELECT username FROM community_users WHERE id = ? LIMIT 1');
+            $author_stmt->execute([$author_id]);
 
-            if ($author_row = $author_result->fetch_assoc()) {
+            if ($author_row = $author_stmt->fetch()) {
                 $author_name = $author_row['username'];
             }
-
-            $author_stmt->close();
         }
 
         // Create notification message and link
@@ -149,9 +141,6 @@ function create_mention_notifications($mentions, $post_id, $comment_id = 0, $aut
         }
 
         // Insert notification
-        $insert_stmt->bind_param('iss', $user_id, $message, $link);
-        $insert_stmt->execute();
+        $insert_stmt->execute([$user_id, $message, $link]);
     }
-
-    $insert_stmt->close();
 }

--- a/community/mentions/search.php
+++ b/community/mentions/search.php
@@ -26,8 +26,7 @@ try {
     $current_user_id = $_SESSION['user_id']; // Get current user ID to exclude from results
 
     // Connect to the database
-    $db = get_db_connection();
-    if (!$db) {
+    if (!$pdo) {
         throw new Exception('Database connection failed');
     }
 
@@ -42,21 +41,13 @@ try {
             ORDER BY c.created_at DESC
         ";
 
-        $stmt = $db->prepare($sql_commenters);
-        if (!$stmt) {
-            throw new Exception('Prepare failed: ' . $db->error);
-        }
+        $stmt = $pdo->prepare($sql_commenters);
 
-        $stmt->bind_param('ii', $post_id, $current_user_id);
-        if (!$stmt->execute()) {
-            throw new Exception('Execute failed: ' . $stmt->error);
-        }
+        $stmt->execute([$post_id, $current_user_id]);
 
-        $result = $stmt->get_result();
-        while ($row = $result->fetch_assoc()) {
+        while ($row = $stmt->fetch()) {
             $commenters[$row['id']] = $row;
         }
-        $stmt->close();
 
         // Get the post author if not already in commenters (and not current user)
         $sql_author = "
@@ -66,23 +57,15 @@ try {
             WHERE p.id = ? AND u.id != ?
         ";
 
-        $stmt = $db->prepare($sql_author);
-        if (!$stmt) {
-            throw new Exception('Prepare failed: ' . $db->error);
-        }
+        $stmt = $pdo->prepare($sql_author);
 
-        $stmt->bind_param('ii', $post_id, $current_user_id);
-        if (!$stmt->execute()) {
-            throw new Exception('Execute failed: ' . $stmt->error);
-        }
+        $stmt->execute([$post_id, $current_user_id]);
 
-        $result = $stmt->get_result();
-        if ($author = $result->fetch_assoc()) {
+        if ($author = $stmt->fetch()) {
             if (!isset($commenters[$author['id']])) {
                 $commenters[$author['id']] = $author;
             }
         }
-        $stmt->close();
     }
 
     // If query is empty (just '@'), show only commenters and post author
@@ -107,21 +90,13 @@ try {
         LIMIT 10
     ";
 
-    $stmt = $db->prepare($sql_exact_start);
-    if (!$stmt) {
-        throw new Exception('Prepare failed: ' . $db->error);
-    }
+    $stmt = $pdo->prepare($sql_exact_start);
 
-    $stmt->bind_param('si', $search_exact_start, $current_user_id);
-    if (!$stmt->execute()) {
-        throw new Exception('Execute failed: ' . $stmt->error);
-    }
+    $stmt->execute([$search_exact_start, $current_user_id]);
 
-    $result = $stmt->get_result();
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $users[$row['id']] = $row;
     }
-    $stmt->close();
 
     // Then, if we have fewer than 10 results, get partial matches anywhere in the username (excluding current user)
     if (count($users) < 10) {
@@ -135,32 +110,23 @@ try {
             ORDER BY username ASC
             LIMIT ?";
 
-        $stmt = $db->prepare($sql_anywhere);
-        if (!$stmt) {
-            error_log('Mentions search prepare failed: ' . $db->error);
-            throw new Exception('Prepare failed');
-        }
+        $stmt = $pdo->prepare($sql_anywhere);
 
-        $types = 's' . str_repeat('i', count($exclude_ids)) . 'ii';
         $params = array_merge([$search_anywhere], $exclude_ids, [$current_user_id, $remaining]);
-        // mysqli bind_param requires pass-by-reference; use call_user_func_array
-        $bindParams = [];
-        $bindParams[] = &$types;
-        foreach ($params as $key => $value) {
-            $bindParams[] = &$params[$key];
+        // Bind parameters with explicit types so LIMIT receives an INT
+        $index = 1;
+        $stmt->bindValue($index++, $search_anywhere, PDO::PARAM_STR);
+        foreach ($exclude_ids as $exclude_id) {
+            $stmt->bindValue($index++, $exclude_id, PDO::PARAM_INT);
         }
-        if (!call_user_func_array([$stmt, 'bind_param'], $bindParams)) {
-            throw new Exception('Bind failed');
-        }
-        if (!$stmt->execute()) {
-            throw new Exception('Execute failed');
-        }
+        $stmt->bindValue($index++, $current_user_id, PDO::PARAM_INT);
+        $stmt->bindValue($index++, $remaining, PDO::PARAM_INT);
 
-        $result = $stmt->get_result();
-        while ($row = $result->fetch_assoc()) {
+        $stmt->execute();
+
+        while ($row = $stmt->fetch()) {
             $users[$row['id']] = $row;
         }
-        $stmt->close();
     }
 
     // Combine results, giving priority to commenters and the post author (all already exclude current user)

--- a/community/post_history.php
+++ b/community/post_history.php
@@ -30,44 +30,35 @@ if (!$post) {
 }
 
 // Check if metadata column exists in post_edit_history
-$db = get_db_connection();
-$result = $db->query("SHOW COLUMNS FROM post_edit_history LIKE 'metadata'");
+$pdo->query("SHOW COLUMNS FROM post_edit_history LIKE 'metadata'");
 
 // Fetch the current post metadata
 $current_metadata = null;
-$metadata_exists = false;
-$result = $db->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
-$metadata_exists = ($result->num_rows > 0);
+$result = $pdo->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
+$metadata_exists = ($result->fetch() !== false);
 
 if ($metadata_exists) {
-    $stmt = $db->prepare('SELECT metadata FROM community_posts WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT metadata FROM community_posts WHERE id = ?');
+    $stmt->execute([$post_id]);
+    $row = $stmt->fetch();
 
     if ($row && !empty($row['metadata'])) {
         $current_metadata = $row['metadata'];
     }
-    $stmt->close();
 }
 
 // Fetch edit history ordered by newest first
-$stmt = $db->prepare('SELECT h.*, u.username 
+$stmt = $pdo->prepare('SELECT h.*, u.username
     FROM post_edit_history h
     LEFT JOIN community_users u ON h.user_id = u.id
     WHERE h.post_id = ?
     ORDER BY h.edited_at DESC');
-$stmt->bind_param('i', $post_id);
-$stmt->execute();
-$result = $stmt->get_result();
+$stmt->execute([$post_id]);
 
 $history = [];
-while ($row = $result->fetch_assoc()) {
+while ($row = $stmt->fetch()) {
     $history[] = $row;
 }
-
-$stmt->close();
 
 // The current version is not in the edit history, so add it as the most current version
 $current_post = [

--- a/community/preview_handler.php
+++ b/community/preview_handler.php
@@ -47,13 +47,9 @@ $bug_actual = isset($_POST['bug_actual']) ? trim($_POST['bug_actual']) : '';
 // Get current user info
 $current_user = null;
 if (isset($_SESSION['user_id'])) {
-    $db = get_db_connection();
-    $stmt = $db->prepare('SELECT username, email, avatar FROM community_users WHERE id = ?');
-    $stmt->bind_param('i', $_SESSION['user_id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $current_user = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT username, email, avatar FROM community_users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch() ?: null;
 }
 
 // Default user info if not logged in

--- a/community/rate_limit.php
+++ b/community/rate_limit.php
@@ -29,7 +29,7 @@ function check_rate_limit($user_id, $action_type)
         return false;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Check if rate limit is defined for this action type
     if (!isset($RATE_LIMITS[$action_type])) {
@@ -41,20 +41,15 @@ function check_rate_limit($user_id, $action_type)
     $long_limit  = $RATE_LIMITS[$action_type]['long'];
 
     // Retrieve existing rate limit row
-    $stmt = $db->prepare('SELECT count, period_start, last_action_at FROM rate_limits WHERE user_id = ? AND action_type = ?');
-    $stmt->bind_param('is', $user_id, $action_type);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row    = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT count, period_start, last_action_at FROM rate_limits WHERE user_id = ? AND action_type = ?');
+    $stmt->execute([$user_id, $action_type]);
+    $row = $stmt->fetch();
 
     if ($row) {
         // Reset count if the long-term window has passed
         if (strtotime($row['period_start']) <= $now - ($long_limit['hours'] * 3600)) {
-            $stmt = $db->prepare('UPDATE rate_limits SET count = 0, period_start = CURRENT_TIMESTAMP WHERE user_id = ? AND action_type = ?');
-            $stmt->bind_param('is', $user_id, $action_type);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('UPDATE rate_limits SET count = 0, period_start = CURRENT_TIMESTAMP WHERE user_id = ? AND action_type = ?');
+            $stmt->execute([$user_id, $action_type]);
 
             $row['count']        = 0;
             $row['period_start'] = date('Y-m-d H:i:s', $now);
@@ -79,16 +74,12 @@ function check_rate_limit($user_id, $action_type)
     // Record this action
     if ($row) {
         // Update existing record
-        $stmt = $db->prepare('UPDATE rate_limits SET count = count + 1, last_action_at = CURRENT_TIMESTAMP WHERE user_id = ? AND action_type = ?');
-        $stmt->bind_param('is', $user_id, $action_type);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE rate_limits SET count = count + 1, last_action_at = CURRENT_TIMESTAMP WHERE user_id = ? AND action_type = ?');
+        $stmt->execute([$user_id, $action_type]);
     } else {
         // Insert new record
-        $stmt = $db->prepare('INSERT INTO rate_limits (user_id, action_type, count, period_start, last_action_at) VALUES (?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)');
-        $stmt->bind_param('is', $user_id, $action_type);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('INSERT INTO rate_limits (user_id, action_type, count, period_start, last_action_at) VALUES (?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)');
+        $stmt->execute([$user_id, $action_type]);
     }
 
     return false;

--- a/community/report/ban_check.php
+++ b/community/report/ban_check.php
@@ -7,10 +7,10 @@
  */
 function is_user_banned($user_id)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Check for active ban that hasn't expired
-    $stmt = $db->prepare('
+    $stmt = $pdo->prepare('
         SELECT id, ban_reason, ban_duration, banned_at, expires_at
         FROM user_bans
         WHERE user_id = ?
@@ -20,11 +20,8 @@ function is_user_banned($user_id)
         LIMIT 1
     ');
 
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $ban = $result->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$user_id]);
+    $ban = $stmt->fetch() ?: null;
 
     return $ban;
 }

--- a/community/report/report_content.php
+++ b/community/report/report_content.php
@@ -53,20 +53,15 @@ if (!in_array($violation_type, $valid_violations)) {
 }
 
 try {
-    $db = get_db_connection();
-
     // Get reporter info
     $reporter_user_id = $_SESSION['user_id'];
     $reporter_email = $_SESSION['email'];
 
     // Verify content exists
     if ($content_type === 'post') {
-        $stmt = $db->prepare('SELECT id, user_id FROM community_posts WHERE id = ?');
-        $stmt->bind_param('i', $content_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $content = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id, user_id FROM community_posts WHERE id = ?');
+        $stmt->execute([$content_id]);
+        $content = $stmt->fetch();
 
         if (!$content) {
             echo json_encode(['success' => false, 'message' => 'Post not found.']);
@@ -79,12 +74,9 @@ try {
             exit;
         }
     } elseif ($content_type === 'comment') {
-        $stmt = $db->prepare('SELECT id, user_id FROM community_comments WHERE id = ?');
-        $stmt->bind_param('i', $content_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $content = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id, user_id FROM community_comments WHERE id = ?');
+        $stmt->execute([$content_id]);
+        $content = $stmt->fetch();
 
         if (!$content) {
             echo json_encode(['success' => false, 'message' => 'Comment not found.']);
@@ -98,12 +90,9 @@ try {
         }
     } else {
         // User report
-        $stmt = $db->prepare('SELECT id, username FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $content_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $content = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id, username FROM community_users WHERE id = ?');
+        $stmt->execute([$content_id]);
+        $content = $stmt->fetch();
 
         if (!$content) {
             echo json_encode(['success' => false, 'message' => 'User not found.']);
@@ -118,12 +107,9 @@ try {
     }
 
     // Check if user has already reported this content
-    $stmt = $db->prepare('SELECT id FROM content_reports WHERE reporter_user_id = ? AND content_type = ? AND content_id = ? AND status = "pending"');
-    $stmt->bind_param('isi', $reporter_user_id, $content_type, $content_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $existing_report = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT id FROM content_reports WHERE reporter_user_id = ? AND content_type = ? AND content_id = ? AND status = "pending"');
+    $stmt->execute([$reporter_user_id, $content_type, $content_id]);
+    $existing_report = $stmt->fetch();
 
     if ($existing_report) {
         echo json_encode(['success' => false, 'message' => 'You have already reported this content.']);
@@ -131,35 +117,30 @@ try {
     }
 
     // Insert report
-    $stmt = $db->prepare('INSERT INTO content_reports (reporter_user_id, reporter_email, content_type, content_id, violation_type, additional_info) VALUES (?, ?, ?, ?, ?, ?)');
-    $stmt->bind_param('ississ', $reporter_user_id, $reporter_email, $content_type, $content_id, $violation_type, $additional_info);
+    $stmt = $pdo->prepare('INSERT INTO content_reports (reporter_user_id, reporter_email, content_type, content_id, violation_type, additional_info) VALUES (?, ?, ?, ?, ?, ?)');
 
-    if ($stmt->execute()) {
-        $report_id = $stmt->insert_id;
-        $stmt->close();
+    if ($stmt->execute([$reporter_user_id, $reporter_email, $content_type, $content_id, $violation_type, $additional_info])) {
+        $report_id = $pdo->lastInsertId();
 
         error_log("Report created with ID: " . $report_id);
 
         // Send notification to admins who have opted in
-        $stmt = $db->prepare('
+        $stmt = $pdo->prepare('
             SELECT ans.notification_email, cu.username as admin_username
             FROM admin_notification_settings ans
             JOIN community_users cu ON ans.user_id = cu.id
             WHERE cu.role = "admin" AND ans.notify_new_reports = 1
         ');
         $stmt->execute();
-        $result = $stmt->get_result();
+        $admins = $stmt->fetchAll();
 
-        error_log("Found " . $result->num_rows . " admins with notifications enabled");
+        error_log("Found " . count($admins) . " admins with notifications enabled");
 
         // Get reporter username
-        $stmt2 = $db->prepare('SELECT username FROM community_users WHERE id = ?');
-        $stmt2->bind_param('i', $reporter_user_id);
-        $stmt2->execute();
-        $reporter_result = $stmt2->get_result();
-        $reporter = $reporter_result->fetch_assoc();
+        $stmt2 = $pdo->prepare('SELECT username FROM community_users WHERE id = ?');
+        $stmt2->execute([$reporter_user_id]);
+        $reporter = $stmt2->fetch();
         $reporter_username = $reporter ? $reporter['username'] : $reporter_email;
-        $stmt2->close();
 
         error_log("Reporter username: " . $reporter_username);
 
@@ -168,26 +149,20 @@ try {
         if ($content_type === 'user') {
             $reported_username = $content['username'] ?? 'Unknown';
         } elseif ($content_type === 'post' && isset($content['user_id'])) {
-            $stmt3 = $db->prepare('SELECT username FROM community_users WHERE id = ?');
-            $stmt3->bind_param('i', $content['user_id']);
-            $stmt3->execute();
-            $user_result = $stmt3->get_result();
-            $user_data = $user_result->fetch_assoc();
+            $stmt3 = $pdo->prepare('SELECT username FROM community_users WHERE id = ?');
+            $stmt3->execute([$content['user_id']]);
+            $user_data = $stmt3->fetch();
             $reported_username = $user_data ? $user_data['username'] : 'Unknown';
-            $stmt3->close();
         } elseif ($content_type === 'comment' && isset($content['user_id'])) {
-            $stmt3 = $db->prepare('SELECT username FROM community_users WHERE id = ?');
-            $stmt3->bind_param('i', $content['user_id']);
-            $stmt3->execute();
-            $user_result = $stmt3->get_result();
-            $user_data = $user_result->fetch_assoc();
+            $stmt3 = $pdo->prepare('SELECT username FROM community_users WHERE id = ?');
+            $stmt3->execute([$content['user_id']]);
+            $user_data = $stmt3->fetch();
             $reported_username = $user_data ? $user_data['username'] : 'Unknown';
-            $stmt3->close();
         }
 
         error_log("Reported username: " . $reported_username);
 
-        while ($admin = $result->fetch_assoc()) {
+        foreach ($admins as $admin) {
             error_log("Sending notification to: " . $admin['notification_email'] . " (admin: " . $admin['admin_username'] . ")");
             $mail_result = send_new_report_notification(
                 $admin['notification_email'],
@@ -199,11 +174,9 @@ try {
             );
             error_log("Mail result for " . $admin['notification_email'] . ": " . ($mail_result ? "success" : "failure"));
         }
-        $stmt->close();
 
         echo json_encode(['success' => true, 'message' => 'Report submitted successfully.']);
     } else {
-        $stmt->close();
         echo json_encode(['success' => false, 'message' => 'Failed to submit report. Please try again.']);
     }
 

--- a/community/users/admin_notification_settings.php
+++ b/community/users/admin_notification_settings.php
@@ -14,14 +14,10 @@ $user_id = $_SESSION['user_id'];
 $success_message = '';
 $error_message = '';
 
-$db = get_db_connection();
-
 // Load current notification settings
-$stmt = $db->prepare('SELECT * FROM admin_notification_settings WHERE user_id = ?');
-$stmt->bind_param('i', $user_id);
-$stmt->execute();
-$result = $stmt->get_result();
-$settings = $result->fetch_assoc();
+$stmt = $pdo->prepare('SELECT * FROM admin_notification_settings WHERE user_id = ?');
+$stmt->execute([$user_id]);
+$settings = $stmt->fetch();
 
 // If no settings exist, create default ones
 if (!$settings) {
@@ -33,11 +29,10 @@ if (!$settings) {
     ];
 
     // Create settings row
-    $stmt = $db->prepare('INSERT INTO admin_notification_settings
+    $stmt = $pdo->prepare('INSERT INTO admin_notification_settings
                          (user_id, notify_new_posts, notify_new_comments, notify_new_reports, notification_email)
                          VALUES (?, ?, ?, ?, ?)');
-    $stmt->bind_param('iiiis', $user_id, $settings['notify_new_posts'], $settings['notify_new_comments'], $settings['notify_new_reports'], $settings['notification_email']);
-    $stmt->execute();
+    $stmt->execute([$user_id, $settings['notify_new_posts'], $settings['notify_new_comments'], $settings['notify_new_reports'], $settings['notification_email']]);
 }
 
 // Process form submission
@@ -53,29 +48,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error_message = 'Please enter a valid email address';
     } else {
         // Update settings
-        $stmt = $db->prepare('UPDATE admin_notification_settings
+        $stmt = $pdo->prepare('UPDATE admin_notification_settings
                              SET notify_new_posts = ?,
                                  notify_new_comments = ?,
                                  notify_new_reports = ?,
                                  notification_email = ?,
                                  updated_at = CURRENT_TIMESTAMP
                              WHERE user_id = ?');
-        $stmt->bind_param('iiisi', $notify_new_posts, $notify_new_comments, $notify_new_reports, $notification_email, $user_id);
 
-        if ($stmt->execute()) {
+        try {
+            $stmt->execute([$notify_new_posts, $notify_new_comments, $notify_new_reports, $notification_email, $user_id]);
             $success_message = 'Notification settings updated successfully.';
             // Update settings array to reflect changes
             $settings['notify_new_posts'] = $notify_new_posts;
             $settings['notify_new_comments'] = $notify_new_comments;
             $settings['notify_new_reports'] = $notify_new_reports;
             $settings['notification_email'] = $notification_email;
-        } else {
-            $error_message = 'Error updating notification settings: ' . $db->error;
+        } catch (PDOException $e) {
+            $error_message = 'Error updating notification settings: ' . $e->getMessage();
         }
     }
 }
-
-$stmt->close();
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/community/users/admin_notification_settings.php
+++ b/community/users/admin_notification_settings.php
@@ -65,7 +65,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $settings['notify_new_reports'] = $notify_new_reports;
             $settings['notification_email'] = $notification_email;
         } catch (PDOException $e) {
-            $error_message = 'Error updating notification settings: ' . $e->getMessage();
+            error_log('admin_notification_settings update failed: ' . $e->getMessage());
+            $error_message = 'Failed to update notification settings. Please try again.';
         }
     }
 }

--- a/community/users/delete_account.php
+++ b/community/users/delete_account.php
@@ -30,16 +30,12 @@ if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || !hash_equ
 }
 
 $user_id = $_SESSION['user_id'];
-$db = get_db_connection();
 
 try {
     // Get user information before scheduling deletion
-    $stmt = $db->prepare('SELECT username, email FROM community_users WHERE id = ?');
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $user = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT username, email FROM community_users WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $user = $stmt->fetch();
 
     if (!$user) {
         $response['message'] = 'User not found';
@@ -48,10 +44,8 @@ try {
     }
 
     $scheduledDate = date('Y-m-d H:i:s', strtotime('+30 days'));
-    $stmt = $db->prepare('UPDATE community_users SET deletion_scheduled_at = ? WHERE id = ?');
-    $stmt->bind_param('si', $scheduledDate, $user_id);
-    $stmt->execute();
-    $stmt->close();
+    $stmt = $pdo->prepare('UPDATE community_users SET deletion_scheduled_at = ? WHERE id = ?');
+    $stmt->execute([$scheduledDate, $user_id]);
 
     // Send account deletion scheduled email
     $email_sent = send_account_deletion_scheduled_email($user['email'], $user['username'], $scheduledDate);

--- a/community/users/edit_profile.php
+++ b/community/users/edit_profile.php
@@ -98,41 +98,31 @@ function handle_profile_update()
         exit;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Check if username is taken by someone else
     if ($username !== $user['username']) {
-        $stmt = $db->prepare('SELECT id FROM community_users WHERE username = ? AND id != ?');
-        $stmt->bind_param('si', $username, $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        if ($result->fetch_assoc()) {
-            $stmt->close();
+        $stmt = $pdo->prepare('SELECT id FROM community_users WHERE username = ? AND id != ?');
+        $stmt->execute([$username, $user_id]);
+        if ($stmt->fetch()) {
             $_SESSION['profile_error'] = 'Username is already taken';
             header('Location: edit_profile.php');
             exit;
         }
-        $stmt->close();
     }
 
     // Update user profile
-    $stmt = $db->prepare('UPDATE community_users SET username = ?, bio = ? WHERE id = ?');
-    $stmt->bind_param('ssi', $username, $bio, $user_id);
+    $stmt = $pdo->prepare('UPDATE community_users SET username = ?, bio = ? WHERE id = ?');
 
-    if ($stmt->execute()) {
-        $stmt->close();
+    if ($stmt->execute([$username, $bio, $user_id])) {
 
         // Update username across all posts and comments if changed
         if ($username !== $user['username']) {
-            $stmt = $db->prepare('UPDATE community_posts SET user_name = ? WHERE user_id = ?');
-            $stmt->bind_param('si', $username, $user_id);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('UPDATE community_posts SET user_name = ? WHERE user_id = ?');
+            $stmt->execute([$username, $user_id]);
 
-            $stmt = $db->prepare('UPDATE community_comments SET user_name = ? WHERE user_id = ?');
-            $stmt->bind_param('si', $username, $user_id);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('UPDATE community_comments SET user_name = ? WHERE user_id = ?');
+            $stmt->execute([$username, $user_id]);
 
             // Update session
             $_SESSION['username'] = $username;
@@ -142,7 +132,6 @@ function handle_profile_update()
         header('Location: edit_profile.php');
         exit;
     } else {
-        $stmt->close();
         $_SESSION['profile_error'] = 'Failed to update profile. Please try again.';
         header('Location: edit_profile.php');
         exit;
@@ -232,17 +221,14 @@ function handle_avatar_change()
         // Update database with consistent path format
         $relative_path = 'uploads/avatars/' . $filename;
 
-        $db = get_db_connection();
-        $stmt = $db->prepare('UPDATE community_users SET avatar = ? WHERE id = ?');
-        $stmt->bind_param('si', $relative_path, $user_id);
+        global $pdo;
+        $stmt = $pdo->prepare('UPDATE community_users SET avatar = ? WHERE id = ?');
 
-        if ($stmt->execute()) {
-            $stmt->close();
+        if ($stmt->execute([$relative_path, $user_id])) {
             $_SESSION['profile_success'] = 'Avatar updated successfully!';
             header('Location: edit_profile.php');
             exit;
         } else {
-            $stmt->close();
             // Clean up uploaded file on database error
             unlink($filepath);
             $_SESSION['profile_error'] = 'Failed to update avatar in database.';
@@ -273,17 +259,14 @@ function handle_avatar_removal()
         }
 
         // Update database
-        $db = get_db_connection();
-        $stmt = $db->prepare('UPDATE community_users SET avatar = NULL WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
+        global $pdo;
+        $stmt = $pdo->prepare('UPDATE community_users SET avatar = NULL WHERE id = ?');
 
-        if ($stmt->execute()) {
-            $stmt->close();
+        if ($stmt->execute([$user_id])) {
             $_SESSION['profile_success'] = 'Avatar removed successfully!';
             header('Location: edit_profile.php');
             exit;
         } else {
-            $stmt->close();
             $_SESSION['profile_error'] = 'Failed to remove avatar.';
             header('Location: edit_profile.php');
             exit;
@@ -321,15 +304,12 @@ function handle_email_change()
         exit;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Verify current password
-    $stmt = $db->prepare('SELECT password_hash FROM community_users WHERE id = ?');
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $password_data = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT password_hash FROM community_users WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $password_data = $stmt->fetch();
 
     if (!$password_data || !password_verify($password, $password_data['password_hash'])) {
         $_SESSION['profile_error'] = 'Current password is incorrect';
@@ -338,27 +318,21 @@ function handle_email_change()
     }
 
     // Check if new email is already used
-    $stmt = $db->prepare('SELECT id FROM community_users WHERE email = ? AND id != ?');
-    $stmt->bind_param('si', $new_email, $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    if ($result->fetch_assoc()) {
-        $stmt->close();
+    $stmt = $pdo->prepare('SELECT id FROM community_users WHERE email = ? AND id != ?');
+    $stmt->execute([$new_email, $user_id]);
+    if ($stmt->fetch()) {
         $_SESSION['profile_error'] = 'This email address is already registered';
         header('Location: edit_profile.php');
         exit;
     }
-    $stmt->close();
 
     // Generate verification code
     $verification_code = generate_verification_code();
 
     // Store pending email change
-    $stmt = $db->prepare('UPDATE community_users SET verification_code = ?, email_verified = 0 WHERE id = ?');
-    $stmt->bind_param('si', $verification_code, $user_id);
+    $stmt = $pdo->prepare('UPDATE community_users SET verification_code = ?, email_verified = 0 WHERE id = ?');
 
-    if ($stmt->execute()) {
-        $stmt->close();
+    if ($stmt->execute([$verification_code, $user_id])) {
 
         // Send verification email to NEW email address
         $email_sent = send_verification_email($new_email, $verification_code, $user['username']);
@@ -376,7 +350,6 @@ function handle_email_change()
             exit;
         }
     } else {
-        $stmt->close();
         $_SESSION['profile_error'] = 'Failed to initiate email change. Please try again.';
         header('Location: edit_profile.php');
         exit;
@@ -402,15 +375,12 @@ function handle_email_verification()
         exit;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Check verification code
-    $stmt = $db->prepare('SELECT verification_code FROM community_users WHERE id = ?');
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $db_data = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT verification_code FROM community_users WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $db_data = $stmt->fetch();
 
     if (!$db_data || $db_data['verification_code'] !== $verification_code) {
         $_SESSION['profile_error'] = 'Invalid verification code';
@@ -420,22 +390,16 @@ function handle_email_verification()
 
     // Update email and verify
     $new_email = $_SESSION['pending_email'];
-    $stmt = $db->prepare('UPDATE community_users SET email = ?, email_verified = 1, verification_code = NULL WHERE id = ?');
-    $stmt->bind_param('si', $new_email, $user_id);
+    $stmt = $pdo->prepare('UPDATE community_users SET email = ?, email_verified = 1, verification_code = NULL WHERE id = ?');
 
-    if ($stmt->execute()) {
-        $stmt->close();
+    if ($stmt->execute([$new_email, $user_id])) {
 
         // Update email in posts and comments
-        $stmt = $db->prepare('UPDATE community_posts SET user_email = ? WHERE user_id = ?');
-        $stmt->bind_param('si', $new_email, $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_posts SET user_email = ? WHERE user_id = ?');
+        $stmt->execute([$new_email, $user_id]);
 
-        $stmt = $db->prepare('UPDATE community_comments SET user_email = ? WHERE user_id = ?');
-        $stmt->bind_param('si', $new_email, $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_comments SET user_email = ? WHERE user_id = ?');
+        $stmt->execute([$new_email, $user_id]);
 
         // Update session
         $_SESSION['email'] = $new_email;
@@ -446,7 +410,6 @@ function handle_email_verification()
         header('Location: edit_profile.php');
         exit;
     } else {
-        $stmt->close();
         $_SESSION['profile_error'] = 'Failed to update email address.';
         header('Location: edit_profile.php');
         exit;
@@ -480,15 +443,12 @@ function handle_password_change()
         exit;
     }
 
-    $db = get_db_connection();
+    global $pdo;
 
     // Verify current password
-    $stmt = $db->prepare('SELECT password_hash FROM community_users WHERE id = ?');
-    $stmt->bind_param('i', $user_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $password_data = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare('SELECT password_hash FROM community_users WHERE id = ?');
+    $stmt->execute([$user_id]);
+    $password_data = $stmt->fetch();
 
     if (!$password_data || !password_verify($current_password, $password_data['password_hash'])) {
         $_SESSION['profile_error'] = 'Current password is incorrect';
@@ -498,16 +458,13 @@ function handle_password_change()
 
     // Update password
     $new_password_hash = password_hash($new_password, PASSWORD_DEFAULT);
-    $stmt = $db->prepare('UPDATE community_users SET password_hash = ? WHERE id = ?');
-    $stmt->bind_param('si', $new_password_hash, $user_id);
+    $stmt = $pdo->prepare('UPDATE community_users SET password_hash = ? WHERE id = ?');
 
-    if ($stmt->execute()) {
-        $stmt->close();
+    if ($stmt->execute([$new_password_hash, $user_id])) {
         $_SESSION['profile_success'] = 'Password changed successfully!';
         header('Location: edit_profile.php');
         exit;
     } else {
-        $stmt->close();
         $_SESSION['profile_error'] = 'Failed to change password. Please try again.';
         header('Location: edit_profile.php');
         exit;

--- a/community/users/profile.php
+++ b/community/users/profile.php
@@ -35,15 +35,10 @@ if (empty($requested_username)) {
     $user = get_user($_SESSION['user_id']);
     $is_own_profile = true;
 } else {
-    $db = get_db_connection();
-
     // Only select needed columns - avoid exposing sensitive fields like password_hash, reset_token, etc.
-    $stmt = $db->prepare("SELECT id, username, email, bio, avatar, role, reputation, created_at, last_login, email_verified, deletion_scheduled_at FROM community_users WHERE username = ?");
-    $stmt->bind_param("s", $requested_username);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $user = $result->fetch_assoc();
-    $stmt->close();
+    $stmt = $pdo->prepare("SELECT id, username, email, bio, avatar, role, reputation, created_at, last_login, email_verified, deletion_scheduled_at FROM community_users WHERE username = ?");
+    $stmt->execute([$requested_username]);
+    $user = $stmt->fetch();
 
     if ($user) {
         $is_own_profile = ((int)$user['id'] === (int)$_SESSION['user_id']);
@@ -54,27 +49,22 @@ if (empty($requested_username)) {
 
 // If user found, get profile data
 if ($user) {
-    $db = get_db_connection();
-
     // MySQL prepared statement for getting post and comment counts
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             COUNT(DISTINCT p.id) AS post_count,
             COUNT(DISTINCT c.id) AS comment_count
-        FROM 
+        FROM
             community_users u
-        LEFT JOIN 
+        LEFT JOIN
             community_posts p ON u.id = p.user_id
-        LEFT JOIN 
+        LEFT JOIN
             community_comments c ON u.id = c.user_id
-        WHERE 
+        WHERE
             u.id = ?
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $profile = $result->fetch_assoc();
-    $stmt->close();
+    $stmt->execute([$user['id']]);
+    $profile = $stmt->fetch();
 
     if (!$profile) {
         // Create default profile if query fails
@@ -92,108 +82,93 @@ if ($user) {
     // For comment downvotes: -1 per downvote
 
     // First, calculate reputation from post votes received
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             COALESCE(SUM(CASE WHEN v.vote_type = 1 THEN 10 ELSE -5 END), 0) as post_vote_rep
-        FROM 
+        FROM
             community_posts p
-        LEFT JOIN 
+        LEFT JOIN
             community_votes v ON p.id = v.post_id
-        WHERE 
+        WHERE
             p.user_id = ? AND v.vote_type IS NOT NULL
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $post_rep_result = $result->fetch_assoc();
+    $stmt->execute([$user['id']]);
+    $post_rep_result = $stmt->fetch();
     $post_reputation = isset($post_rep_result['post_vote_rep']) ? $post_rep_result['post_vote_rep'] : 0;
-    $stmt->close();
 
     // Calculate reputation from downvotes cast by user
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             COUNT(*) * -2 as downvote_cost
-        FROM 
+        FROM
             community_votes
-        WHERE 
+        WHERE
             user_id = ? AND vote_type = -1
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $downvote_result = $result->fetch_assoc();
+    $stmt->execute([$user['id']]);
+    $downvote_result = $stmt->fetch();
     $downvote_reputation = isset($downvote_result['downvote_cost']) ? $downvote_result['downvote_cost'] : 0;
-    $stmt->close();
 
     // Calculate reputation from comment votes
     $comment_reputation = 0;
     $comment_votes_exist = false;
 
     // Check if comment_votes table exists
-    $result = $db->query("SHOW TABLES LIKE 'comment_votes'");
-    if ($result->num_rows > 0) {
+    $tables_check = $pdo->query("SHOW TABLES LIKE 'comment_votes'");
+    if ($tables_check->fetch() !== false) {
         $comment_votes_exist = true;
 
         // Calculate comment upvote reputation (+2 each)
-        $stmt = $db->prepare("
-            SELECT 
+        $stmt = $pdo->prepare("
+            SELECT
                 COALESCE(SUM(CASE WHEN cv.vote_type = 1 THEN 2 ELSE -1 END), 0) as comment_vote_rep
-            FROM 
+            FROM
                 community_comments c
-            LEFT JOIN 
+            LEFT JOIN
                 comment_votes cv ON c.id = cv.comment_id
-            WHERE 
+            WHERE
                 c.user_id = ? AND cv.vote_type IS NOT NULL
         ");
-        $stmt->bind_param("i", $user['id']);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $comment_rep_result = $result->fetch_assoc();
+        $stmt->execute([$user['id']]);
+        $comment_rep_result = $stmt->fetch();
         $comment_reputation = isset($comment_rep_result['comment_vote_rep']) ? $comment_rep_result['comment_vote_rep'] : 0;
-        $stmt->close();
     }
 
     // Total reputation
     $reputation = $post_reputation + $downvote_reputation + $comment_reputation;
 
     // Calculate impact (total views on posts)
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             COALESCE(SUM(views), 0) AS people_reached
-        FROM 
+        FROM
             community_posts
-        WHERE 
+        WHERE
             user_id = ?
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $impact_result = $result->fetch_assoc();
+    $stmt->execute([$user['id']]);
+    $impact_result = $stmt->fetch();
     $people_reached = isset($impact_result['people_reached']) ? $impact_result['people_reached'] : 0;
-    $stmt->close();
 
     // Get votes cast
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             COUNT(*) AS votes_cast
-        FROM 
+        FROM
             community_votes
-        WHERE 
+        WHERE
             user_id = ?
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $votes_result = $result->fetch_assoc();
+    $stmt->execute([$user['id']]);
+    $votes_result = $stmt->fetch();
     $votes_cast = isset($votes_result['votes_cast']) ? $votes_result['votes_cast'] : 0;
-    $stmt->close();
 
     // Get reputation history (will need to calculate from existing data)
     $reputation_history = [];
 
     // Post upvotes received - each worth +10
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             v.id,
             'post_upvote' as action_type,
             p.id as post_id,
@@ -201,26 +176,23 @@ if ($user) {
             v.created_at,
             p.title as post_title,
             10 as rep_change
-        FROM 
+        FROM
             community_votes v
-        JOIN 
+        JOIN
             community_posts p ON v.post_id = p.id
-        WHERE 
+        WHERE
             p.user_id = ? AND v.vote_type = 1
-        ORDER BY 
+        ORDER BY
             v.created_at DESC
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    while ($row = $result->fetch_assoc()) {
+    $stmt->execute([$user['id']]);
+    while ($row = $stmt->fetch()) {
         $reputation_history[] = $row;
     }
-    $stmt->close();
 
     // Post downvotes received - each worth -5
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             v.id,
             'post_downvote' as action_type,
             p.id as post_id,
@@ -228,26 +200,23 @@ if ($user) {
             v.created_at,
             p.title as post_title,
             -5 as rep_change
-        FROM 
+        FROM
             community_votes v
-        JOIN 
+        JOIN
             community_posts p ON v.post_id = p.id
-        WHERE 
+        WHERE
             p.user_id = ? AND v.vote_type = -1
-        ORDER BY 
+        ORDER BY
             v.created_at DESC
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    while ($row = $result->fetch_assoc()) {
+    $stmt->execute([$user['id']]);
+    while ($row = $stmt->fetch()) {
         $reputation_history[] = $row;
     }
-    $stmt->close();
 
     // Downvotes cast by user - each worth -2
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             v.id,
             'downvoted_other' as action_type,
             p.id as post_id,
@@ -255,28 +224,25 @@ if ($user) {
             v.created_at,
             p.title as post_title,
             -2 as rep_change
-        FROM 
+        FROM
             community_votes v
-        JOIN 
+        JOIN
             community_posts p ON v.post_id = p.id
-        WHERE 
+        WHERE
             v.user_id = ? AND v.vote_type = -1
-        ORDER BY 
+        ORDER BY
             v.created_at DESC
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    while ($row = $result->fetch_assoc()) {
+    $stmt->execute([$user['id']]);
+    while ($row = $stmt->fetch()) {
         $reputation_history[] = $row;
     }
-    $stmt->close();
 
     // Add comment votes if the table exists
     if ($comment_votes_exist) {
         // Comment upvotes received - each worth +2
-        $stmt = $db->prepare("
-            SELECT 
+        $stmt = $pdo->prepare("
+            SELECT
                 cv.id,
                 'comment_upvote' as action_type,
                 p.id as post_id,
@@ -284,28 +250,25 @@ if ($user) {
                 cv.created_at,
                 p.title as post_title,
                 2 as rep_change
-            FROM 
+            FROM
                 comment_votes cv
-            JOIN 
+            JOIN
                 community_comments c ON cv.comment_id = c.id
             JOIN
                 community_posts p ON c.post_id = p.id
-            WHERE 
+            WHERE
                 c.user_id = ? AND cv.vote_type = 1
-            ORDER BY 
+            ORDER BY
                 cv.created_at DESC
         ");
-        $stmt->bind_param("i", $user['id']);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        while ($row = $result->fetch_assoc()) {
+        $stmt->execute([$user['id']]);
+        while ($row = $stmt->fetch()) {
             $reputation_history[] = $row;
         }
-        $stmt->close();
 
         // Comment downvotes received - each worth -1
-        $stmt = $db->prepare("
-            SELECT 
+        $stmt = $pdo->prepare("
+            SELECT
                 cv.id,
                 'comment_downvote' as action_type,
                 p.id as post_id,
@@ -313,24 +276,21 @@ if ($user) {
                 cv.created_at,
                 p.title as post_title,
                 -1 as rep_change
-            FROM 
+            FROM
                 comment_votes cv
-            JOIN 
+            JOIN
                 community_comments c ON cv.comment_id = c.id
             JOIN
                 community_posts p ON c.post_id = p.id
-            WHERE 
+            WHERE
                 c.user_id = ? AND cv.vote_type = -1
-            ORDER BY 
+            ORDER BY
                 cv.created_at DESC
         ");
-        $stmt->bind_param("i", $user['id']);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        while ($row = $result->fetch_assoc()) {
+        $stmt->execute([$user['id']]);
+        while ($row = $stmt->fetch()) {
             $reputation_history[] = $row;
         }
-        $stmt->close();
     }
 
     // Sort reputation history by date (newest first)
@@ -372,16 +332,13 @@ if ($user) {
         $sort_query
     ";
 
-    $stmt = $db->prepare($query);
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([$user['id']]);
 
     $user_posts = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $user_posts[] = $row;
     }
-    $stmt->close();
 
     // Get user's comments
     $comment_sort = isset($_GET['comment_sort']) ? $_GET['comment_sort'] : 'newest';
@@ -400,31 +357,28 @@ if ($user) {
             break;
     }
 
-    $stmt = $db->prepare("
-        SELECT 
+    $stmt = $pdo->prepare("
+        SELECT
             c.id,
             c.content,
             c.created_at,
             c.votes,
             c.post_id,
             p.title as post_title
-        FROM 
+        FROM
             community_comments c
         JOIN
             community_posts p ON c.post_id = p.id
-        WHERE 
+        WHERE
             c.user_id = ?
         $comment_sort_query
     ");
-    $stmt->bind_param("i", $user['id']);
-    $stmt->execute();
-    $result = $stmt->get_result();
+    $stmt->execute([$user['id']]);
 
     $user_comments = [];
-    while ($row = $result->fetch_assoc()) {
+    while ($row = $stmt->fetch()) {
         $user_comments[] = $row;
     }
-    $stmt->close();
 
     // Prepare data for reputation chart
     $rep_by_date = [];

--- a/community/users/resend_verification_code.php
+++ b/community/users/resend_verification_code.php
@@ -14,13 +14,9 @@ if (!isset($_SESSION['temp_user_id'])) {
 $user_id = $_SESSION['temp_user_id'];
 
 // Get user details from database
-$db = get_db_connection();
-$stmt = $db->prepare('SELECT id, email, username, email_verified FROM community_users WHERE id = ?');
-$stmt->bind_param('i', $user_id);
-$stmt->execute();
-$result = $stmt->get_result();
-$user = $result->fetch_assoc();
-$stmt->close();
+$stmt = $pdo->prepare('SELECT id, email, username, email_verified FROM community_users WHERE id = ?');
+$stmt->execute([$user_id]);
+$user = $stmt->fetch();
 
 if (!$user) {
     header('Location: register.php?error=user_not_found');
@@ -37,10 +33,8 @@ if ($user['email_verified'] == 1) {
 $new_verification_code = generate_verification_code();
 
 // Update the database with the new verification code
-$stmt = $db->prepare('UPDATE community_users SET verification_code = ? WHERE id = ?');
-$stmt->bind_param('si', $new_verification_code, $user_id);
-$update_result = $stmt->execute();
-$stmt->close();
+$stmt = $pdo->prepare('UPDATE community_users SET verification_code = ? WHERE id = ?');
+$update_result = $stmt->execute([$new_verification_code, $user_id]);
 
 if (!$update_result) {
     header('Location: verify_code.php?error=update_failed');

--- a/community/users/reset_password.php
+++ b/community/users/reset_password.php
@@ -53,13 +53,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Verify token is valid
-$db = get_db_connection();
-$stmt = $db->prepare('SELECT id FROM community_users WHERE reset_token = ? AND reset_token_expiry > CURRENT_TIMESTAMP');
-$stmt->bind_param('s', $token);
-$stmt->execute();
-$result = $stmt->get_result();
-$valid_token = ($result->num_rows > 0);
-$stmt->close();
+$stmt = $pdo->prepare('SELECT id FROM community_users WHERE reset_token = ? AND reset_token_expiry > CURRENT_TIMESTAMP');
+$stmt->execute([$token]);
+$valid_token = ($stmt->fetch() !== false);
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/community/users/user_functions.php
+++ b/community/users/user_functions.php
@@ -6,7 +6,7 @@ namespace {
 
     /**
      * Register a new user with verification code
-     * 
+     *
      * @param string $username Username
      * @param string $email Email address
      * @param string $password Plain text password
@@ -14,27 +14,21 @@ namespace {
      */
     function register_user($username, $email, $password)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Check if username exists
-        $stmt = $db->prepare('SELECT id FROM community_users WHERE username = ?');
-        $stmt->bind_param('s', $username);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user_exists = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id FROM community_users WHERE username = ?');
+        $stmt->execute([$username]);
+        $user_exists = $stmt->fetch();
 
         if ($user_exists) {
             return ['success' => false, 'message' => 'Username already exists'];
         }
 
         // Check if email exists
-        $stmt = $db->prepare('SELECT id FROM community_users WHERE email = ?');
-        $stmt->bind_param('s', $email);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $email_exists = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id FROM community_users WHERE email = ?');
+        $stmt->execute([$email]);
+        $email_exists = $stmt->fetch();
 
         if ($email_exists) {
             return ['success' => false, 'message' => 'Email already exists'];
@@ -44,14 +38,12 @@ namespace {
         $password_hash = password_hash($password, PASSWORD_DEFAULT);
 
         // Insert new user
-        $stmt = $db->prepare('INSERT INTO community_users (username, email, password_hash, verification_code, email_verified) 
+        $stmt = $pdo->prepare('INSERT INTO community_users (username, email, password_hash, verification_code, email_verified)
                          VALUES (?, ?, ?, ?, 0)');
-        $stmt->bind_param('ssss', $username, $email, $password_hash, $verification_code);
-        $success = $stmt->execute();
-        $stmt->close();
+        $success = $stmt->execute([$username, $email, $password_hash, $verification_code]);
 
         if ($success) {
-            $user_id = $db->insert_id;
+            $user_id = $pdo->lastInsertId();
 
             // Send verification email with code
             send_verification_email($email, $verification_code, $username);
@@ -75,7 +67,7 @@ namespace {
      */
     function login_user($login, $password)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Check if login is email or username - use whitelist to prevent any injection
         $field = filter_var($login, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
@@ -84,12 +76,9 @@ namespace {
         $sql = ($field === 'email')
             ? 'SELECT * FROM community_users WHERE email = ?'
             : 'SELECT * FROM community_users WHERE username = ?';
-        $stmt = $db->prepare($sql);
-        $stmt->bind_param('s', $login);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([$login]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             return false;
@@ -111,10 +100,8 @@ namespace {
             $deletion_was_scheduled = !is_null($user['deletion_scheduled_at']);
 
             // Update last login time and cancel scheduled deletion
-            $stmt = $db->prepare('UPDATE community_users SET last_login = NOW(), deletion_scheduled_at = NULL WHERE id = ?');
-            $stmt->bind_param('i', $user['id']);
-            $stmt->execute();
-            $stmt->close();
+            $stmt = $pdo->prepare('UPDATE community_users SET last_login = NOW(), deletion_scheduled_at = NULL WHERE id = ?');
+            $stmt->execute([$user['id']]);
 
             // If deletion was scheduled, send cancellation email
             if ($deletion_was_scheduled) {
@@ -157,22 +144,17 @@ namespace {
                     return;
                 }
 
-                $db = get_db_connection();
+                global $pdo;
 
                 // Check if user had scheduled deletion
-                $stmt = $db->prepare('SELECT deletion_scheduled_at FROM community_users WHERE id = ?');
-                $stmt->bind_param('i', $user['id']);
-                $stmt->execute();
-                $result = $stmt->get_result();
-                $user_data = $result->fetch_assoc();
+                $stmt = $pdo->prepare('SELECT deletion_scheduled_at FROM community_users WHERE id = ?');
+                $stmt->execute([$user['id']]);
+                $user_data = $stmt->fetch();
                 $deletion_was_scheduled = !is_null($user_data['deletion_scheduled_at']);
-                $stmt->close();
 
                 // Update last login time and cancel scheduled deletion
-                $stmt = $db->prepare('UPDATE community_users SET last_login = NOW(), deletion_scheduled_at = NULL WHERE id = ?');
-                $stmt->bind_param('i', $user['id']);
-                $stmt->execute();
-                $stmt->close();
+                $stmt = $pdo->prepare('UPDATE community_users SET last_login = NOW(), deletion_scheduled_at = NULL WHERE id = ?');
+                $stmt->execute([$user['id']]);
 
                 // If deletion was scheduled, send cancellation email
                 if ($deletion_was_scheduled) {
@@ -199,30 +181,26 @@ namespace {
 
     /**
      * Generate a remember me token for a user
-     * 
+     *
      * @param int $user_id User ID
      * @return string|bool Token or false on failure
      */
     function generate_remember_token($user_id)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Create a unique token
         $token = bin2hex(random_bytes(32));
         $expires = date('Y-m-d H:i:s', time() + (30 * 24 * 60 * 60)); // 30 days
 
         // Remove any existing tokens for this user
-        $stmt = $db->prepare('DELETE FROM remember_tokens WHERE user_id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('DELETE FROM remember_tokens WHERE user_id = ?');
+        $stmt->execute([$user_id]);
 
         // Store a hash of the token (never store raw tokens in the database)
         $token_hash = hash('sha256', $token);
-        $stmt = $db->prepare('INSERT INTO remember_tokens (user_id, token, expires_at) VALUES (?, ?, ?)');
-        $stmt->bind_param('iss', $user_id, $token_hash, $expires);
-        $success = $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('INSERT INTO remember_tokens (user_id, token, expires_at) VALUES (?, ?, ?)');
+        $success = $stmt->execute([$user_id, $token_hash, $expires]);
 
         if ($success) {
             return $token;
@@ -233,24 +211,21 @@ namespace {
 
     /**
      * Validate a remember me token and get the associated user
-     * 
+     *
      * @param string $token Remember me token
      * @return array|bool User data or false if invalid
      */
     function validate_remember_token($token)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Hash the token to compare against the stored hash
         $token_hash = hash('sha256', $token);
-        $stmt = $db->prepare('SELECT rt.user_id, u.* FROM remember_tokens rt
+        $stmt = $pdo->prepare('SELECT rt.user_id, u.* FROM remember_tokens rt
                          JOIN community_users u ON rt.user_id = u.id
                          WHERE rt.token = ? AND rt.expires_at > NOW()');
-        $stmt->bind_param('s', $token_hash);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt->execute([$token_hash]);
+        $user = $stmt->fetch();
 
         if ($user) {
             // Don't return sensitive data
@@ -267,17 +242,15 @@ namespace {
 
     /**
      * Clear remember me token when logging out
-     * 
+     *
      * @param int $user_id User ID
      */
     function clear_remember_token($user_id)
     {
-        $db = get_db_connection();
+        global $pdo;
 
-        $stmt = $db->prepare('DELETE FROM remember_tokens WHERE user_id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('DELETE FROM remember_tokens WHERE user_id = ?');
+        $stmt->execute([$user_id]);
 
         // Clear the cookie
         setcookie('remember_me', '', time() - 3600, '/');
@@ -285,49 +258,38 @@ namespace {
 
     /**
      * Get user by ID
-     * 
+     *
      * @param int $user_id User ID
      * @return array|bool User data or false if not found
      */
     function get_user($user_id)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Use a new database connection for each call
-        $stmt = $db->prepare('SELECT id, username, email, bio, avatar, role, email_verified, created_at, last_login 
+        $stmt = $pdo->prepare('SELECT id, username, email, bio, avatar, role, email_verified, created_at, last_login
                         FROM community_users WHERE id = ?');
 
-        if (!$stmt) {
-            error_log("Database prepare error in get_user(): " . $db->error);
-            return false;
-        }
-
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch();
 
         return $user ? $user : false;
     }
 
     /**
      * Request password reset
-     * 
+     *
      * @param string $email User's email address
      * @return bool Success status
      */
     function request_password_reset($email)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Find user by email
-        $stmt = $db->prepare('SELECT id, username FROM community_users WHERE email = ?');
-        $stmt->bind_param('s', $email);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id, username FROM community_users WHERE email = ?');
+        $stmt->execute([$email]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             return false;
@@ -340,10 +302,8 @@ namespace {
         $expiry = date('Y-m-d H:i:s', strtotime('+1 hour'));
 
         // Update user with reset token
-        $stmt = $db->prepare('UPDATE community_users SET reset_token = ?, reset_token_expiry = ? WHERE id = ?');
-        $stmt->bind_param('ssi', $reset_token, $expiry, $user['id']);
-        $success = $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_users SET reset_token = ?, reset_token_expiry = ? WHERE id = ?');
+        $success = $stmt->execute([$reset_token, $expiry, $user['id']]);
 
         if ($success) {
             return send_password_reset_email($email, $reset_token, $user['username']);
@@ -354,22 +314,19 @@ namespace {
 
     /**
      * Reset password using token
-     * 
+     *
      * @param string $token Reset token
      * @param string $new_password New password
      * @return bool Success status
      */
     function reset_password($token, $new_password)
     {
-        $db = get_db_connection();
+        global $pdo;
 
         // Find user by reset token and check expiry
-        $stmt = $db->prepare('SELECT id FROM community_users WHERE reset_token = ? AND reset_token_expiry > NOW()');
-        $stmt->bind_param('s', $token);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT id FROM community_users WHERE reset_token = ? AND reset_token_expiry > NOW()');
+        $stmt->execute([$token]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             return false;
@@ -378,17 +335,15 @@ namespace {
         $password_hash = password_hash($new_password, PASSWORD_DEFAULT);
 
         // Update user with new password and clear reset token
-        $stmt = $db->prepare('UPDATE community_users SET password_hash = ?, reset_token = NULL, reset_token_expiry = NULL WHERE id = ?');
-        $stmt->bind_param('si', $password_hash, $user['id']);
-        $success = $stmt->execute();
-        $stmt->close();
+        $stmt = $pdo->prepare('UPDATE community_users SET password_hash = ?, reset_token = NULL, reset_token_expiry = NULL WHERE id = ?');
+        $success = $stmt->execute([$password_hash, $user['id']]);
 
         return $success;
     }
 
     /**
      * Upload avatar image
-     * 
+     *
      * @param int $user_id User ID
      * @param array $file File data from $_FILES
      * @return string|bool Image path on success, false on failure
@@ -439,13 +394,11 @@ namespace {
         }
 
         // Get current avatar path before updating
-        $db = get_db_connection();
-        $stmt = $db->prepare('SELECT avatar FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $old_avatar = $result->fetch_assoc()['avatar'] ?? '';
-        $stmt->close();
+        global $pdo;
+        $stmt = $pdo->prepare('SELECT avatar FROM community_users WHERE id = ?');
+        $stmt->execute([$user_id]);
+        $old_avatar_row = $stmt->fetch();
+        $old_avatar = $old_avatar_row['avatar'] ?? '';
 
         // Generate unique filename
         $extension = pathinfo($file['name'], PATHINFO_EXTENSION);
@@ -459,22 +412,20 @@ namespace {
 
             try {
                 // Begin transaction to reduce lock time
-                $db->begin_transaction();
+                $pdo->beginTransaction();
 
                 $avatar_path = 'uploads/avatars/' . $filename;
-                $stmt = $db->prepare('UPDATE community_users SET avatar = ?, updated_at = NOW() WHERE id = ?');
-                $stmt->bind_param('si', $avatar_path, $user_id);
-                $success = $stmt->execute();
-                $stmt->close();
+                $stmt = $pdo->prepare('UPDATE community_users SET avatar = ?, updated_at = NOW() WHERE id = ?');
+                $success = $stmt->execute([$avatar_path, $user_id]);
 
                 if (!$success) {
-                    $db->rollback();
-                    error_log("Failed to update avatar in database: " . $db->error);
+                    $pdo->rollBack();
+                    error_log("Failed to update avatar in database");
                     return false;
                 }
 
                 // Commit transaction
-                $db->commit();
+                $pdo->commit();
 
                 // Update session with avatar path
                 $_SESSION['avatar'] = $avatar_path;
@@ -490,7 +441,9 @@ namespace {
                 return $avatar_path;
             } catch (Exception $e) {
                 // Rollback on exception
-                $db->rollback();
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
                 error_log("Exception in avatar upload: " . $e->getMessage());
                 return false;
             }
@@ -502,7 +455,7 @@ namespace {
 
     /**
      * Check if user is logged in and exists in database
-     * 
+     *
      * @return bool True if user is logged in and exists in database
      */
     function is_user_logged_in()
@@ -514,23 +467,15 @@ namespace {
 
         // Then verify user exists in database
         try {
-            $db = get_db_connection();
-            if (!$db) {
+            global $pdo;
+            if (!$pdo) {
                 error_log('Database connection failed in is_user_logged_in');
                 return false;
             }
 
-            $stmt = $db->prepare('SELECT id FROM community_users WHERE id = ?');
-            if (!$stmt) {
-                error_log('Failed to prepare statement in is_user_logged_in: ' . $db->error);
-                return false;
-            }
-
-            $stmt->bind_param('i', $_SESSION['user_id']);
-            $stmt->execute();
-            $result = $stmt->get_result();
-            $user = $result->fetch_assoc();
-            $stmt->close();
+            $stmt = $pdo->prepare('SELECT id FROM community_users WHERE id = ?');
+            $stmt->execute([$_SESSION['user_id']]);
+            $user = $stmt->fetch();
 
             if (!$user) {
                 error_log('User with ID ' . $_SESSION['user_id'] . ' not found in database');
@@ -592,15 +537,12 @@ namespace CommunityUsers {
         }
 
         $user_id = $_SESSION['user_id'];
-        $db = get_db_connection();
+        global $pdo;
 
-        $stmt = $db->prepare('SELECT id, username, email, bio, avatar, role, email_verified, created_at, last_login 
+        $stmt = $pdo->prepare('SELECT id, username, email, bio, avatar, role, email_verified, created_at, last_login
                          FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
-        $stmt->close();
+        $stmt->execute([$user_id]);
+        $user = $stmt->fetch();
 
         if (!$user) {
             // User ID in session but not found in database

--- a/community/users/verify_code.php
+++ b/community/users/verify_code.php
@@ -34,13 +34,9 @@ if (!isset($_SESSION['temp_user_id'])) {
 $user_id = $_SESSION['temp_user_id'];
 
 // Check if the user exists in the database
-$db = get_db_connection();
-$stmt = $db->prepare('SELECT id, verification_code FROM community_users WHERE id = ?');
-$stmt->bind_param('i', $user_id);
-$stmt->execute();
-$result = $stmt->get_result();
-$user = $result->fetch_assoc();
-$stmt->close();
+$stmt = $pdo->prepare('SELECT id, verification_code FROM community_users WHERE id = ?');
+$stmt->execute([$user_id]);
+$user = $stmt->fetch();
 
 if (!$user) {
     header('Location: register.php?error=user_not_found');
@@ -76,12 +72,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'Please enter a valid 6-digit verification code';
     } else {
         // Get the current verification code from database
-        $stmt = $db->prepare('SELECT verification_code FROM community_users WHERE id = ?');
-        $stmt->bind_param('i', $user_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $db_verification = $result->fetch_assoc();
-        $stmt->close();
+        $stmt = $pdo->prepare('SELECT verification_code FROM community_users WHERE id = ?');
+        $stmt->execute([$user_id]);
+        $db_verification = $stmt->fetch();
 
         if (!$db_verification) {
             $error = 'User not found. Please register again.';
@@ -89,19 +82,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Compare the codes directly
             if ($db_verification['verification_code'] === $verification_code) {
                 // Update user as verified and clear verification code
-                $stmt = $db->prepare('UPDATE community_users SET email_verified = 1, verification_code = NULL WHERE id = ?');
-                $stmt->bind_param('i', $user_id);
-                $update_result = $stmt->execute();
-                $stmt->close();
+                $stmt = $pdo->prepare('UPDATE community_users SET email_verified = 1, verification_code = NULL WHERE id = ?');
+                $update_result = $stmt->execute([$user_id]);
 
                 if ($update_result) {
                     // Get the full user details to populate the session
-                    $stmt = $db->prepare('SELECT id, username, email, role, avatar FROM community_users WHERE id = ?');
-                    $stmt->bind_param('i', $user_id);
-                    $stmt->execute();
-                    $result = $stmt->get_result();
-                    $verified_user = $result->fetch_assoc();
-                    $stmt->close();
+                    $stmt = $pdo->prepare('SELECT id, username, email, role, avatar FROM community_users WHERE id = ?');
+                    $stmt->execute([$user_id]);
+                    $verified_user = $stmt->fetch();
 
                     if ($verified_user) {
                         // Regenerate session ID to prevent session fixation

--- a/community/view_post.php
+++ b/community/view_post.php
@@ -38,38 +38,30 @@ if ($post_id <= 0 || !$post) {
 }
 
 // Check if metadata column exists
-$metadata_exists = false;
-$db = get_db_connection();
-$result = $db->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
-$metadata_exists = ($result->num_rows > 0);
+$result = $pdo->query("SHOW COLUMNS FROM community_posts LIKE 'metadata'");
+$metadata_exists = ($result->fetch() !== false);
 
 if ($metadata_exists) {
     // Get metadata if it exists
-    $stmt = $db->prepare('SELECT metadata FROM community_posts WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
+    $stmt = $pdo->prepare('SELECT metadata FROM community_posts WHERE id = ?');
+    $stmt->execute([$post_id]);
+    $row = $stmt->fetch();
 
     if ($row && !empty($row['metadata'])) {
         $metadata = json_decode($row['metadata'], true);
         $has_metadata = !empty($metadata);
     }
-    $stmt->close();
 }
 
 // Get last edit for the post
-$stmt = $db->prepare('SELECT h.*, u.username 
+$stmt = $pdo->prepare('SELECT h.*, u.username
     FROM post_edit_history h
     LEFT JOIN community_users u ON h.user_id = u.id
     WHERE h.post_id = ?
     ORDER BY h.edited_at DESC
     LIMIT 1');
-$stmt->bind_param('i', $post_id);
-$stmt->execute();
-$result = $stmt->get_result();
-$post_last_edit = $result->fetch_assoc();
-$stmt->close();
+$stmt->execute([$post_id]);
+$post_last_edit = $stmt->fetch();
 
 $current_user = $is_logged_in ? \CommunityUsers\get_current_user() : null;
 
@@ -79,11 +71,8 @@ $is_admin = $is_logged_in && (isset($current_user['role']) && $current_user['rol
 
 if (!$is_admin && !in_array($post_id, $viewed_posts)) {
     // Update view count in database
-    $db = get_db_connection();
-    $stmt = $db->prepare('UPDATE community_posts SET views = views + 1 WHERE id = ?');
-    $stmt->bind_param('i', $post_id);
-    $stmt->execute();
-    $stmt->close();
+    $stmt = $pdo->prepare('UPDATE community_posts SET views = views + 1 WHERE id = ?');
+    $stmt->execute([$post_id]);
 
     // Add post to viewed posts in session
     $viewed_posts[] = $post_id;

--- a/community/vote.php
+++ b/community/vote.php
@@ -51,8 +51,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($vote_type !== 1 && $vote_type !== -1) {
         $response['message'] = 'Invalid vote type';
     } else {
-        $db = get_db_connection();
-
         if ($post_id > 0) {
             // Voting on a post
             // Verify post exists
@@ -75,10 +73,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         // Connect vote to user account
                         if ($user_id > 0) {
                             // Update the vote record with user_id
-                            $stmt = $db->prepare('UPDATE community_votes SET user_id = ? WHERE post_id = ? AND user_email = ?');
-                            $stmt->bind_param('iis', $user_id, $post_id, $email);
-                            $stmt->execute();
-                            $stmt->close();
+                            $stmt = $pdo->prepare('UPDATE community_votes SET user_id = ? WHERE post_id = ? AND user_email = ?');
+                            $stmt->execute([$user_id, $post_id, $email]);
                         }
 
                         $response = [
@@ -95,12 +91,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } elseif ($comment_id > 0) {
             // Voting on a comment
             // Verify comment exists and check if user is the author
-            $stmt = $db->prepare('SELECT id, user_id FROM community_comments WHERE id = ?');
-            $stmt->bind_param('i', $comment_id);
-            $stmt->execute();
-            $result = $stmt->get_result();
-            $comment = $result->fetch_assoc();
-            $stmt->close();
+            $stmt = $pdo->prepare('SELECT id, user_id FROM community_comments WHERE id = ?');
+            $stmt->execute([$comment_id]);
+            $comment = $stmt->fetch();
 
             if (!$comment) {
                 $response['message'] = 'Comment not found';
@@ -117,10 +110,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     // Connect vote to user account
                     if ($user_id > 0) {
                         // Update the vote record with user_id
-                        $stmt = $db->prepare('UPDATE comment_votes SET user_id = ? WHERE comment_id = ? AND user_email = ?');
-                        $stmt->bind_param('iis', $user_id, $comment_id, $email);
-                        $stmt->execute();
-                        $stmt->close();
+                        $stmt = $pdo->prepare('UPDATE comment_votes SET user_id = ? WHERE comment_id = ? AND user_email = ?');
+                        $stmt->execute([$user_id, $comment_id, $email]);
                     }
 
                     $response = [

--- a/config/pricing.php
+++ b/config/pricing.php
@@ -185,15 +185,12 @@ function calculate_invoice_processing_fee($amount, $currency = 'CAD') {
  */
 function _convert_fixed_fee_to_currency($amountCAD, $currency) {
     try {
-        $db = get_db_connection();
-        $stmt = $db->prepare(
+        global $pdo;
+        $stmt = $pdo->prepare(
             'SELECT rates FROM exchange_rates WHERE rate_date <= CURDATE() ORDER BY rate_date DESC LIMIT 1'
         );
         $stmt->execute();
-        $result = $stmt->get_result();
-        $row = $result->fetch_assoc();
-        $stmt->close();
-        $db->close();
+        $row = $stmt->fetch();
 
         if (!$row || empty($row['rates'])) {
             return $amountCAD; // Fallback: use same numeric value

--- a/cron/account_purge.php
+++ b/cron/account_purge.php
@@ -95,7 +95,9 @@ try {
             $deletedCount++;
 
         } catch (Exception $e) {
-            $pdo->rollBack();
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
             logPurge("Failed to delete account $username (#$userId): " . $e->getMessage(), 'ERROR');
             $failedCount++;
         }

--- a/db_connect.php
+++ b/db_connect.php
@@ -67,29 +67,3 @@ function portal_decrypt(string $encoded): string
     }
     return $plaintext;
 }
-
-/**
- * Database connection function for MySQL (mysqli)
- */
-function get_db_connection()
-{
-    $host = $_ENV['DB_HOST'];
-    $username = $_ENV['DB_USERNAME'];
-    $password = $_ENV['DB_PASSWORD'];
-    $database = $_ENV['DB_NAME'];
-
-    // Create new connection
-    $db = new mysqli($host, $username, $password, $database);
-
-    // Check connection
-    if ($db->connect_error) {
-        error_log("Database connection error: " . $db->connect_error);
-        http_response_code(503);
-        die("Service temporarily unavailable. Please try again later.");
-    }
-
-    // Set character set
-    $db->set_charset("utf8mb4");
-
-    return $db;
-}

--- a/email_sender.php
+++ b/email_sender.php
@@ -169,24 +169,17 @@ function send_verification_email($email, $code, $username)
  */
 function send_notification_email($type, $data)
 {
-    $db = get_db_connection();
+    global $pdo;
 
     // Get all admins with the corresponding notification enabled
     $notification_column = ($type === 'new_post') ? 'notify_new_posts' : 'notify_new_comments';
 
-    $stmt = $db->prepare("SELECT u.username, ans.notification_email
+    $stmt = $pdo->prepare("SELECT u.username, ans.notification_email
                          FROM admin_notification_settings ans
                          JOIN community_users u ON ans.user_id = u.id
                          WHERE u.role = 'admin' AND ans.$notification_column = 1");
     $stmt->execute();
-    $result = $stmt->get_result();
-
-    $recipients = [];
-    while ($row = $result->fetch_assoc()) {
-        $recipients[] = $row;
-    }
-
-    $stmt->close();
+    $recipients = $stmt->fetchAll();
 
     // If no admins have notifications enabled, exit early
     if (empty($recipients)) {

--- a/pricing/premium/checkout/process-subscription.php
+++ b/pricing/premium/checkout/process-subscription.php
@@ -507,7 +507,9 @@ try {
     }
 
 } catch (PDOException $e) {
-    $pdo->rollBack();
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     error_log("Premium Subscription Error: " . $e->getMessage());
     http_response_code(500);
     echo json_encode([

--- a/statistics.php
+++ b/statistics.php
@@ -8,7 +8,7 @@ require_once 'db_connect.php';
 
 /**
  * Track a statistical event
- * 
+ *
  * @param string $event_type Type of event (download, page_view, etc.)
  * @param string $event_data Additional event data
  * @return bool Success status
@@ -20,60 +20,53 @@ function track_event($event_type, $event_data = '')
         return false;
     }
 
-    $db = get_db_connection();
+    global $pdo;
     $ip_address = $_SERVER['REMOTE_ADDR'];
     $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
-    // Only record one occurrence of an event per IP per day
-    $today_start = date('Y-m-d 00:00:00');
-    $exists_stmt = $db->prepare('SELECT 1 FROM statistics WHERE event_type = ? AND event_data = ? AND ip_address = ? AND created_at >= ? LIMIT 1');
-    $exists_stmt->bind_param('ssss', $event_type, $event_data, $ip_address, $today_start);
-    $exists_stmt->execute();
-    $exists_result = $exists_stmt->get_result();
-    if ($exists_result->num_rows > 0) {
-        $exists_stmt->close();
-        return false;
-    }
-    $exists_stmt->close();
+    try {
+        // Only record one occurrence of an event per IP per day
+        $today_start = date('Y-m-d 00:00:00');
+        $exists_stmt = $pdo->prepare('SELECT 1 FROM statistics WHERE event_type = ? AND event_data = ? AND ip_address = ? AND created_at >= ? LIMIT 1');
+        $exists_stmt->execute([$event_type, $event_data, $ip_address, $today_start]);
+        if ($exists_stmt->fetch() !== false) {
+            return false;
+        }
 
-    $country_code = null;
+        $country_code = null;
 
-    // Check if we already have this IP's country code in our database
-    $check_stmt = $db->prepare('SELECT country_code FROM statistics WHERE ip_address = ? AND country_code IS NOT NULL AND country_code != "" LIMIT 1');
-    $check_stmt->bind_param('s', $ip_address);
-    $check_stmt->execute();
-    $check_result = $check_stmt->get_result();
+        // Check if we already have this IP's country code in our database
+        $check_stmt = $pdo->prepare('SELECT country_code FROM statistics WHERE ip_address = ? AND country_code IS NOT NULL AND country_code != "" LIMIT 1');
+        $check_stmt->execute([$ip_address]);
+        $row = $check_stmt->fetch();
 
-    if ($check_result->num_rows > 0) {
-        // We already have this IP's country code
-        $row = $check_result->fetch_assoc();
-        $country_code = $row['country_code'];
-        $check_stmt->close();
-    } else {
-        $check_stmt->close();
+        if ($row !== false) {
+            // We already have this IP's country code
+            $country_code = $row['country_code'];
+        } else {
+            // New IP or no country code yet, use cURL to contact the API
+            if (function_exists('curl_init')) {
+                $ch = curl_init("https://ipinfo.io/{$ip_address}/country");
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+                curl_setopt($ch, CURLOPT_USERAGENT, 'ArgoSalesTracker/1.0');
+                $response = curl_exec($ch);
+                $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        // New IP or no country code yet, use cURL to contact the API
-        if (function_exists('curl_init')) {
-            $ch = curl_init("https://ipinfo.io/{$ip_address}/country");
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_TIMEOUT, 3);
-            curl_setopt($ch, CURLOPT_USERAGENT, 'ArgoSalesTracker/1.0');
-            $response = curl_exec($ch);
-            $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-            if ($http_code == 200 && !empty($response)) {
-                $country_code = trim($response);
+                if ($http_code == 200 && !empty($response)) {
+                    $country_code = trim($response);
+                }
             }
         }
+
+        // Insert event
+        $stmt = $pdo->prepare('INSERT INTO statistics (event_type, event_data, ip_address, user_agent, country_code) VALUES (?, ?, ?, ?, ?)');
+        $result = $stmt->execute([$event_type, $event_data, $ip_address, $user_agent, $country_code]);
+
+        return $result;
+    } catch (PDOException $e) {
+        return false;
     }
-
-    // Insert event
-    $stmt = $db->prepare('INSERT INTO statistics (event_type, event_data, ip_address, user_agent, country_code) VALUES (?, ?, ?, ?, ?)');
-    $stmt->bind_param('sssss', $event_type, $event_data, $ip_address, $user_agent, $country_code);
-    $result = $stmt->execute();
-    $stmt->close();
-
-    return $result;
 }
 
 /**
@@ -101,7 +94,7 @@ function track_referral_visit($source_code, $page_url = '')
         return false;
     }
 
-    $db = get_db_connection();
+    global $pdo;
     $ip_address = $_SERVER['REMOTE_ADDR'];
     $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
@@ -110,54 +103,46 @@ function track_referral_visit($source_code, $page_url = '')
         $_SESSION['referral_source'] = $source_code;
     }
 
-    // Check if this IP already visited from this source today
-    $today_start = date('Y-m-d 00:00:00');
-    $exists_stmt = $db->prepare('SELECT 1 FROM referral_visits WHERE source_code = ? AND ip_address = ? AND visited_at >= ? LIMIT 1');
-    $exists_stmt->bind_param('sss', $source_code, $ip_address, $today_start);
-    $exists_stmt->execute();
-    $exists_result = $exists_stmt->get_result();
-    if ($exists_result->num_rows > 0) {
-        $exists_stmt->close();
-        return false; // Already tracked this IP for this source today
-    }
-    $exists_stmt->close();
+    try {
+        // Check if this IP already visited from this source today
+        $today_start = date('Y-m-d 00:00:00');
+        $exists_stmt = $pdo->prepare('SELECT 1 FROM referral_visits WHERE source_code = ? AND ip_address = ? AND visited_at >= ? LIMIT 1');
+        $exists_stmt->execute([$source_code, $ip_address, $today_start]);
+        if ($exists_stmt->fetch() !== false) {
+            return false; // Already tracked this IP for this source today
+        }
 
-    $country_code = null;
+        $country_code = null;
 
-    // Check if we already have this IP's country code
-    $check_stmt = $db->prepare('SELECT country_code FROM referral_visits WHERE ip_address = ? AND country_code IS NOT NULL AND country_code != "" LIMIT 1');
-    $check_stmt->bind_param('s', $ip_address);
-    $check_stmt->execute();
-    $check_result = $check_stmt->get_result();
+        // Check if we already have this IP's country code
+        $check_stmt = $pdo->prepare('SELECT country_code FROM referral_visits WHERE ip_address = ? AND country_code IS NOT NULL AND country_code != "" LIMIT 1');
+        $check_stmt->execute([$ip_address]);
+        $row = $check_stmt->fetch();
 
-    if ($check_result->num_rows > 0) {
-        $row = $check_result->fetch_assoc();
-        $country_code = $row['country_code'];
-        $check_stmt->close();
-    } else {
-        $check_stmt->close();
+        if ($row !== false) {
+            $country_code = $row['country_code'];
+        } else {
+            // New IP, get country code from API
+            if (function_exists('curl_init')) {
+                $ch = curl_init("https://ipinfo.io/{$ip_address}/country");
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+                curl_setopt($ch, CURLOPT_USERAGENT, 'ArgoSalesTracker/1.0');
+                $response = curl_exec($ch);
+                $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        // New IP, get country code from API
-        if (function_exists('curl_init')) {
-            $ch = curl_init("https://ipinfo.io/{$ip_address}/country");
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_TIMEOUT, 3);
-            curl_setopt($ch, CURLOPT_USERAGENT, 'ArgoSalesTracker/1.0');
-            $response = curl_exec($ch);
-            $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-            if ($http_code == 200 && !empty($response)) {
-                $country_code = trim($response);
+                if ($http_code == 200 && !empty($response)) {
+                    $country_code = trim($response);
+                }
             }
         }
+
+        // Insert referral visit
+        $stmt = $pdo->prepare('INSERT INTO referral_visits (source_code, page_url, ip_address, user_agent, country_code) VALUES (?, ?, ?, ?, ?)');
+        $result = $stmt->execute([$source_code, $page_url, $ip_address, $user_agent, $country_code]);
+
+        return $result;
+    } catch (PDOException $e) {
+        return false;
     }
-
-    // Insert referral visit
-    $stmt = $db->prepare('INSERT INTO referral_visits (source_code, page_url, ip_address, user_agent, country_code) VALUES (?, ?, ?, ?, ?)');
-    $stmt->bind_param('sssss', $source_code, $page_url, $ip_address, $user_agent, $country_code);
-    $result = $stmt->execute();
-    $stmt->close();
-
-    return $result;
 }
-

--- a/statistics.php
+++ b/statistics.php
@@ -21,6 +21,9 @@ function track_event($event_type, $event_data = '')
     }
 
     global $pdo;
+    if (!$pdo) {
+        return false;
+    }
     $ip_address = $_SERVER['REMOTE_ADDR'];
     $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
@@ -98,9 +101,13 @@ function track_referral_visit($source_code, $page_url = '')
     $ip_address = $_SERVER['REMOTE_ADDR'];
     $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
-    // Store source in session for conversion tracking
+    // Store source in session for conversion tracking (runs even if DB is down)
     if (!isset($_SESSION['referral_source'])) {
         $_SESSION['referral_source'] = $source_code;
+    }
+
+    if (!$pdo) {
+        return false;
     }
 
     try {


### PR DESCRIPTION
## Summary

Full migration of the codebase from the `mysqli` API to PDO. Removes the two-interface split documented in CLAUDE.md — `get_db_connection()` is deleted from `db_connect.php` and every callsite now uses the global `$pdo`.

**Stacked on #300** — base is `audit-cleanup`, which depends on the helpers and `env()`/`site_url()` work there. GitHub will auto-retarget this to `main` when #300 merges.

## What changed

- **51 files converted**: `admin/*`, `community/*`, `api/portal/*`, `api/portal/webhooks/*`, `api/google/*`, plus `statistics.php`, `config/pricing.php`, `email_sender.php`, and the three previously-mixed-interface files (`portal-helper.php`, `register.php`, `community/users/user_functions.php`).
- **`get_db_connection()` deleted** from `db_connect.php`.
- **CLAUDE.md updated**: the "Database Access — Two Interfaces" section is replaced by a concise "Database Access" section documenting PDO-only conventions; the mysqli entry is removed from "Known Deferred Refactors" (only the relative-path include refactor remains there).

## Conversion rules applied (mechanically)

| mysqli | PDO |
|---|---|
| `get_db_connection()` at top-level | removed (`$pdo` is in scope from `require_once db_connect.php`) |
| `get_db_connection()` inside a function | `global $pdo;` |
| `$db->prepare(...)` | `$pdo->prepare(...)` |
| `bind_param('sii', $a, $b, $c) + execute()` | `execute([$a, $b, $c])` |
| `get_result()->fetch_assoc()` | `fetch()` |
| `get_result()->fetch_all(MYSQLI_ASSOC)` | `fetchAll()` |
| `$result->num_rows > 0` on SELECT | fetch + `!== false`, or `fetchColumn()` for COUNT |
| `$stmt->close()` / `$db->close()` | removed |
| `$stmt->insert_id` | `$pdo->lastInsertId()` |
| `$stmt->affected_rows` | `$stmt->rowCount()` |
| `begin_transaction` / `rollback` | `beginTransaction` / `rollBack` (capital B) |

## Error handling

PDO throws `PDOException` by default (`ERRMODE_EXCEPTION` is set in `db_connect.php`). Callers that previously checked `$stmt === false` or `execute() === false` are either simplified (exceptions bubble) or wrapped in try/catch where a specific user-facing error message was needed. `statistics.php` explicitly preserves its fail-silent behavior with try/catch around its DB calls so a DB outage doesn't 500 every page.

## Net diff

- **+924 insertions, −1657 deletions** (net ~−730 lines)
- The multi-line mysqli boilerplate (`prepare → bind_param → execute → get_result → fetch_assoc → close`) collapses to two PDO calls (`prepare → execute`).

## Noteworthy conversions

- **`api/portal/connect-callback.php`** — handler functions accept PDO as a typed parameter (`PDO $db`) rather than switching to `global $pdo` inside each. Smaller diff, no functional difference.
- **`api/portal/portal-helper.php::record_portal_payment`** — preserves the `ON DUPLICATE KEY UPDATE` duplicate-detection logic (`rowCount() == 1` means insert, `== 2` means duplicate found) which is PDO_MYSQL-specific.
- **`api/portal/register.php`** — API-key rotation path wrapped in try/catch to preserve the exact 500 error response on DB failure.
- **`cron/subscription_renewal.php` on `audit-cleanup`** already had a clean PDO transaction; untouched here.

## Bugs caught during pre-commit review and fixed

Three regressions introduced by subagent conversion were caught and fixed before commit:

- `community/mentions/mentions.php`, `community/view_post.php`, `community/post_history.php` used `$result->rowCount()` after `SHOW TABLES` / `SHOW COLUMNS` to test existence. `rowCount()` on SELECT-style queries is unreliable on PDO_MYSQL with `ATTR_EMULATE_PREPARES => false`; changed to `$result->fetch() !== false`.

## Test plan

- [ ] Admin login (5-attempt rate limit, 2FA verification, last-login update all work)
- [ ] Community: create a post, add a comment, vote, edit post, delete comment, view profile, edit profile, password reset
- [ ] Portal: register a company, publish an invoice, view an invoice, process a payment, sync payments
- [ ] Payment webhooks: Stripe, PayPal, Square — confirm payments get recorded idempotently
- [ ] Google OAuth flow end-to-end (initiate → callback → tokens stored)
- [ ] Hit a normal marketing page and confirm `statistics.php` records the view without issues
- [ ] `grep -rn "get_db_connection\|bind_param\|get_result\|fetch_assoc" --include="*.php" .` returns 0 matches
- [ ] `php -l` on every modified file (or equivalent via CI) returns no syntax errors
