### PR TITLE
Guard rollBack() with inTransaction() in two catch blocks

### DIFF
--- a/cron/account_purge.php
+++ b/cron/account_purge.php
@@ -95,7 +95,9 @@ try {
             $deletedCount++;
 
         } catch (Exception $e) {
-            $pdo->rollBack();
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
             logPurge("Failed to delete account $username (#$userId): " . $e->getMessage(), 'ERROR');
             $failedCount++;
         }

--- a/pricing/premium/checkout/process-subscription.php
+++ b/pricing/premium/checkout/process-subscription.php
@@ -507,7 +507,9 @@ try {
     }
 
 } catch (PDOException $e) {
-    $pdo->rollBack();
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     error_log("Premium Subscription Error: " . $e->getMessage());
     http_response_code(500);
     echo json_encode([


### PR DESCRIPTION
## Summary

PDO's `rollBack()` throws a `PDOException` when called with no active transaction. Two existing catch blocks were calling it unconditionally:

- **`pricing/premium/checkout/process-subscription.php`** — outer `catch (PDOException)` at the end of the subscription-creation flow. In today's code, the inner provider-specific catches call `rollBack()` and `exit()` before reaching this, so the unguarded call isn't hit in practice. But if a `PDOException` leaks from anywhere in the outer try _before_ `beginTransaction()` completes, the rollBack throws a secondary exception that masks the original.

- **`cron/account_purge.php`** — per-user delete catch inside the daily account-purge loop. The inner try wraps `UPDATE` + `DELETE` + `commit`. If `beginTransaction()` itself fails (connection blip mid-batch, locked rows, etc.), the catch would call `rollBack()` on a non-active transaction, throw, and abort the whole loop instead of just skipping this user and continuing.

Both fixes are the same one-line pattern — wrap the `rollBack()` in `if (\$pdo->inTransaction())` so only genuinely-active transactions get rolled back.

## Origin

Surfaced by Copilot and our own review during PRs #300 / #301. Unrelated to the audit-cleanup / mysqli→PDO work in those PRs, so landing here as its own small change against `main`.

## Test plan

- [ ] With subscription-checkout: deliberately throw a PDOException before `beginTransaction()` (e.g., by breaking an earlier query) — confirm outer catch returns the friendly 500 message instead of a secondary exception.
- [ ] With account_purge: inject a simulated connection failure during the per-user loop — confirm the loop continues to the next user instead of aborting.
- [ ] Normal paths: verify subscription creation and account purge still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)