### PR TITLE
Outreach A/B: extend testing across all variant types

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -39,6 +39,7 @@ $base_path = $in_subdir ? '../' : '';
     </script>
     <script src="<?php echo $base_path; ?>../resources/notifications/notifications.js" defer></script>
     <script src="<?php echo $base_path; ?>pagination.js" defer></script>
+    <script src="<?php echo $base_path; ?>section-tabs.js" defer></script>
 
     <link rel="stylesheet" href="<?php echo $base_path; ?>common-style.css">
     <link rel="stylesheet" href="<?php echo $base_path; ?>../resources/styles/link.css">

--- a/admin/app-stats/index.php
+++ b/admin/app-stats/index.php
@@ -234,57 +234,7 @@ include __DIR__ . '/../admin_header.php';
     margin-bottom: 2rem;
 }
 
-.tab-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin-bottom: 1.5rem;
-    border-bottom: 2px solid #e5e7eb;
-    padding-bottom: 0;
-    justify-content: center;
-}
-
-.tab-button {
-    padding: 12px 20px;
-    background: #f9fafb;
-    border: 1px solid #d1d5db;
-    border-bottom: none;
-    cursor: pointer;
-    font-size: 14px;
-    font-weight: 500;
-    color: #6b7280;
-    border-radius: 8px 8px 0 0;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-}
-
-.tab-button:hover {
-    background: #f3f4f6;
-    color: #374151;
-}
-
-.tab-button.active {
-    background: white;
-    color: #1f2937;
-    border-color: #9ca3af;
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
-    margin-bottom: -2px;
-    border-bottom: 2px solid white;
-}
-
-.tab-content {
-    display: none;
-    animation: fadeIn 0.3s ease-in-out;
-}
-
-.tab-content.active {
-    display: block;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
+/* Tab styles are shared across admin pages — see admin/common-style.css */
 
 .stats-grid {
     display: grid;
@@ -337,11 +287,11 @@ include __DIR__ . '/../admin_header.php';
 }
 
 @media (max-width: 768px) {
-    .tab-buttons {
+    .section-tabs {
         gap: 2px;
     }
 
-    .tab-button {
+    .section-tab {
         padding: 10px 14px;
         font-size: 13px;
     }
@@ -443,20 +393,20 @@ include __DIR__ . '/../admin_header.php';
         </div>
 
         <div class="tabs-container">
-            <div class="tab-buttons">
-                <div class="tab-button active" onclick="switchTab('active-users')">Active Users</div>
+            <div class="section-tabs">
+                <button class="section-tab active" data-tab="active-users">Active Users</button>
                 <?php if ($aggregatedData['geoLocationEnabled']): ?>
-                <div class="tab-button" onclick="switchTab('geographic')">Geographic</div>
+                <button class="section-tab" data-tab="geographic">Geographic</button>
                 <?php endif; ?>
-                <div class="tab-button" onclick="switchTab('versions')">Versions</div>
-                <div class="tab-button" onclick="switchTab('features')">Features</div>
-                <div class="tab-button" onclick="switchTab('errors')">Errors</div>
-                <div class="tab-button" onclick="switchTab('usage')">Usage</div>
-                <div class="tab-button" onclick="switchTab('api')">API Usage</div>
+                <button class="section-tab" data-tab="versions">Versions</button>
+                <button class="section-tab" data-tab="features">Features</button>
+                <button class="section-tab" data-tab="errors">Errors</button>
+                <button class="section-tab" data-tab="usage">Usage</button>
+                <button class="section-tab" data-tab="api">API Usage</button>
             </div>
 
             <!-- Active Users Tab -->
-            <div id="active-users-tab" class="tab-content active">
+            <div id="active-users" class="tab-content active">
                 <h2 class="section-title">Active Users</h2>
 
                 <div class="stats-grid" id="activeUsersKpiGrid">
@@ -532,7 +482,7 @@ include __DIR__ . '/../admin_header.php';
 
             <!-- Geographic Tab -->
             <?php if ($aggregatedData['geoLocationEnabled']): ?>
-            <div id="geographic-tab" class="tab-content">
+            <div id="geographic" class="tab-content">
                 <h2 class="section-title">Geographic Analytics</h2>
                 
                 <div class="chart-row">
@@ -571,7 +521,7 @@ include __DIR__ . '/../admin_header.php';
             <?php endif; ?>
 
             <!-- Versions Tab -->
-            <div id="versions-tab" class="tab-content">
+            <div id="versions" class="tab-content">
                 <h2 class="section-title">Version Analytics</h2>
 
                 <div class="chart-row">
@@ -605,7 +555,7 @@ include __DIR__ . '/../admin_header.php';
             </div>
 
             <!-- Features Tab -->
-            <div id="features-tab" class="tab-content">
+            <div id="features" class="tab-content">
                 <h2 class="section-title">Feature Usage Analytics</h2>
 
                 <div class="chart-row">
@@ -624,7 +574,7 @@ include __DIR__ . '/../admin_header.php';
             </div>
 
             <!-- Errors Tab -->
-            <div id="errors-tab" class="tab-content">
+            <div id="errors" class="tab-content">
                 <h2 class="section-title">Error Analysis</h2>
 
                 <div class="chart-row">
@@ -652,7 +602,7 @@ include __DIR__ . '/../admin_header.php';
             </div>
 
             <!-- Usage Tab -->
-            <div id="usage-tab" class="tab-content">
+            <div id="usage" class="tab-content">
                 <h2 class="section-title">Usage Analytics</h2>
 
                 <div class="chart-row">
@@ -679,7 +629,7 @@ include __DIR__ . '/../admin_header.php';
             </div>
 
             <!-- API Usage Tab -->
-            <div id="api-tab" class="tab-content">
+            <div id="api" class="tab-content">
                 <h2 class="section-title">API Usage</h2>
 
                 <div class="chart-row">
@@ -765,30 +715,7 @@ include __DIR__ . '/../admin_header.php';
 </div>
 
 <script>
-// Tab switching functionality
-function switchTab(tabName) {
-    // Hide all tab contents
-    const tabContents = document.querySelectorAll('.tab-content');
-    tabContents.forEach(content => {
-        content.classList.remove('active');
-    });
-    
-    // Remove active class from all tab buttons
-    const tabButtons = document.querySelectorAll('.tab-button');
-    tabButtons.forEach(button => {
-        button.classList.remove('active');
-    });
-    
-    // Show selected tab content
-    const selectedTab = document.getElementById(tabName + '-tab');
-    if (selectedTab) {
-        selectedTab.classList.add('active');
-    }
-    
-    // Add active class to clicked button
-    event.target.classList.add('active');
-}
-
+// Tab switching is handled centrally by admin/section-tabs.js
 // Pass PHP data to JavaScript
 window.dashboardData = <?= $jsonData ?>;
 </script>

--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -601,6 +601,7 @@ tbody tr:hover {
 
 .alert-success,
 .success-message {
+  text-align: center;
   background: var(--emerald-100);
   color: var(--emerald-800);
   border-color: var(--emerald-500);
@@ -1424,28 +1425,6 @@ tbody tr:hover {
   box-shadow: 0 1px 3px var(--overlay-light);
 }
 
-/* Dark theme - Tab buttons (payments, license) */
-[data-theme="dark"] .tab-buttons {
-  border-bottom-color: var(--gray-text-dark);
-}
-
-[data-theme="dark"] .tab-button {
-  background: var(--gray-800);
-  border-color: var(--gray-text-dark);
-  color: var(--gray-400);
-}
-
-[data-theme="dark"] .tab-button:hover {
-  background: var(--gray-700);
-  color: var(--gray-200);
-}
-
-[data-theme="dark"] .tab-button.active {
-  background: var(--gray-text-darker);
-  color: var(--gray-100);
-  box-shadow: 0 -2px 8px var(--overlay-light);
-}
-
 [data-theme="dark"] .section-tabs {
   border-bottom-color: var(--gray-text-dark);
 }
@@ -2007,5 +1986,76 @@ tbody tr:hover {
 [data-theme="dark"] .pg-num.pg-active {
   background: var(--blue-primary, #3b82f6);
   color: #fff;
+}
+
+
+/* ══════════════════════════════════════════════════════════════════════
+   Section tabs — shared page-level tab style for all admin pages.
+   Markup:
+       <div class="section-tabs">
+           <button class="section-tab active" data-tab="foo">Foo</button>
+           <button class="section-tab"         data-tab="bar">Bar</button>
+       </div>
+       <div id="foo" class="tab-content active">...</div>
+       <div id="bar" class="tab-content">...</div>
+   Behaviour is handled by admin/section-tabs.js.
+   ══════════════════════════════════════════════════════════════════════ */
+
+.section-tabs {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 30px;
+    border-bottom: 2px solid var(--gray-border);
+    padding-bottom: 0;
+}
+
+.section-tab {
+    padding: 12px 24px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--gray-text);
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.2s, border-color 0.2s;
+    font-family: inherit;
+}
+
+.section-tab:hover {
+    color: var(--gray-text-dark);
+}
+
+.section-tab.active {
+    color: var(--primary-blue);
+    border-bottom-color: var(--primary-blue);
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+[data-theme="dark"] .section-tabs {
+    border-bottom-color: var(--gray-700);
+}
+
+[data-theme="dark"] .section-tab {
+    color: var(--gray-400);
+}
+
+[data-theme="dark"] .section-tab:hover {
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .section-tab.active {
+    color: var(--primary-blue);
+    border-bottom-color: var(--primary-blue);
 }
 

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -822,37 +822,7 @@ function copyToClipboard(text, btn) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Tab switching
-    const tabs = document.querySelectorAll('.section-tab');
-    const contents = document.querySelectorAll('.tab-content');
-
-    // Check URL hash for active tab
-    const hash = window.location.hash.substring(1);
-    if (hash) {
-        tabs.forEach(t => t.classList.remove('active'));
-        contents.forEach(c => c.classList.remove('active'));
-
-        const targetTab = document.querySelector(`[data-tab="${hash}"]`);
-        const targetContent = document.getElementById(hash);
-        if (targetTab && targetContent) {
-            targetTab.classList.add('active');
-            targetContent.classList.add('active');
-        }
-    }
-
-    tabs.forEach(tab => {
-        tab.addEventListener('click', function() {
-            const target = this.dataset.tab;
-
-            tabs.forEach(t => t.classList.remove('active'));
-            contents.forEach(c => c.classList.remove('active'));
-
-            this.classList.add('active');
-            document.getElementById(target).classList.add('active');
-
-            history.replaceState(null, null, '#' + target);
-        });
-    });
+    // Tab switching is handled centrally by admin/section-tabs.js
 
     // Subscription Key Bulk Selection
     const subKeySelectAll = document.getElementById('sub-key-select-all');

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -1,35 +1,5 @@
-.section-tabs {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 30px;
-    border-bottom: 2px solid var(--gray-border);
-    padding-bottom: 0;
-}
-.section-tab {
-    padding: 12px 24px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 1rem;
-    font-weight: 500;
-    color: var(--gray-text);
-    border-bottom: 3px solid transparent;
-    margin-bottom: -2px;
-    transition: all 0.2s;
-}
-.section-tab:hover {
-    color: var(--gray-text-dark);
-}
-.section-tab.active {
-    color: var(--primary-blue);
-    border-bottom-color: var(--primary-blue);
-}
-.tab-content {
-    display: none;
-}
-.tab-content.active {
-    display: block;
-}
+/* Section-tab styles are now shared across admin pages — see admin/common-style.css */
+
 table th {
     white-space: nowrap;
 }

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -191,7 +191,8 @@ function get_leads($pdo)
     ];
     $orderBy = $orderMap[$sort] ?? 'ol.date_added DESC';
 
-    $stmt = $pdo->prepare("SELECT ol.*, MIN(rv.visited_at) AS clicked_at FROM outreach_leads ol LEFT JOIN referral_visits rv ON rv.source_code = CONCAT('outreach-', ol.id) $whereClause GROUP BY ol.id ORDER BY $orderBy");
+    // Match both legacy source codes ("outreach-42") and A/B-tagged ones ("outreach-42-v7")
+    $stmt = $pdo->prepare("SELECT ol.*, MIN(rv.visited_at) AS clicked_at FROM outreach_leads ol LEFT JOIN referral_visits rv ON (rv.source_code = CONCAT('outreach-', ol.id) OR rv.source_code LIKE CONCAT('outreach-', ol.id, '-v%')) $whereClause GROUP BY ol.id ORDER BY $orderBy");
     $stmt->execute($params);
     $leads = $stmt->fetchAll();
 
@@ -365,7 +366,9 @@ function get_stats($pdo)
         SUM(status = 'interested') as interested
     FROM outreach_leads")->fetch();
 
-    $rows['clicked'] = $pdo->query("SELECT COUNT(DISTINCT rv.source_code) FROM referral_visits rv WHERE rv.source_code LIKE 'outreach-%'")->fetchColumn();
+    // Count distinct leads clicked. SUBSTRING_INDEX collapses "outreach-42-v7" → "outreach-42"
+    // so a lead that received multiple variants and had any of them clicked counts once.
+    $rows['clicked'] = $pdo->query("SELECT COUNT(DISTINCT SUBSTRING_INDEX(rv.source_code, '-v', 1)) FROM referral_visits rv WHERE rv.source_code LIKE 'outreach-%'")->fetchColumn();
 
     json_response([
         'success' => true,
@@ -520,8 +523,21 @@ function send_outreach_email($pdo)
         json_response(['success' => false, 'message' => 'No draft to send'], 400);
     }
 
+    // Guard against re-sending to the same lead. Cold-outreach resends are
+    // a spam-filter red flag and we never want this to happen by accident,
+    // whether from the detail modal, the bulk-send flow, or a stray API call.
+    if (!empty($lead['sent_at'])) {
+        json_response([
+            'success' => false,
+            'message' => 'This lead was already emailed on ' . $lead['sent_at'] . '. Outreach does not resend to the same address.'
+        ], 409);
+    }
+
     if (send_outreach_lead($pdo, $lead)) {
-        log_activity($pdo, $id, 'email_sent', 'Outreach email sent to: ' . $lead['email']);
+        $variantTag = !empty($lead['ab_variant_id'])
+            ? ' [A/B test #' . (int) $lead['ab_test_id'] . ', variant #' . (int) $lead['ab_variant_id'] . ']'
+            : '';
+        log_activity($pdo, $id, 'email_sent', 'Outreach email sent to: ' . $lead['email'] . $variantTag);
         json_response(['success' => true, 'message' => 'Email sent successfully']);
     } else {
         log_activity($pdo, $id, 'email_failed', 'Email send failed for: ' . $lead['email']);

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -252,7 +252,7 @@ include __DIR__ . '/../admin_header.php';
     <div class="bulk-draft-progress" id="bulkDraftProgress" style="display:none;">
         <span class="bulk-draft-spinner"></span>
         <span id="bulkDraftProgressText"></span>
-        <button class="btn btn-small" id="btnCancelDraft" onclick="cancelBulkDrafts()" style="margin-left:8px;">Cancel</button>
+        <button class="btn btn-small btn-neutral" id="btnCancelDraft" onclick="cancelBulkDrafts()" style="margin-left:8px;">Cancel</button>
     </div>
 
     <!-- Leads Table -->

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -13,6 +13,27 @@ if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
 
+// Tab partials (load render + POST handlers)
+require_once __DIR__ . '/tabs/ab-tests.php';
+require_once __DIR__ . '/tabs/settings.php';
+
+// Dispatch POST submissions from tab-specific forms BEFORE any output so
+// redirects via header() still work.
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['tab'])) {
+    $postTab = $_POST['tab'];
+    if ($postTab === 'ab-tests') {
+        ab_tests_tab_handle_post($pdo);
+    } elseif ($postTab === 'settings') {
+        settings_tab_handle_post($pdo);
+    }
+}
+
+// Determine active tab from ?tab=
+$activeTab = $_GET['tab'] ?? 'leads';
+if (!in_array($activeTab, ['leads', 'ab-tests', 'settings'], true)) {
+    $activeTab = 'leads';
+}
+
 // Set page variables for the header
 $page_title = "Business Outreach";
 $page_description = "Find local businesses, generate outreach emails, and track leads";
@@ -24,6 +45,15 @@ include __DIR__ . '/../admin_header.php';
 <meta name="csrf-token" content="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
 <link rel="stylesheet" href="style.css">
 <link rel="stylesheet" href="../../resources/styles/checkbox.css">
+
+<!-- Page-level tabs -->
+<div class="section-tabs">
+    <button class="section-tab <?php echo $activeTab === 'leads' ? 'active' : ''; ?>" data-tab="leads">Leads</button>
+    <button class="section-tab <?php echo $activeTab === 'ab-tests' ? 'active' : ''; ?>" data-tab="ab-tests">A/B Tests</button>
+    <button class="section-tab <?php echo $activeTab === 'settings' ? 'active' : ''; ?>" data-tab="settings">Settings</button>
+</div>
+
+<div id="leads" class="tab-content <?php echo $activeTab === 'leads' ? 'active' : ''; ?>">
 
 <!-- Pipeline Running Banner -->
 <div id="pipelineBanner" style="display:none; background:#fff3cd; color:#856404; border:1px solid #ffc107; border-radius:6px; padding:12px 16px; margin-bottom:16px; font-weight:500;">
@@ -240,6 +270,16 @@ include __DIR__ . '/../admin_header.php';
             </tbody>
         </table>
     </div>
+</div>
+
+</div> <!-- /#leads -->
+
+<div id="ab-tests" class="tab-content <?php echo $activeTab === 'ab-tests' ? 'active' : ''; ?>">
+    <?php ab_tests_tab_render($pdo, (int) ($_GET['test_id'] ?? 0)); ?>
+</div>
+
+<div id="settings" class="tab-content <?php echo $activeTab === 'settings' ? 'active' : ''; ?>">
+    <?php settings_tab_render($pdo); ?>
 </div>
 
 <!-- Lead Detail Modal -->

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -18,8 +18,16 @@ require_once __DIR__ . '/tabs/ab-tests.php';
 require_once __DIR__ . '/tabs/settings.php';
 
 // Dispatch POST submissions from tab-specific forms BEFORE any output so
-// redirects via header() still work.
+// redirects via header() still work. CSRF: every state-changing tab form
+// must include the session csrf_token; reject anything that doesn't match.
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['tab'])) {
+    $postedToken = $_POST['csrf_token'] ?? '';
+    $sessionToken = $_SESSION['csrf_token'] ?? '';
+    if (!$sessionToken || !$postedToken || !hash_equals($sessionToken, $postedToken)) {
+        $_SESSION['message'] = 'Session expired or invalid request token. Please try again.';
+        $_SESSION['message_type'] = 'error';
+        header('Location: index.php?tab=' . urlencode($_POST['tab'])); exit;
+    }
     $postTab = $_POST['tab'];
     if ($postTab === 'ab-tests') {
         ab_tests_tab_handle_post($pdo);

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -558,8 +558,8 @@ async function openLeadDetail(id) {
         document.getElementById('draftBody').value = lead.draft_body || '';
         updateDraftStatus(lead);
 
-        // Reset to info tab
-        switchTab('tabInfo', document.querySelector('.tab'));
+        // Reset to info tab (scope to the modal — the page now has its own .tab bar)
+        switchTab('tabInfo', document.querySelector('#leadDetailModal .tab'));
 
         // Load activity
         loadActivity(id);
@@ -1111,11 +1111,18 @@ document.addEventListener('keydown', function (e) {
     }
 });
 
-// ─── Tab Switching ───
+// ─── Modal tab switching (Info / Email Draft / Activity inside the lead-detail modal) ───
+// Page-level tabs are handled by admin/section-tabs.js. This function is only
+// for the modal's inner tabs (.tabs inside .modal-body) and is scoped to its
+// own container so it doesn't clobber the page-level section-tabs.
 function switchTab(tabId, btn) {
-    document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.getElementById(tabId).classList.add('active');
+    const tabsContainer = btn.closest('.tabs');
+    if (!tabsContainer) return;
+    const scope = tabsContainer.parentElement;
+    scope.querySelectorAll(':scope > .tab-content').forEach(t => t.classList.remove('active'));
+    tabsContainer.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    const target = document.getElementById(tabId);
+    if (target) target.classList.add('active');
     btn.classList.add('active');
 }
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -707,11 +707,12 @@ async function createLead() {
 
     try {
         const result = await api('create_lead', { method: 'POST', body: data });
-        notify(result.message, result.success ? 'success' : 'error');
         if (result.success) {
             closeModal('addLeadModal');
             loadLeads();
             loadStats();
+        } else {
+            notify(result.message, 'error');
         }
     } catch (e) {
         notify(e.message, 'error');
@@ -968,12 +969,12 @@ async function sendEmail() {
         const result = await api('send_email', { method: 'POST', body: { id: currentLeadId } });
         btn.textContent = 'Send Email';
 
-        notify(result.message, result.success ? 'success' : 'error');
         if (result.success) {
             openLeadDetail(currentLeadId);
             loadLeads();
             loadStats();
         } else {
+            notify(result.message, 'error');
             btn.disabled = false;
         }
     } catch (e) {

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -962,10 +962,30 @@
     cursor: pointer;
 }
 
+/* Neutral (no-color-modifier) button used inside the A/B create form. */
+.btn-neutral {
+    background: var(--white);
+    color: var(--gray-700);
+    border: 1px solid var(--gray-border);
+}
+
+.btn-neutral:hover {
+    background: var(--gray-100, #f3f4f6);
+    color: var(--gray-800);
+}
+
 .variant-remove {
+    width: auto;
+    min-width: 0;
     padding: 2px 10px;
     font-size: 16px;
     line-height: 1;
+}
+
+.variant-remove:hover {
+    color: #dc2626;
+    border-color: #dc2626;
+    background: var(--white);
 }
 
 .variant-content-cell {
@@ -1241,4 +1261,21 @@
 
 [data-theme="dark"] .hint {
     color: var(--gray-400);
+}
+
+[data-theme="dark"] .btn-neutral {
+    background: var(--gray-800);
+    color: var(--gray-200);
+    border-color: var(--gray-700);
+}
+
+[data-theme="dark"] .btn-neutral:hover {
+    background: var(--gray-700);
+    color: var(--gray-100);
+}
+
+[data-theme="dark"] .variant-remove:hover {
+    color: #f87171;
+    border-color: #f87171;
+    background: var(--gray-800);
 }

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -889,3 +889,356 @@
 [data-theme="dark"] .discovery-table-wrapper::-webkit-scrollbar-thumb:hover {
     background: var(--gray-500);
 }
+
+
+/* ══════════════════════════════════════════════════════════════════════
+   A/B Tests + Settings tabs (migrated from /admin/ab-tests/style.css)
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* Generic table wrapper, counterpart to .leads-table-wrapper */
+.table-wrap {
+    overflow-x: auto;
+}
+
+.stat-active { color: var(--green-600); }
+.stat-completed { color: var(--purple-500); }
+.stat-clicked-ab { color: var(--blue-500); }
+
+.link-strong {
+    font-weight: 600;
+    color: var(--primary-blue);
+    text-decoration: none;
+}
+
+.link-strong:hover {
+    text-decoration: underline;
+}
+
+.hint {
+    font-size: 13px;
+    color: var(--gray-500);
+    margin: 12px 0;
+}
+
+.hint code {
+    background: var(--gray-100, #f3f4f6);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+.idea-list {
+    margin: 8px 0;
+    padding-left: 20px;
+}
+
+.idea-list li {
+    margin-bottom: 6px;
+    line-height: 1.45;
+}
+
+/* Variant rows in the "New A/B Test" form */
+.variant-row {
+    background: var(--gray-50, #fafafa);
+    border: 1px solid var(--gray-border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-top: 10px;
+}
+
+.variant-row-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    font-size: 13px;
+    color: var(--gray-700);
+}
+
+.variant-row-header label {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    cursor: pointer;
+}
+
+.variant-remove {
+    padding: 2px 10px;
+    font-size: 16px;
+    line-height: 1;
+}
+
+.variant-content-cell {
+    max-width: 360px;
+    word-break: break-word;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    color: var(--gray-700);
+}
+
+/* Status pills (test status) */
+.status-pill {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.status-draft {
+    background: var(--gray-100, #f3f4f6);
+    color: var(--gray-700);
+}
+
+.status-active {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.status-paused {
+    background: #fef3c7;
+    color: #854d0e;
+}
+
+.status-completed {
+    background: #ede9fe;
+    color: #6b21a8;
+}
+
+/* Confidence-vs-leader tags on detail view */
+.confidence-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.conf-insufficient {
+    background: var(--gray-100, #f3f4f6);
+    color: var(--gray-text, #6b7280);
+}
+
+.conf-trending {
+    background: #fef3c7;
+    color: #854d0e;
+}
+
+.conf-significant {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.conf-leader-row {
+    background: rgba(34, 197, 94, 0.06);
+}
+
+.directive-pill {
+    display: inline-block;
+    background: #e0e7ff;
+    color: #3730a3;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-right: 6px;
+    vertical-align: middle;
+}
+
+.chart-card {
+    background: var(--white);
+    border: 1px solid var(--gray-border);
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin-top: 16px;
+}
+
+.chart-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--gray-700);
+}
+
+.chart-wrap {
+    position: relative;
+    height: 260px;
+}
+
+/* Detail page metadata tiles */
+.test-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.meta-item {
+    background: var(--gray-50, #fafafa);
+    padding: 10px 14px;
+    border-radius: 6px;
+}
+
+.meta-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--gray-500);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.meta-value {
+    font-size: 14px;
+    color: var(--gray-800);
+    font-weight: 500;
+    margin-top: 2px;
+    word-break: break-word;
+}
+
+/* Settings tab segmented toggle (Auto-send / Review; A/B on / off) */
+.segmented-toggle {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+    justify-content: center;
+}
+
+.segmented-option {
+    flex: 0 0 280px;
+    width: 280px;
+    box-sizing: border-box;
+    border: 2px solid var(--gray-border);
+    border-radius: 8px;
+    background: var(--white);
+    padding: 14px 16px;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+    transition: border-color 0.15s, background-color 0.15s;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--gray-700);
+}
+
+.segmented-option:hover {
+    border-color: var(--primary-blue);
+}
+
+.segmented-option.active {
+    border-color: var(--primary-blue);
+    background: rgba(59, 130, 246, 0.08);
+    color: var(--gray-800);
+}
+
+.segmented-title {
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.segmented-desc {
+    font-size: 12px;
+    color: var(--gray-500);
+    line-height: 1.4;
+}
+
+/* Log tail in Settings tab */
+.log-tail {
+    background: var(--gray-900, #0f172a);
+    color: #e2e8f0;
+    padding: 12px 14px;
+    border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    max-height: 400px;
+    overflow: auto;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+/* Dark-theme overrides for the A/B / Settings elements */
+[data-theme="dark"] .variant-row {
+    background: var(--gray-900);
+    border-color: var(--gray-700);
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .variant-row-header {
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .variant-content-cell,
+[data-theme="dark"] .hint code {
+    color: var(--gray-300);
+    background: var(--gray-900);
+}
+
+[data-theme="dark"] .meta-item {
+    background: var(--gray-900);
+}
+
+[data-theme="dark"] .meta-label {
+    color: var(--gray-400);
+}
+
+[data-theme="dark"] .meta-value {
+    color: var(--gray-100);
+}
+
+[data-theme="dark"] .chart-card {
+    background: var(--gray-900);
+    border-color: var(--gray-700);
+}
+
+[data-theme="dark"] .chart-card h3 {
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .status-draft {
+    background: var(--gray-700);
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .conf-insufficient {
+    background: var(--gray-700);
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .directive-pill {
+    background: #312e81;
+    color: #c7d2fe;
+}
+
+[data-theme="dark"] .idea-list {
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .segmented-option {
+    background: var(--gray-800);
+    border-color: var(--gray-700);
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .segmented-option:hover {
+    border-color: var(--primary-blue);
+}
+
+[data-theme="dark"] .segmented-option.active {
+    background: rgba(59, 130, 246, 0.18);
+    border-color: var(--primary-blue);
+    color: var(--gray-100);
+}
+
+[data-theme="dark"] .segmented-desc {
+    color: var(--gray-400);
+}
+
+[data-theme="dark"] .hint {
+    color: var(--gray-400);
+}

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -927,16 +927,6 @@
     font-size: 12px;
 }
 
-.idea-list {
-    margin: 8px 0;
-    padding-left: 20px;
-}
-
-.idea-list li {
-    margin-bottom: 6px;
-    line-height: 1.45;
-}
-
 /* Variant rows in the "New A/B Test" form */
 .variant-row {
     background: var(--gray-50, #fafafa);
@@ -1233,10 +1223,6 @@
 [data-theme="dark"] .directive-pill {
     background: #312e81;
     color: #c7d2fe;
-}
-
-[data-theme="dark"] .idea-list {
-    color: var(--gray-200);
 }
 
 [data-theme="dark"] .segmented-option {

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -37,22 +37,31 @@ function ab_tests_tab_handle_post($pdo)
             header('Location: index.php?tab=ab-tests'); exit;
         }
 
-        if (!in_array($variantType, ['subject', 'body', 'sender', 'cta'], true)) {
+        if (!in_array($variantType, ['subject', 'body', 'sender', 'cta', 'preheader', 'format'], true)) {
             $variantType = 'subject';
         }
 
-        $rows = [];
-        foreach ($variantLabels as $i => $label) {
-            $label = trim((string) $label);
-            $content = trim((string) ($variantContents[$i] ?? ''));
-            if ($label === '' || $content === '') continue;
-            $rows[] = ['label' => $label, 'content' => $content, 'is_default' => ($i === $defaultIdx) ? 1 : 0];
-        }
+        if ($variantType === 'format') {
+            // Format tests are fixed: html (control) vs plain. Ignore any
+            // variant rows the form posted — the values are not user-authored.
+            $rows = [
+                ['label' => 'A', 'content' => 'html',  'is_default' => 1],
+                ['label' => 'B', 'content' => 'plain', 'is_default' => 0],
+            ];
+        } else {
+            $rows = [];
+            foreach ($variantLabels as $i => $label) {
+                $label = trim((string) $label);
+                $content = trim((string) ($variantContents[$i] ?? ''));
+                if ($label === '' || $content === '') continue;
+                $rows[] = ['label' => $label, 'content' => $content, 'is_default' => ($i === $defaultIdx) ? 1 : 0];
+            }
 
-        if (count($rows) < 2) {
-            $_SESSION['message'] = 'A/B tests need at least 2 variants (both label and content filled).';
-            $_SESSION['message_type'] = 'error';
-            header('Location: index.php?tab=ab-tests'); exit;
+            if (count($rows) < 2) {
+                $_SESSION['message'] = 'A/B tests need at least 2 variants (both label and content filled).';
+                $_SESSION['message_type'] = 'error';
+                header('Location: index.php?tab=ab-tests'); exit;
+            }
         }
 
         $pdo->beginTransaction();
@@ -220,6 +229,7 @@ function ab_tests_tab_render_list($pdo)
                             <option value="cta">CTA / offer</option>
                             <option value="sender">Sender from-name</option>
                             <option value="preheader">Preheader (inbox preview)</option>
+                            <option value="format">Format (HTML vs plain text)</option>
                         </select>
                     </div>
                 </div>
@@ -235,11 +245,16 @@ function ab_tests_tab_render_list($pdo)
                     Directives let the AI generate the value each time while staying in a style.
                     <span id="senderHintNote" style="display:none;"><br><strong>Sender variants are literal-only</strong> — the from-name string is used as-is in the email envelope, with no AI interpretation. Skip the <code>directive:</code> prefix here. Try things like <code>Evan</code> vs <code>Evan from Argo Books</code> vs <code>Argo Books</code>.</span>
                     <span id="preheaderHintNote" style="display:none;"><br><strong>Preheader variants are literal-only</strong> — this is the snippet most inboxes show next to the subject. Use short, scannable text. Try things like <code>Quick question about your business</code> vs <code>Free 1-year license inside</code> vs leave one variant blank to test the &ldquo;no preheader&rdquo; baseline.</span>
+                    <span id="formatHintNote" style="display:none;"><br><strong>Format is a fixed two-variant test</strong> — Variant A sends the full styled HTML email (current behaviour); Variant B sends the same content as plain text (no template, no logo, bare URLs). The variant rows below are not used for this test type.</span>
                 </p>
 
                 <div id="abVariantRows"></div>
 
-                <div style="display:flex; gap:8px; margin-top:8px; align-items:center;">
+                <div id="abFormatFixedNotice" class="hint" style="display:none; padding:10px; border:1px dashed var(--border-color, #d1d5db); border-radius:6px; margin-top:8px;">
+                    Will create two variants automatically: <strong>A &mdash; <code>html</code></strong> (default) and <strong>B &mdash; <code>plain</code></strong>.
+                </div>
+
+                <div id="abVariantControls" style="display:flex; gap:8px; margin-top:8px; align-items:center;">
                     <button type="button" class="btn btn-small btn-neutral" onclick="abAddVariantRow()">+ Add variant</button>
                     <span class="hint" id="abVariantCountHint">2 of up to 4 variants</span>
                 </div>
@@ -335,7 +350,7 @@ function ab_tests_tab_render_list($pdo)
                 <li><strong>Personalization depth</strong> &mdash; with vs without the AI-generated <code>business_summary</code>.</li>
                 <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder (author as a body directive).</li>
             </ul>
-            <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, HTML vs plain-text, unsubscribe placement.</p>
+            <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, unsubscribe placement.</p>
         </div>
     </div>
 
@@ -405,10 +420,20 @@ function ab_tests_tab_render_list($pdo)
             var typeSelect = document.getElementById('abVariantType');
             var senderNote = document.getElementById('senderHintNote');
             var preheaderNote = document.getElementById('preheaderHintNote');
+            var formatNote = document.getElementById('formatHintNote');
+            var formatFixedNotice = document.getElementById('abFormatFixedNotice');
+            var variantRows = document.getElementById('abVariantRows');
+            var variantControls = document.getElementById('abVariantControls');
             if (typeSelect) {
                 var syncTypeNotes = function () {
-                    if (senderNote) senderNote.style.display = typeSelect.value === 'sender' ? 'inline' : 'none';
-                    if (preheaderNote) preheaderNote.style.display = typeSelect.value === 'preheader' ? 'inline' : 'none';
+                    var v = typeSelect.value;
+                    if (senderNote) senderNote.style.display = v === 'sender' ? 'inline' : 'none';
+                    if (preheaderNote) preheaderNote.style.display = v === 'preheader' ? 'inline' : 'none';
+                    if (formatNote) formatNote.style.display = v === 'format' ? 'inline' : 'none';
+                    var isFormat = (v === 'format');
+                    if (variantRows) variantRows.style.display = isFormat ? 'none' : '';
+                    if (variantControls) variantControls.style.display = isFormat ? 'none' : 'flex';
+                    if (formatFixedNotice) formatFixedNotice.style.display = isFormat ? 'block' : 'none';
                 };
                 typeSelect.addEventListener('change', syncTypeNotes);
                 syncTypeNotes();

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -1,0 +1,653 @@
+<?php
+/**
+ * A/B Tests tab partial.
+ *
+ * Renders inside admin/outreach/index.php. Handles list view + detail view
+ * in a single partial, dispatching on $_GET['test_id'].
+ *
+ * Exposes two functions:
+ *   ab_tests_tab_handle_post($pdo) — process POST submissions for this tab
+ *   ab_tests_tab_render($pdo, $testId) — output HTML body of the tab
+ *
+ * Assumes $pdo is the global PDO connection and the admin session is active.
+ */
+
+require_once __DIR__ . '/../../../cron/lib/ab_helpers.php';
+
+/**
+ * Handle POST submissions posted with hidden input tab=ab-tests.
+ * Every branch ends with header() + exit, so callers should not continue after.
+ */
+function ab_tests_tab_handle_post($pdo)
+{
+    $action = $_POST['action'] ?? '';
+    $testId = (int) ($_POST['test_id'] ?? 0);
+
+    if ($action === 'create') {
+        $name = trim($_POST['name'] ?? '');
+        $variantType = $_POST['variant_type'] ?? 'subject';
+        $notes = trim($_POST['notes'] ?? '');
+        $variantLabels = $_POST['variant_label'] ?? [];
+        $variantContents = $_POST['variant_content'] ?? [];
+        $defaultIdx = isset($_POST['default_variant']) ? (int) $_POST['default_variant'] : 0;
+
+        if ($name === '') {
+            $_SESSION['message'] = 'Test name is required.';
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?tab=ab-tests'); exit;
+        }
+
+        if (!in_array($variantType, ['subject', 'body', 'sender', 'cta'], true)) {
+            $variantType = 'subject';
+        }
+
+        $rows = [];
+        foreach ($variantLabels as $i => $label) {
+            $label = trim((string) $label);
+            $content = trim((string) ($variantContents[$i] ?? ''));
+            if ($label === '' || $content === '') continue;
+            $rows[] = ['label' => $label, 'content' => $content, 'is_default' => ($i === $defaultIdx) ? 1 : 0];
+        }
+
+        if (count($rows) < 2) {
+            $_SESSION['message'] = 'A/B tests need at least 2 variants (both label and content filled).';
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?tab=ab-tests'); exit;
+        }
+
+        $pdo->beginTransaction();
+        try {
+            $stmt = $pdo->prepare("INSERT INTO outreach_ab_tests (name, variant_type, status, notes) VALUES (?, ?, 'draft', ?)");
+            $stmt->execute([$name, $variantType, $notes !== '' ? $notes : null]);
+            $newId = (int) $pdo->lastInsertId();
+
+            $vStmt = $pdo->prepare("INSERT INTO outreach_ab_variants (test_id, label, content, is_default) VALUES (?, ?, ?, ?)");
+            foreach ($rows as $r) {
+                $vStmt->execute([$newId, $r['label'], $r['content'], $r['is_default']]);
+            }
+            $pdo->commit();
+
+            $_SESSION['message'] = 'Test created as draft. Click "Start" when ready.';
+            $_SESSION['message_type'] = 'success';
+            header('Location: index.php?tab=ab-tests&test_id=' . $newId); exit;
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            $_SESSION['message'] = 'Failed to create test: ' . $e->getMessage();
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?tab=ab-tests'); exit;
+        }
+    }
+
+    if ($action === 'status_change') {
+        $newStatus = $_POST['status'] ?? '';
+        if ($testId && in_array($newStatus, ['draft', 'active', 'paused', 'completed'], true)) {
+            if ($newStatus === 'active') {
+                $typeStmt = $pdo->prepare("SELECT variant_type FROM outreach_ab_tests WHERE id = ?");
+                $typeStmt->execute([$testId]);
+                $type = $typeStmt->fetchColumn();
+                if ($type) {
+                    $pdo->prepare("UPDATE outreach_ab_tests SET status = 'paused' WHERE status = 'active' AND variant_type = ? AND id <> ?")
+                        ->execute([$type, $testId]);
+                }
+                $pdo->prepare("UPDATE outreach_ab_tests SET status = 'active', started_at = COALESCE(started_at, NOW()) WHERE id = ?")
+                    ->execute([$testId]);
+            } elseif ($newStatus === 'completed') {
+                $pdo->prepare("UPDATE outreach_ab_tests SET status = 'completed', completed_at = NOW() WHERE id = ?")
+                    ->execute([$testId]);
+            } else {
+                $pdo->prepare("UPDATE outreach_ab_tests SET status = ? WHERE id = ?")
+                    ->execute([$newStatus, $testId]);
+            }
+            $_SESSION['message'] = 'Test status updated.';
+            $_SESSION['message_type'] = 'success';
+        }
+        $redirect = $testId ? ('index.php?tab=ab-tests&test_id=' . $testId) : 'index.php?tab=ab-tests';
+        header('Location: ' . $redirect); exit;
+    }
+
+    if ($action === 'promote') {
+        $variantId = (int) ($_POST['variant_id'] ?? 0);
+        if ($testId > 0 && $variantId > 0) {
+            $check = $pdo->prepare("SELECT id FROM outreach_ab_variants WHERE id = ? AND test_id = ?");
+            $check->execute([$variantId, $testId]);
+            if ($check->fetch()) {
+                $pdo->prepare("UPDATE outreach_ab_tests
+                    SET winner_variant_id = ?, status = 'completed', completed_at = NOW()
+                    WHERE id = ?")
+                    ->execute([$variantId, $testId]);
+                $_SESSION['message'] = 'Variant promoted. Test completed; the pipeline will start a new cycle on its next run if automation is on.';
+                $_SESSION['message_type'] = 'success';
+            }
+        }
+        header('Location: index.php?tab=ab-tests&test_id=' . $testId); exit;
+    }
+
+    if ($action === 'update_notes') {
+        if ($testId > 0) {
+            $notes = trim($_POST['notes'] ?? '');
+            $pdo->prepare("UPDATE outreach_ab_tests SET notes = ? WHERE id = ?")
+                ->execute([$notes !== '' ? $notes : null, $testId]);
+            $_SESSION['message'] = 'Notes saved.';
+            $_SESSION['message_type'] = 'success';
+        }
+        header('Location: index.php?tab=ab-tests&test_id=' . $testId); exit;
+    }
+
+    // Unknown action — just bounce back to the tab
+    header('Location: index.php?tab=ab-tests'); exit;
+}
+
+function ab_tests_tab_render($pdo, $testId = 0)
+{
+    if ($testId > 0) {
+        ab_tests_tab_render_detail($pdo, $testId);
+    } else {
+        ab_tests_tab_render_list($pdo);
+    }
+}
+
+function ab_tests_tab_render_list($pdo)
+{
+    $testsQuery = $pdo->query("
+        SELECT
+            t.*,
+            (SELECT COUNT(*) FROM outreach_ab_variants v WHERE v.test_id = t.id) AS variant_count,
+            (SELECT COUNT(*) FROM outreach_leads ol WHERE ol.ab_test_id = t.id) AS assigned_count,
+            (SELECT COUNT(*) FROM outreach_leads ol WHERE ol.ab_test_id = t.id AND ol.sent_at IS NOT NULL) AS sent_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN referral_visits rv
+                  ON rv.source_code = CONCAT('outreach-', ol.id, '-v', ol.ab_variant_id)
+                WHERE ol.ab_test_id = t.id) AS clicked_count
+        FROM outreach_ab_tests t
+        ORDER BY
+            FIELD(t.status, 'active', 'paused', 'draft', 'completed'),
+            COALESCE(t.started_at, t.created_at) DESC
+    ");
+    $tests = $testsQuery->fetchAll();
+
+    $stats = ['active' => 0, 'completed' => 0, 'assigned' => 0, 'clicked' => 0];
+    foreach ($tests as $t) {
+        if ($t['status'] === 'active') $stats['active']++;
+        if ($t['status'] === 'completed') $stats['completed']++;
+        $stats['assigned'] += (int) $t['assigned_count'];
+        $stats['clicked']  += (int) $t['clicked_count'];
+    }
+    ?>
+
+    <div class="stats-row" style="margin-top:4px;">
+        <div class="stat-card">
+            <div class="stat-label">Active Tests</div>
+            <div class="stat-value stat-active"><?php echo (int) $stats['active']; ?></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Completed</div>
+            <div class="stat-value stat-completed"><?php echo (int) $stats['completed']; ?></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Leads Assigned</div>
+            <div class="stat-value"><?php echo (int) $stats['assigned']; ?></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Leads Clicked</div>
+            <div class="stat-value stat-clicked-ab"><?php echo (int) $stats['clicked']; ?></div>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header" onclick="togglePanel('abCreatePanelContent')">
+            <h2>New A/B Test (manual)</h2>
+            <span class="panel-toggle" id="abCreatePanelToggle">&#9654;</span>
+        </div>
+        <div class="panel-content" id="abCreatePanelContent" style="display:none;">
+            <p class="hint" style="margin-top:0;">
+                A/B automation creates tests for you when turned on. Use this form if you want to run a specific test by hand.
+            </p>
+            <form method="POST" id="abCreateForm">
+                <input type="hidden" name="tab" value="ab-tests">
+                <input type="hidden" name="action" value="create">
+
+                <div class="form-row">
+                    <div class="form-group" style="flex:2; min-width:220px;">
+                        <label for="abTestName">Test name</label>
+                        <input type="text" id="abTestName" name="name" placeholder="e.g. Curiosity vs direct subject line" required>
+                    </div>
+                    <div class="form-group" style="flex:1; min-width:140px;">
+                        <label for="abVariantType">Variant type</label>
+                        <select id="abVariantType" name="variant_type">
+                            <option value="subject" selected>Subject line</option>
+                            <option value="body" disabled>Body (not wired yet)</option>
+                            <option value="sender" disabled>Sender (not wired yet)</option>
+                            <option value="cta" disabled>CTA (not wired yet)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="form-group" style="margin-top:12px;">
+                    <label for="abTestNotes">Notes (optional)</label>
+                    <textarea id="abTestNotes" name="notes" rows="2" placeholder="What are you trying to learn?"></textarea>
+                </div>
+
+                <p class="hint">
+                    <strong>Subject content:</strong> Either a literal subject (used verbatim) OR a directive prefixed with
+                    <code>directive:</code> (e.g. <code>directive: Ask a curiosity question referencing the business's city</code>).
+                    Directives let the AI generate a subject each time while staying in a style.
+                </p>
+
+                <div id="abVariantRows"></div>
+
+                <div style="display:flex; gap:8px; margin-top:8px; align-items:center;">
+                    <button type="button" class="btn btn-small" onclick="abAddVariantRow()">+ Add variant</button>
+                    <span class="hint" id="abVariantCountHint">2 of up to 4 variants</span>
+                </div>
+
+                <div style="margin-top:16px; display:flex; gap:8px;">
+                    <button type="submit" class="btn btn-blue">Create as draft</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>All tests</h2>
+        </div>
+        <div class="panel-content">
+            <?php if (empty($tests)): ?>
+                <p class="empty-state">No A/B tests yet. Turn on automation in the Settings tab, or create one above.</p>
+            <?php else: ?>
+                <div class="table-wrap">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Type</th>
+                                <th>Status</th>
+                                <th>Variants</th>
+                                <th>Assigned</th>
+                                <th>Sent</th>
+                                <th>Clicked</th>
+                                <th>CTR</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($tests as $t): ?>
+                                <tr>
+                                    <td>
+                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="link-strong">
+                                            <?php echo htmlspecialchars($t['name']); ?>
+                                        </a>
+                                    </td>
+                                    <td><?php echo htmlspecialchars($t['variant_type']); ?></td>
+                                    <td>
+                                        <span class="status-pill status-<?php echo htmlspecialchars($t['status']); ?>">
+                                            <?php echo htmlspecialchars(ucfirst($t['status'])); ?>
+                                        </span>
+                                    </td>
+                                    <td><?php echo (int) $t['variant_count']; ?></td>
+                                    <td><?php echo (int) $t['assigned_count']; ?></td>
+                                    <td><?php echo (int) $t['sent_count']; ?></td>
+                                    <td><?php echo (int) $t['clicked_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['clicked_count']); ?></td>
+                                    <td class="actions-cell">
+                                        <?php if ($t['status'] === 'draft' || $t['status'] === 'paused'): ?>
+                                            <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other active test of the same type will be paused.');">
+                                                <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="action" value="status_change">
+                                                <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
+                                                <input type="hidden" name="status" value="active">
+                                                <button type="submit" class="btn btn-small btn-green">Start</button>
+                                            </form>
+                                        <?php elseif ($t['status'] === 'active'): ?>
+                                            <form method="POST" style="display:inline;">
+                                                <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="action" value="status_change">
+                                                <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
+                                                <input type="hidden" name="status" value="paused">
+                                                <button type="submit" class="btn btn-small">Pause</button>
+                                            </form>
+                                        <?php endif; ?>
+                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="btn btn-small">Details</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Ideas for future tests</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">Once the subject-line loop is proven, good next candidates are:</p>
+            <ul class="idea-list">
+                <li><strong>Email body / opener</strong> &mdash; schema already supports <code>variant_type='body'</code>; prompt just swaps the body directive. Biggest remaining lever after subject.</li>
+                <li><strong>CTA framing</strong> &mdash; "free 1-year premium license for feedback" vs "15 min chat in exchange for a year free".</li>
+                <li><strong>Preheader / preview text</strong> &mdash; the text next to the subject in the inbox.</li>
+                <li><strong>Sender name</strong> &mdash; "Evan" vs "Evan at Argo Books" vs "Argo Books".</li>
+                <li><strong>Personalization depth</strong> &mdash; with vs without the AI-generated <code>business_summary</code>.</li>
+                <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder.</li>
+            </ul>
+            <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, HTML vs plain-text, unsubscribe placement.</p>
+        </div>
+    </div>
+
+    <script>
+        (function() {
+            if (window.__abVariantRowsInit) return;
+            window.__abVariantRowsInit = true;
+
+            var container = document.getElementById('abVariantRows');
+            if (!container) return;
+            var hint = document.getElementById('abVariantCountHint');
+            var MAX = 4;
+
+            function renderLabel(idx) { return String.fromCharCode(65 + idx); }
+
+            function makeRow(idx) {
+                var row = document.createElement('div');
+                row.className = 'variant-row';
+                row.innerHTML =
+                    '<div class="variant-row-header">' +
+                        '<label><input type="radio" name="default_variant" value="' + idx + '"' + (idx === 0 ? ' checked' : '') + '> Default</label>' +
+                        '<button type="button" class="btn btn-small variant-remove" title="Remove variant">&times;</button>' +
+                    '</div>' +
+                    '<div class="form-row">' +
+                        '<div class="form-group" style="flex:0 0 110px;">' +
+                            '<label>Label</label>' +
+                            '<input type="text" name="variant_label[]" value="' + renderLabel(idx) + '" required>' +
+                        '</div>' +
+                        '<div class="form-group" style="flex:1; min-width:240px;">' +
+                            '<label>Subject or <code>directive:</code> prompt</label>' +
+                            '<input type="text" name="variant_content[]" placeholder="e.g. Thought of you guys  OR  directive: Ask a curiosity question referencing the city" required>' +
+                        '</div>' +
+                    '</div>';
+                row.querySelector('.variant-remove').addEventListener('click', function() {
+                    if (container.children.length <= 2) return;
+                    row.remove();
+                    refreshIndices();
+                });
+                return row;
+            }
+
+            function refreshIndices() {
+                var rows = container.querySelectorAll('.variant-row');
+                rows.forEach(function(r, i) {
+                    var radio = r.querySelector('input[name="default_variant"]');
+                    if (radio) radio.value = i;
+                    var labelInput = r.querySelector('input[name="variant_label[]"]');
+                    if (labelInput && labelInput.dataset.autoLabel !== 'false') {
+                        labelInput.value = renderLabel(i);
+                    }
+                });
+                if (hint) hint.textContent = rows.length + ' of up to ' + MAX + ' variants';
+            }
+
+            window.abAddVariantRow = function() {
+                var count = container.children.length;
+                if (count >= MAX) return;
+                container.appendChild(makeRow(count));
+                refreshIndices();
+            };
+
+            container.appendChild(makeRow(0));
+            container.appendChild(makeRow(1));
+            refreshIndices();
+        })();
+    </script>
+    <?php
+}
+
+function ab_tests_tab_render_detail($pdo, $testId)
+{
+    $testStmt = $pdo->prepare("SELECT * FROM outreach_ab_tests WHERE id = ?");
+    $testStmt->execute([$testId]);
+    $test = $testStmt->fetch();
+
+    if (!$test) {
+        echo '<p class="empty-state">Test not found. <a href="?tab=ab-tests" class="link-strong">Back to all tests</a></p>';
+        return;
+    }
+
+    $variants = load_variants_with_stats($pdo, $testId);
+    $leaderIdx = find_leader_idx($variants);
+
+    $chartLabels = array_map(fn($v) => $v['label'], $variants);
+    $chartCtrs   = array_map(fn($v) => round($v['ctr'] * 100, 2), $variants);
+    $chartClicks = array_map(fn($v) => (int) $v['clicked_count'], $variants);
+    $chartSent   = array_map(fn($v) => (int) $v['sent_count'], $variants);
+    ?>
+
+    <p style="margin-top:0;"><a href="?tab=ab-tests" class="link-strong">&larr; All tests</a></p>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>
+                <?php echo htmlspecialchars($test['name']); ?>
+                <span class="status-pill status-<?php echo htmlspecialchars($test['status']); ?>" style="margin-left:8px; font-size:11px; vertical-align:middle;">
+                    <?php echo htmlspecialchars(ucfirst($test['status'])); ?>
+                </span>
+            </h2>
+            <div>
+                <?php if ($test['status'] === 'draft' || $test['status'] === 'paused'): ?>
+                    <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other active test of the same type will be paused.');">
+                        <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="action" value="status_change">
+                        <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
+                        <input type="hidden" name="status" value="active">
+                        <button type="submit" class="btn btn-small btn-green">Start</button>
+                    </form>
+                <?php elseif ($test['status'] === 'active'): ?>
+                    <form method="POST" style="display:inline;">
+                        <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="action" value="status_change">
+                        <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
+                        <input type="hidden" name="status" value="paused">
+                        <button type="submit" class="btn btn-small">Pause</button>
+                    </form>
+                    <form method="POST" style="display:inline;" onsubmit="return confirm('End this test without picking a winner? Existing leads keep their variant; new leads stop getting assigned.');">
+                        <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="action" value="status_change">
+                        <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
+                        <input type="hidden" name="status" value="completed">
+                        <button type="submit" class="btn btn-small">End</button>
+                    </form>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="panel-content">
+            <div class="test-meta">
+                <div class="meta-item">
+                    <div class="meta-label">Variant type</div>
+                    <div class="meta-value"><?php echo htmlspecialchars($test['variant_type']); ?></div>
+                </div>
+                <div class="meta-item">
+                    <div class="meta-label">Created</div>
+                    <div class="meta-value"><?php echo htmlspecialchars(date('M j, Y', strtotime($test['created_at']))); ?></div>
+                </div>
+                <div class="meta-item">
+                    <div class="meta-label">Started</div>
+                    <div class="meta-value"><?php echo $test['started_at'] ? htmlspecialchars(date('M j, Y', strtotime($test['started_at']))) : '—'; ?></div>
+                </div>
+                <div class="meta-item">
+                    <div class="meta-label">Completed</div>
+                    <div class="meta-value"><?php echo $test['completed_at'] ? htmlspecialchars(date('M j, Y', strtotime($test['completed_at']))) : '—'; ?></div>
+                </div>
+                <div class="meta-item">
+                    <div class="meta-label">Winner</div>
+                    <div class="meta-value">
+                        <?php
+                            if ($test['winner_variant_id']) {
+                                $winnerLabel = '';
+                                foreach ($variants as $v) {
+                                    if ((int) $v['id'] === (int) $test['winner_variant_id']) {
+                                        $winnerLabel = $v['label'];
+                                        break;
+                                    }
+                                }
+                                echo htmlspecialchars($winnerLabel !== '' ? $winnerLabel : '#' . $test['winner_variant_id']);
+                            } else {
+                                echo '—';
+                            }
+                        ?>
+                    </div>
+                </div>
+            </div>
+
+            <form method="POST" style="margin-top:4px;">
+                <input type="hidden" name="tab" value="ab-tests">
+                <input type="hidden" name="action" value="update_notes">
+                <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
+                <div class="form-group">
+                    <label for="abNotesField">Notes</label>
+                    <textarea id="abNotesField" name="notes" rows="2" placeholder="Why you ran this test, any context for later."><?php echo htmlspecialchars((string) $test['notes']); ?></textarea>
+                </div>
+                <div style="margin-top:8px;">
+                    <button type="submit" class="btn btn-small">Save notes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Variants</h2>
+        </div>
+        <div class="panel-content">
+            <?php if (empty($variants)): ?>
+                <p class="empty-state">No variants on this test.</p>
+            <?php else: ?>
+                <div class="table-wrap">
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Label</th>
+                                <th>Content</th>
+                                <th>Assigned</th>
+                                <th>Sent</th>
+                                <th>Clicked</th>
+                                <th>CTR</th>
+                                <th>Confidence vs leader</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($variants as $i => $v): ?>
+                                <?php
+                                    $isLeader = ($i === $leaderIdx);
+                                    $confidence = ['tag' => 'insufficient', 'label' => '—'];
+                                    if ($leaderIdx !== null && !$isLeader) {
+                                        $confidence = confidence_vs_leader(
+                                            $variants[$leaderIdx]['sent_count'],
+                                            $variants[$leaderIdx]['clicked_count'],
+                                            $v['sent_count'],
+                                            $v['clicked_count']
+                                        );
+                                    }
+                                    $isDirective = stripos(trim((string) $v['content']), 'directive:') === 0;
+                                    $isWinner = ((int) $test['winner_variant_id'] === (int) $v['id']);
+                                ?>
+                                <tr class="<?php echo $isLeader ? 'conf-leader-row' : ''; ?>">
+                                    <td>
+                                        <strong><?php echo htmlspecialchars($v['label']); ?></strong>
+                                        <?php if ($v['is_default']): ?><span class="hint" style="display:block; margin:0; font-size:11px;">default</span><?php endif; ?>
+                                        <?php if ($isWinner): ?><span class="status-pill status-completed" style="font-size:10px; margin-top:2px;">Winner</span><?php endif; ?>
+                                    </td>
+                                    <td class="variant-content-cell">
+                                        <?php if ($isDirective): ?><span class="directive-pill">directive</span><?php endif; ?>
+                                        <?php echo htmlspecialchars($isDirective ? trim(substr($v['content'], strlen('directive:'))) : $v['content']); ?>
+                                    </td>
+                                    <td><?php echo (int) $v['assigned_count']; ?></td>
+                                    <td><?php echo (int) $v['sent_count']; ?></td>
+                                    <td><?php echo (int) $v['clicked_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $v['sent_count'], (int) $v['clicked_count']); ?></td>
+                                    <td>
+                                        <?php if ($isLeader): ?>
+                                            <span class="hint" style="margin:0;">leader</span>
+                                        <?php else: ?>
+                                            <span class="confidence-tag conf-<?php echo htmlspecialchars($confidence['tag']); ?>">
+                                                <?php echo htmlspecialchars($confidence['label']); ?>
+                                            </span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <?php if ($test['status'] !== 'completed'): ?>
+                                            <form method="POST" style="display:inline;" onsubmit="return confirm('Promote this variant and end the test? No more new leads will be assigned.');">
+                                                <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="action" value="promote">
+                                                <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
+                                                <input type="hidden" name="variant_id" value="<?php echo (int) $v['id']; ?>">
+                                                <button type="submit" class="btn btn-small btn-blue">Promote to winner</button>
+                                            </form>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="chart-card">
+                    <h3>CTR by variant (% of sent emails that got a click)</h3>
+                    <div class="chart-wrap">
+                        <canvas id="abCtrChart"></canvas>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <script>
+    (function() {
+        var el = document.getElementById('abCtrChart');
+        if (!el || typeof Chart === 'undefined') return;
+
+        var ctrs = <?php echo json_encode($chartCtrs); ?>;
+        var clicks = <?php echo json_encode($chartClicks); ?>;
+        var sent = <?php echo json_encode($chartSent); ?>;
+        var leaderIdx = <?php echo $leaderIdx === null ? '-1' : (int) $leaderIdx; ?>;
+
+        new Chart(el.getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: <?php echo json_encode($chartLabels); ?>,
+                datasets: [{
+                    label: 'CTR %',
+                    data: ctrs,
+                    backgroundColor: ctrs.map(function(_, i) {
+                        return i === leaderIdx ? '#22c55e' : '#3b82f6';
+                    }),
+                    borderRadius: 4,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: function(ctx) {
+                                var i = ctx.dataIndex;
+                                return 'CTR: ' + ctrs[i].toFixed(1) + '% (' + clicks[i] + ' clicks of ' + sent[i] + ' sent)';
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: { callback: function(v) { return v + '%'; } }
+                    }
+                }
+            }
+        });
+    })();
+    </script>
+    <?php
+}

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -352,22 +352,6 @@ function ab_tests_tab_render_list($pdo)
         </div>
     </div>
 
-    <div class="panel">
-        <div class="panel-header">
-            <h2>Ideas for future tests</h2>
-        </div>
-        <div class="panel-content">
-            <p class="hint" style="margin-top:0;">Once the subject-line loop is proven, good next candidates are:</p>
-            <ul class="idea-list">
-                <li><strong>Email body / opener</strong> &mdash; schema already supports <code>variant_type='body'</code>; prompt just swaps the body directive. Biggest remaining lever after subject.</li>
-                <li><strong>CTA framing</strong> &mdash; "free 1-year premium license for feedback" vs "15 min chat in exchange for a year free".</li>
-                <li><strong>Sender name</strong> &mdash; "Evan" vs "Evan at Argo Books" vs "Argo Books".</li>
-                <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder (author as a body directive).</li>
-            </ul>
-            <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, unsubscribe placement.</p>
-        </div>
-    </div>
-
     <script>
         (function() {
             if (window.__abVariantRowsInit) return;

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -217,8 +217,8 @@ function ab_tests_tab_render_list($pdo)
                         <select id="abVariantType" name="variant_type">
                             <option value="subject" selected>Subject line</option>
                             <option value="body">Email body</option>
+                            <option value="cta">CTA / offer</option>
                             <option value="sender" disabled>Sender (not wired yet)</option>
-                            <option value="cta" disabled>CTA (not wired yet)</option>
                         </select>
                     </div>
                 </div>

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -218,7 +218,7 @@ function ab_tests_tab_render_list($pdo)
                             <option value="subject" selected>Subject line</option>
                             <option value="body">Email body</option>
                             <option value="cta">CTA / offer</option>
-                            <option value="sender" disabled>Sender (not wired yet)</option>
+                            <option value="sender">Sender from-name</option>
                         </select>
                     </div>
                 </div>
@@ -229,9 +229,10 @@ function ab_tests_tab_render_list($pdo)
                 </div>
 
                 <p class="hint">
-                    <strong>Subject content:</strong> Either a literal subject (used verbatim) OR a directive prefixed with
+                    <strong>Variant content:</strong> Either a literal value (used verbatim) OR a directive prefixed with
                     <code>directive:</code> (e.g. <code>directive: Ask a curiosity question referencing the business's city</code>).
-                    Directives let the AI generate a subject each time while staying in a style.
+                    Directives let the AI generate the value each time while staying in a style.
+                    <span id="senderHintNote" style="display:none;"><br><strong>Sender variants are literal-only</strong> — the from-name string is used as-is in the email envelope, with no AI interpretation. Skip the <code>directive:</code> prefix here. Try things like <code>Evan</code> vs <code>Evan from Argo Books</code> vs <code>Argo Books</code>.</span>
                 </p>
 
                 <div id="abVariantRows"></div>
@@ -398,6 +399,17 @@ function ab_tests_tab_render_list($pdo)
             container.appendChild(makeRow(0));
             container.appendChild(makeRow(1));
             refreshIndices();
+
+            // Show sender-specific note when 'sender' is selected as the variant type.
+            var typeSelect = document.getElementById('abVariantType');
+            var senderNote = document.getElementById('senderHintNote');
+            if (typeSelect && senderNote) {
+                var syncSenderNote = function () {
+                    senderNote.style.display = typeSelect.value === 'sender' ? 'inline' : 'none';
+                };
+                typeSelect.addEventListener('change', syncSenderNote);
+                syncSenderNote();
+            }
         })();
     </script>
     <?php

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -216,7 +216,7 @@ function ab_tests_tab_render_list($pdo)
                         <label for="abVariantType">Variant type</label>
                         <select id="abVariantType" name="variant_type">
                             <option value="subject" selected>Subject line</option>
-                            <option value="body" disabled>Body (not wired yet)</option>
+                            <option value="body">Email body</option>
                             <option value="sender" disabled>Sender (not wired yet)</option>
                             <option value="cta" disabled>CTA (not wired yet)</option>
                         </select>

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -100,13 +100,12 @@ function ab_tests_tab_handle_post($pdo)
         $newStatus = $_POST['status'] ?? '';
         if ($testId && in_array($newStatus, ['draft', 'active', 'paused', 'completed'], true)) {
             if ($newStatus === 'active') {
-                $typeStmt = $pdo->prepare("SELECT variant_type FROM outreach_ab_tests WHERE id = ?");
-                $typeStmt->execute([$testId]);
-                $type = $typeStmt->fetchColumn();
-                if ($type) {
-                    $pdo->prepare("UPDATE outreach_ab_tests SET status = 'paused' WHERE status = 'active' AND variant_type = ? AND id <> ?")
-                        ->execute([$type, $testId]);
-                }
+                // Only one test can be active at a time across the whole
+                // framework — the draft generator picks the first active
+                // test it finds, so a second active test of any other type
+                // would silently starve. Pause every other active test.
+                $pdo->prepare("UPDATE outreach_ab_tests SET status = 'paused' WHERE status = 'active' AND id <> ?")
+                    ->execute([$testId]);
                 $pdo->prepare("UPDATE outreach_ab_tests SET status = 'active', started_at = COALESCE(started_at, NOW()) WHERE id = ?")
                     ->execute([$testId]);
             } elseif ($newStatus === 'completed') {
@@ -325,7 +324,7 @@ function ab_tests_tab_render_list($pdo)
                                     <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['clicked_count']); ?></td>
                                     <td class="actions-cell">
                                         <?php if ($t['status'] === 'draft' || $t['status'] === 'paused'): ?>
-                                            <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other active test of the same type will be paused.');">
+                                            <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other currently active test will be paused (only one A/B test can be active at a time).');">
                                                 <input type="hidden" name="tab" value="ab-tests">
                                                 <input type="hidden" name="action" value="status_change">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
@@ -477,7 +476,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
             </h2>
             <div>
                 <?php if ($test['status'] === 'draft' || $test['status'] === 'paused'): ?>
-                    <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other active test of the same type will be paused.');">
+                    <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other currently active test will be paused (only one A/B test can be active at a time).');">
                         <input type="hidden" name="tab" value="ab-tests">
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -353,10 +353,10 @@ function ab_tests_tab_render_list($pdo)
                                                 <input type="hidden" name="action" value="status_change">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
                                                 <input type="hidden" name="status" value="paused">
-                                                <button type="submit" class="btn btn-small">Pause</button>
+                                                <button type="submit" class="btn btn-small btn-neutral">Pause</button>
                                             </form>
                                         <?php endif; ?>
-                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="btn btn-small">Details</a>
+                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="btn btn-small btn-neutral">Details</a>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
@@ -507,7 +507,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="paused">
-                        <button type="submit" class="btn btn-small">Pause</button>
+                        <button type="submit" class="btn btn-small btn-neutral">Pause</button>
                     </form>
                     <form method="POST" style="display:inline;" onsubmit="return confirm('End this test without picking a winner? Existing leads keep their variant; new leads stop getting assigned.');">
                         <input type="hidden" name="tab" value="ab-tests">
@@ -515,7 +515,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="completed">
-                        <button type="submit" class="btn btn-small">End</button>
+                        <button type="submit" class="btn btn-small btn-neutral">End</button>
                     </form>
                 <?php endif; ?>
             </div>
@@ -569,7 +569,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                     <textarea id="abNotesField" name="notes" rows="2" placeholder="Why you ran this test, any context for later."><?php echo htmlspecialchars((string) $test['notes']); ?></textarea>
                 </div>
                 <div style="margin-top:8px;">
-                    <button type="submit" class="btn btn-small">Save notes</button>
+                    <button type="submit" class="btn btn-small btn-neutral">Save notes</button>
                 </div>
             </form>
         </div>

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -219,6 +219,7 @@ function ab_tests_tab_render_list($pdo)
                             <option value="body">Email body</option>
                             <option value="cta">CTA / offer</option>
                             <option value="sender">Sender from-name</option>
+                            <option value="preheader">Preheader (inbox preview)</option>
                         </select>
                     </div>
                 </div>
@@ -233,6 +234,7 @@ function ab_tests_tab_render_list($pdo)
                     <code>directive:</code> (e.g. <code>directive: Ask a curiosity question referencing the business's city</code>).
                     Directives let the AI generate the value each time while staying in a style.
                     <span id="senderHintNote" style="display:none;"><br><strong>Sender variants are literal-only</strong> — the from-name string is used as-is in the email envelope, with no AI interpretation. Skip the <code>directive:</code> prefix here. Try things like <code>Evan</code> vs <code>Evan from Argo Books</code> vs <code>Argo Books</code>.</span>
+                    <span id="preheaderHintNote" style="display:none;"><br><strong>Preheader variants are literal-only</strong> — this is the snippet most inboxes show next to the subject. Use short, scannable text. Try things like <code>Quick question about your business</code> vs <code>Free 1-year license inside</code> vs leave one variant blank to test the &ldquo;no preheader&rdquo; baseline.</span>
                 </p>
 
                 <div id="abVariantRows"></div>
@@ -329,10 +331,9 @@ function ab_tests_tab_render_list($pdo)
             <ul class="idea-list">
                 <li><strong>Email body / opener</strong> &mdash; schema already supports <code>variant_type='body'</code>; prompt just swaps the body directive. Biggest remaining lever after subject.</li>
                 <li><strong>CTA framing</strong> &mdash; "free 1-year premium license for feedback" vs "15 min chat in exchange for a year free".</li>
-                <li><strong>Preheader / preview text</strong> &mdash; the text next to the subject in the inbox.</li>
                 <li><strong>Sender name</strong> &mdash; "Evan" vs "Evan at Argo Books" vs "Argo Books".</li>
                 <li><strong>Personalization depth</strong> &mdash; with vs without the AI-generated <code>business_summary</code>.</li>
-                <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder.</li>
+                <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder (author as a body directive).</li>
             </ul>
             <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, HTML vs plain-text, unsubscribe placement.</p>
         </div>
@@ -400,15 +401,17 @@ function ab_tests_tab_render_list($pdo)
             container.appendChild(makeRow(1));
             refreshIndices();
 
-            // Show sender-specific note when 'sender' is selected as the variant type.
+            // Show type-specific notes when the matching type is selected.
             var typeSelect = document.getElementById('abVariantType');
             var senderNote = document.getElementById('senderHintNote');
-            if (typeSelect && senderNote) {
-                var syncSenderNote = function () {
-                    senderNote.style.display = typeSelect.value === 'sender' ? 'inline' : 'none';
+            var preheaderNote = document.getElementById('preheaderHintNote');
+            if (typeSelect) {
+                var syncTypeNotes = function () {
+                    if (senderNote) senderNote.style.display = typeSelect.value === 'sender' ? 'inline' : 'none';
+                    if (preheaderNote) preheaderNote.style.display = typeSelect.value === 'preheader' ? 'inline' : 'none';
                 };
-                typeSelect.addEventListener('change', syncSenderNote);
-                syncSenderNote();
+                typeSelect.addEventListener('change', syncTypeNotes);
+                syncTypeNotes();
             }
         })();
     </script>

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -222,6 +222,7 @@ function ab_tests_tab_render_list($pdo)
             </p>
             <form method="POST" id="abCreateForm">
                 <input type="hidden" name="tab" value="ab-tests">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                 <input type="hidden" name="action" value="create">
 
                 <div class="form-row">
@@ -326,6 +327,7 @@ function ab_tests_tab_render_list($pdo)
                                         <?php if ($t['status'] === 'draft' || $t['status'] === 'paused'): ?>
                                             <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other currently active test will be paused (only one A/B test can be active at a time).');">
                                                 <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                                                 <input type="hidden" name="action" value="status_change">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
                                                 <input type="hidden" name="status" value="active">
@@ -334,6 +336,7 @@ function ab_tests_tab_render_list($pdo)
                                         <?php elseif ($t['status'] === 'active'): ?>
                                             <form method="POST" style="display:inline;">
                                                 <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                                                 <input type="hidden" name="action" value="status_change">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
                                                 <input type="hidden" name="status" value="paused">
@@ -478,6 +481,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                 <?php if ($test['status'] === 'draft' || $test['status'] === 'paused'): ?>
                     <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other currently active test will be paused (only one A/B test can be active at a time).');">
                         <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="active">
@@ -486,6 +490,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                 <?php elseif ($test['status'] === 'active'): ?>
                     <form method="POST" style="display:inline;">
                         <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="paused">
@@ -493,6 +498,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                     </form>
                     <form method="POST" style="display:inline;" onsubmit="return confirm('End this test without picking a winner? Existing leads keep their variant; new leads stop getting assigned.');">
                         <input type="hidden" name="tab" value="ab-tests">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="completed">
@@ -542,6 +548,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
 
             <form method="POST" style="margin-top:4px;">
                 <input type="hidden" name="tab" value="ab-tests">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                 <input type="hidden" name="action" value="update_notes">
                 <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                 <div class="form-group">
@@ -620,6 +627,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                                         <?php if ($test['status'] !== 'completed'): ?>
                                             <form method="POST" style="display:inline;" onsubmit="return confirm('Promote this variant and end the test? No more new leads will be assigned.');">
                                                 <input type="hidden" name="tab" value="ab-tests">
+                                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                                                 <input type="hidden" name="action" value="promote">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                                                 <input type="hidden" name="variant_id" value="<?php echo (int) $v['id']; ?>">

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -37,7 +37,7 @@ function ab_tests_tab_handle_post($pdo)
             header('Location: index.php?tab=ab-tests'); exit;
         }
 
-        if (!in_array($variantType, ['subject', 'body', 'sender', 'cta', 'preheader', 'format'], true)) {
+        if (!in_array($variantType, ['subject', 'body', 'sender', 'cta', 'preheader', 'format', 'personalization'], true)) {
             $variantType = 'subject';
         }
 
@@ -47,6 +47,15 @@ function ab_tests_tab_handle_post($pdo)
             $rows = [
                 ['label' => 'A', 'content' => 'html',  'is_default' => 1],
                 ['label' => 'B', 'content' => 'plain', 'is_default' => 0],
+            ];
+        } elseif ($variantType === 'personalization') {
+            // Personalization tests are fixed: on (current behaviour, includes
+            // the AI-generated business_summary) vs off (skip the summary call
+            // entirely). Variant content is the literal string read by
+            // generate_draft_for_lead.
+            $rows = [
+                ['label' => 'A', 'content' => 'on',  'is_default' => 1],
+                ['label' => 'B', 'content' => 'off', 'is_default' => 0],
             ];
         } else {
             $rows = [];
@@ -230,6 +239,7 @@ function ab_tests_tab_render_list($pdo)
                             <option value="sender">Sender from-name</option>
                             <option value="preheader">Preheader (inbox preview)</option>
                             <option value="format">Format (HTML vs plain text)</option>
+                            <option value="personalization">Personalization (with vs without business summary)</option>
                         </select>
                     </div>
                 </div>
@@ -246,12 +256,17 @@ function ab_tests_tab_render_list($pdo)
                     <span id="senderHintNote" style="display:none;"><br><strong>Sender variants are literal-only</strong> — the from-name string is used as-is in the email envelope, with no AI interpretation. Skip the <code>directive:</code> prefix here. Try things like <code>Evan</code> vs <code>Evan from Argo Books</code> vs <code>Argo Books</code>.</span>
                     <span id="preheaderHintNote" style="display:none;"><br><strong>Preheader variants are literal-only</strong> — this is the snippet most inboxes show next to the subject. Use short, scannable text. Try things like <code>Quick question about your business</code> vs <code>Free 1-year license inside</code> vs leave one variant blank to test the &ldquo;no preheader&rdquo; baseline.</span>
                     <span id="formatHintNote" style="display:none;"><br><strong>Format is a fixed two-variant test</strong> — Variant A sends the full styled HTML email (current behaviour); Variant B sends the same content as plain text (no template, no logo, bare URLs). The variant rows below are not used for this test type.</span>
+                    <span id="personalizationHintNote" style="display:none;"><br><strong>Personalization is a fixed two-variant test</strong> — Variant A keeps the AI-generated <code>business_summary</code> (current behaviour, costs an OpenAI call per lead). Variant B skips the summary entirely. Use it to find out whether the extra call actually moves CTR.</span>
                 </p>
 
                 <div id="abVariantRows"></div>
 
                 <div id="abFormatFixedNotice" class="hint" style="display:none; padding:10px; border:1px dashed var(--border-color, #d1d5db); border-radius:6px; margin-top:8px;">
                     Will create two variants automatically: <strong>A &mdash; <code>html</code></strong> (default) and <strong>B &mdash; <code>plain</code></strong>.
+                </div>
+
+                <div id="abPersonalizationFixedNotice" class="hint" style="display:none; padding:10px; border:1px dashed var(--border-color, #d1d5db); border-radius:6px; margin-top:8px;">
+                    Will create two variants automatically: <strong>A &mdash; <code>on</code></strong> (default, summary included) and <strong>B &mdash; <code>off</code></strong> (summary skipped).
                 </div>
 
                 <div id="abVariantControls" style="display:flex; gap:8px; margin-top:8px; align-items:center;">
@@ -347,7 +362,6 @@ function ab_tests_tab_render_list($pdo)
                 <li><strong>Email body / opener</strong> &mdash; schema already supports <code>variant_type='body'</code>; prompt just swaps the body directive. Biggest remaining lever after subject.</li>
                 <li><strong>CTA framing</strong> &mdash; "free 1-year premium license for feedback" vs "15 min chat in exchange for a year free".</li>
                 <li><strong>Sender name</strong> &mdash; "Evan" vs "Evan at Argo Books" vs "Argo Books".</li>
-                <li><strong>Personalization depth</strong> &mdash; with vs without the AI-generated <code>business_summary</code>.</li>
                 <li><strong>Tone</strong> &mdash; casual local-developer vs professional founder (author as a body directive).</li>
             </ul>
             <p class="hint">Parked for now (too noisy at ~10 sends/day): send time of day, unsubscribe placement.</p>
@@ -421,7 +435,9 @@ function ab_tests_tab_render_list($pdo)
             var senderNote = document.getElementById('senderHintNote');
             var preheaderNote = document.getElementById('preheaderHintNote');
             var formatNote = document.getElementById('formatHintNote');
+            var personalizationNote = document.getElementById('personalizationHintNote');
             var formatFixedNotice = document.getElementById('abFormatFixedNotice');
+            var personalizationFixedNotice = document.getElementById('abPersonalizationFixedNotice');
             var variantRows = document.getElementById('abVariantRows');
             var variantControls = document.getElementById('abVariantControls');
             if (typeSelect) {
@@ -430,10 +446,12 @@ function ab_tests_tab_render_list($pdo)
                     if (senderNote) senderNote.style.display = v === 'sender' ? 'inline' : 'none';
                     if (preheaderNote) preheaderNote.style.display = v === 'preheader' ? 'inline' : 'none';
                     if (formatNote) formatNote.style.display = v === 'format' ? 'inline' : 'none';
-                    var isFormat = (v === 'format');
-                    if (variantRows) variantRows.style.display = isFormat ? 'none' : '';
-                    if (variantControls) variantControls.style.display = isFormat ? 'none' : 'flex';
-                    if (formatFixedNotice) formatFixedNotice.style.display = isFormat ? 'block' : 'none';
+                    if (personalizationNote) personalizationNote.style.display = v === 'personalization' ? 'inline' : 'none';
+                    var isFixed = (v === 'format' || v === 'personalization');
+                    if (variantRows) variantRows.style.display = isFixed ? 'none' : '';
+                    if (variantControls) variantControls.style.display = isFixed ? 'none' : 'flex';
+                    if (formatFixedNotice) formatFixedNotice.style.display = v === 'format' ? 'block' : 'none';
+                    if (personalizationFixedNotice) personalizationFixedNotice.style.display = v === 'personalization' ? 'block' : 'none';
                 };
                 typeSelect.addEventListener('change', syncTypeNotes);
                 syncTypeNotes();

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -237,7 +237,7 @@ function ab_tests_tab_render_list($pdo)
                 <div id="abVariantRows"></div>
 
                 <div style="display:flex; gap:8px; margin-top:8px; align-items:center;">
-                    <button type="button" class="btn btn-small" onclick="abAddVariantRow()">+ Add variant</button>
+                    <button type="button" class="btn btn-small btn-neutral" onclick="abAddVariantRow()">+ Add variant</button>
                     <span class="hint" id="abVariantCountHint">2 of up to 4 variants</span>
                 </div>
 
@@ -355,7 +355,7 @@ function ab_tests_tab_render_list($pdo)
                 row.innerHTML =
                     '<div class="variant-row-header">' +
                         '<label><input type="radio" name="default_variant" value="' + idx + '"' + (idx === 0 ? ' checked' : '') + '> Default</label>' +
-                        '<button type="button" class="btn btn-small variant-remove" title="Remove variant">&times;</button>' +
+                        '<button type="button" class="btn btn-small btn-neutral variant-remove" title="Remove variant">&times;</button>' +
                     '</div>' +
                     '<div class="form-row">' +
                         '<div class="form-group" style="flex:0 0 110px;">' +

--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -58,11 +58,24 @@ function ab_tests_tab_handle_post($pdo)
                 ['label' => 'B', 'content' => 'off', 'is_default' => 0],
             ];
         } else {
+            // Sender/preheader variants are applied verbatim at send time
+            // (no AI interpretation), so a "directive:" prefix would just be
+            // taken literally. Reject server-side so admins can't accidentally
+            // misconfigure it past the UI hint.
+            $literalOnlyTypes = ['sender', 'preheader'];
+
             $rows = [];
             foreach ($variantLabels as $i => $label) {
                 $label = trim((string) $label);
                 $content = trim((string) ($variantContents[$i] ?? ''));
                 if ($label === '' || $content === '') continue;
+
+                if (in_array($variantType, $literalOnlyTypes, true) && stripos($content, 'directive:') === 0) {
+                    $_SESSION['message'] = ucfirst($variantType) . ' variants are literal-only — remove the "directive:" prefix.';
+                    $_SESSION['message_type'] = 'error';
+                    header('Location: index.php?tab=ab-tests'); exit;
+                }
+
                 $rows[] = ['label' => $label, 'content' => $content, 'is_default' => ($i === $defaultIdx) ? 1 : 0];
             }
 
@@ -380,8 +393,8 @@ function ab_tests_tab_render_list($pdo)
                             '<input type="text" name="variant_label[]" value="' + renderLabel(idx) + '" required>' +
                         '</div>' +
                         '<div class="form-group" style="flex:1; min-width:240px;">' +
-                            '<label>Subject or <code>directive:</code> prompt</label>' +
-                            '<input type="text" name="variant_content[]" placeholder="e.g. Thought of you guys  OR  directive: Ask a curiosity question referencing the city" required>' +
+                            '<label>Variant content</label>' +
+                            '<input type="text" name="variant_content[]" placeholder="literal value, or directive: a style for the AI to follow" required>' +
                         '</div>' +
                     '</div>';
                 row.querySelector('.variant-remove').addEventListener('click', function() {

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -91,9 +91,16 @@ function settings_tab_render($pdo)
     // fresh install keeps behaving as before.
     $outreachEnabled = settings_tab_get_state($pdo, 'outreach_enabled', '1') === '1';
 
-    // Current state — default to 'auto' for send mode and '1' for A/B automation
-    $autoSendMode = settings_tab_get_state($pdo, 'auto_send_mode', 'auto');
-    if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = 'auto';
+    // Current state. Use the same fallback as the cron pipeline so the UI
+    // and the pipeline agree on the effective send mode before the admin
+    // explicitly chooses one. cron/outreach_pipeline.php derives the default
+    // from OUTREACH_AUTO_APPROVE (auto if truthy, review otherwise) — match
+    // that here so a fresh install with OUTREACH_AUTO_APPROVE=false doesn't
+    // show "Auto-send" in the UI while the cron actually behaves as Review.
+    $autoApproveRaw = strtolower(trim((string) ($_ENV['OUTREACH_AUTO_APPROVE'] ?? 'true')));
+    $defaultAutoSendMode = filter_var($autoApproveRaw, FILTER_VALIDATE_BOOLEAN) ? 'auto' : 'review';
+    $autoSendMode = settings_tab_get_state($pdo, 'auto_send_mode', $defaultAutoSendMode);
+    if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = $defaultAutoSendMode;
 
     $abAutoEnabled = settings_tab_get_state($pdo, 'ab_auto_enabled', '1') === '1';
     require_once __DIR__ . '/../../../cron/lib/outreach_helpers.php';
@@ -228,7 +235,7 @@ function settings_tab_render($pdo)
                     <input type="hidden" name="mode" value="review">
                     <button type="submit" class="segmented-option <?php echo $autoSendMode === 'review' ? 'active' : ''; ?>">
                         <span class="segmented-title">Review before send</span>
-                        <span class="segmented-desc">Pipeline generates drafts and stops. You approve each from the Leads tab.</span>
+                        <span class="segmented-desc">Pipeline generates drafts and stops. Review or edit them in the Leads tab, then click Send Email (or use bulk send).</span>
                     </button>
                 </form>
             </div>

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -155,7 +155,7 @@ function settings_tab_render($pdo)
         if (is_array($lines)) {
             $tail = array_slice($lines, -200);
             foreach ($tail as $line) {
-                if (preg_match('/A\/B|ab_auto|stepManageAbTests|subject cycle|Promoted variant/i', $line)) {
+                if (preg_match('/A\/B|ab_auto|stepManageAbTests|auto-cycle|auto-rotation|Promoted variant/i', $line)) {
                     $logLines[] = $line;
                 }
             }
@@ -245,9 +245,11 @@ function settings_tab_render($pdo)
         </div>
         <div class="panel-content">
             <p class="hint" style="margin-top:0;">
-                When on, the pipeline runs subject-line tests by itself: it auto-generates 3 variants with OpenAI each cycle,
-                promotes the winner when it has enough data (or after 14&ndash;28 days), and starts the next cycle.
-                It will self-pause if CTR drops below <?php echo number_format($ctrFloor * 100, 1); ?>%.
+                When on, the pipeline runs A/B cycles by itself: it auto-generates variants each cycle (or uses the
+                fixed pool for sender / format / personalization), promotes the winner when it has enough data (or
+                after 14&ndash;28 days), and starts the next cycle. By default it cycles only subject-line tests
+                &mdash; flip the auto-rotation toggle below to cycle across other types too.
+                It will self-pause if winner CTR drops below <?php echo number_format($ctrFloor * 100, 1); ?>%.
             </p>
             <div class="segmented-toggle">
                 <form method="POST" style="display:contents;">
@@ -354,7 +356,7 @@ function settings_tab_render($pdo)
                     </div>
                 </div>
             <?php else: ?>
-                <p class="empty-state">No active subject-line test.
+                <p class="empty-state">No active A/B test.
                     <?php if ($abAutoEnabled): ?>
                         The next pipeline run will create one.
                     <?php endif; ?>

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -82,6 +82,15 @@ function settings_tab_handle_post($pdo)
         header('Location: index.php?tab=settings'); exit;
     }
 
+    if ($action === 'set_ab_auto_rotation') {
+        $enabled = $_POST['enabled'] ?? '';
+        $val = ($enabled === '1') ? '1' : '0';
+        settings_tab_set_state($pdo, 'ab_auto_rotation', $val);
+        $_SESSION['message'] = 'A/B auto-rotation: ' . ($val === '1' ? 'ON' : 'OFF');
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?tab=settings'); exit;
+    }
+
     header('Location: index.php?tab=settings'); exit;
 }
 
@@ -96,6 +105,13 @@ function settings_tab_render($pdo)
     if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = 'auto';
 
     $abAutoEnabled = settings_tab_get_state($pdo, 'ab_auto_enabled', '1') === '1';
+    $abAutoRotation = settings_tab_get_state($pdo, 'ab_auto_rotation', '0') === '1';
+    require_once __DIR__ . '/../../../cron/lib/outreach_helpers.php';
+    $rotationOrder = ab_auto_rotation_order();
+    $abNextType = settings_tab_get_state($pdo, 'ab_auto_next_type', $rotationOrder[0]);
+    if (!in_array($abNextType, $rotationOrder, true)) {
+        $abNextType = $rotationOrder[0];
+    }
 
     $dailyLimit = (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10);
     $ctrFloor = (float) settings_tab_get_state($pdo, 'ab_ctr_floor', '0.01');
@@ -250,6 +266,42 @@ function settings_tab_render($pdo)
                     <button type="submit" class="segmented-option <?php echo !$abAutoEnabled ? 'active' : ''; ?>">
                         <span class="segmented-title">Off</span>
                         <span class="segmented-desc">Active test keeps running; no new cycles start.</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>A/B auto-rotation</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">
+                When on, completed cycles trigger the next type in rotation:
+                <strong><?php echo htmlspecialchars(implode(' &rarr; ', $rotationOrder)); ?></strong> &rarr; (loop).
+                When off, only subject-line cycles auto-create. Body / CTA / preheader stay admin-initiated either way.
+                <?php if ($abAutoRotation): ?>
+                    <br>Next type the pipeline will start: <strong><?php echo htmlspecialchars($abNextType); ?></strong>.
+                <?php endif; ?>
+            </p>
+            <div class="segmented-toggle">
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_ab_auto_rotation">
+                    <input type="hidden" name="enabled" value="1">
+                    <button type="submit" class="segmented-option <?php echo $abAutoRotation ? 'active' : ''; ?>">
+                        <span class="segmented-title">On</span>
+                        <span class="segmented-desc">Cycle across subject, sender, format, personalization.</span>
+                    </button>
+                </form>
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_ab_auto_rotation">
+                    <input type="hidden" name="enabled" value="0">
+                    <button type="submit" class="segmented-option <?php echo !$abAutoRotation ? 'active' : ''; ?>">
+                        <span class="segmented-title">Off</span>
+                        <span class="segmented-desc">Subject-only auto-cycles (default).</span>
                     </button>
                 </form>
             </div>

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -140,7 +140,9 @@ function settings_tab_render($pdo)
     $logLines = [];
     $logPath = __DIR__ . '/../../../cron/logs/outreach_pipeline_' . date('Y-m-d') . '.log';
     if (is_readable($logPath)) {
-        // Read last ~200 lines then filter — avoid loading an enormous file entirely
+        // Logs are date-rotated daily so a single file stays small (typically a few KB
+        // per cron run). Load the day's file, take the last 200 lines, then filter
+        // for A/B-related events.
         $lines = @file($logPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if (is_array($lines)) {
             $tail = array_slice($lines, -200);
@@ -178,6 +180,7 @@ function settings_tab_render($pdo)
             <div class="segmented-toggle">
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_outreach_enabled">
                     <input type="hidden" name="enabled" value="1">
                     <button type="submit" class="segmented-option <?php echo $outreachEnabled ? 'active' : ''; ?>">
@@ -187,6 +190,7 @@ function settings_tab_render($pdo)
                 </form>
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_outreach_enabled">
                     <input type="hidden" name="enabled" value="0">
                     <button type="submit" class="segmented-option <?php echo !$outreachEnabled ? 'active' : ''; ?>">
@@ -209,6 +213,7 @@ function settings_tab_render($pdo)
             <div class="segmented-toggle">
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_auto_send_mode">
                     <input type="hidden" name="mode" value="auto">
                     <button type="submit" class="segmented-option <?php echo $autoSendMode === 'auto' ? 'active' : ''; ?>">
@@ -218,6 +223,7 @@ function settings_tab_render($pdo)
                 </form>
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_auto_send_mode">
                     <input type="hidden" name="mode" value="review">
                     <button type="submit" class="segmented-option <?php echo $autoSendMode === 'review' ? 'active' : ''; ?>">
@@ -256,6 +262,7 @@ function settings_tab_render($pdo)
             <div class="segmented-toggle">
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_ab_auto_enabled">
                     <input type="hidden" name="enabled" value="1">
                     <button type="submit" class="segmented-option <?php echo $abAutoEnabled ? 'active' : ''; ?>">
@@ -265,6 +272,7 @@ function settings_tab_render($pdo)
                 </form>
                 <form method="POST" style="display:contents;">
                     <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
                     <input type="hidden" name="action" value="set_ab_auto_enabled">
                     <input type="hidden" name="enabled" value="0">
                     <button type="submit" class="segmented-option <?php echo !$abAutoEnabled ? 'active' : ''; ?>">

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -82,15 +82,6 @@ function settings_tab_handle_post($pdo)
         header('Location: index.php?tab=settings'); exit;
     }
 
-    if ($action === 'set_ab_auto_rotation') {
-        $enabled = $_POST['enabled'] ?? '';
-        $val = ($enabled === '1') ? '1' : '0';
-        settings_tab_set_state($pdo, 'ab_auto_rotation', $val);
-        $_SESSION['message'] = 'A/B auto-rotation: ' . ($val === '1' ? 'ON' : 'OFF');
-        $_SESSION['message_type'] = 'success';
-        header('Location: index.php?tab=settings'); exit;
-    }
-
     header('Location: index.php?tab=settings'); exit;
 }
 
@@ -105,7 +96,6 @@ function settings_tab_render($pdo)
     if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = 'auto';
 
     $abAutoEnabled = settings_tab_get_state($pdo, 'ab_auto_enabled', '1') === '1';
-    $abAutoRotation = settings_tab_get_state($pdo, 'ab_auto_rotation', '0') === '1';
     require_once __DIR__ . '/../../../cron/lib/outreach_helpers.php';
     $rotationOrder = ab_auto_rotation_order();
     $abNextType = settings_tab_get_state($pdo, 'ab_auto_next_type', $rotationOrder[0]);
@@ -245,11 +235,23 @@ function settings_tab_render($pdo)
         </div>
         <div class="panel-content">
             <p class="hint" style="margin-top:0;">
-                When on, the pipeline runs A/B cycles by itself: it auto-generates variants each cycle (or uses the
-                fixed pool for sender / format / personalization), promotes the winner when it has enough data (or
-                after 14&ndash;28 days), and starts the next cycle. By default it cycles only subject-line tests
-                &mdash; flip the auto-rotation toggle below to cycle across other types too.
+                When on, the pipeline runs A/B cycles by itself: it auto-generates variants each cycle (or uses the fixed pool for sender / format / personalization), promotes the winner when it has enough data (or after 14&ndash;28 days), and starts the next cycle &mdash; rotating across types so it tests one lever, then another, and so on.
                 It will self-pause if winner CTR drops below <?php echo number_format($ctrFloor * 100, 1); ?>%.
+            </p>
+            <p class="hint">
+                Rotation order:
+            </p>
+            <ol class="hint" style="margin-top:0;">
+                <li><strong>Subject line</strong> &mdash; AI-generated subject styles.</li>
+                <li><strong>Sender from-name</strong> &mdash; "Evan" vs "Evan from Argo Books" vs "Argo Books".</li>
+                <li><strong>Format</strong> &mdash; full HTML email vs plain text.</li>
+                <li><strong>Personalization</strong> &mdash; with vs without the AI-generated business summary.</li>
+            </ol>
+            <p class="hint">
+                Body, CTA, and preheader tests aren't in the rotation: those need wording you write yourself, so they're always started by hand from the A/B Tests tab. Manual tests still work either way &mdash; they just delay the rotation while they run.
+                <?php if ($abAutoEnabled): ?>
+                    <br><br>The next type the cron will start is <strong><?php echo htmlspecialchars($abNextType); ?></strong> (assuming nothing else is running by then).
+                <?php endif; ?>
             </p>
             <div class="segmented-toggle">
                 <form method="POST" style="display:contents;">
@@ -258,7 +260,7 @@ function settings_tab_render($pdo)
                     <input type="hidden" name="enabled" value="1">
                     <button type="submit" class="segmented-option <?php echo $abAutoEnabled ? 'active' : ''; ?>">
                         <span class="segmented-title">On</span>
-                        <span class="segmented-desc">Runs on every hourly cron.</span>
+                        <span class="segmented-desc">Runs in the daily outreach cron.</span>
                     </button>
                 </form>
                 <form method="POST" style="display:contents;">
@@ -268,42 +270,6 @@ function settings_tab_render($pdo)
                     <button type="submit" class="segmented-option <?php echo !$abAutoEnabled ? 'active' : ''; ?>">
                         <span class="segmented-title">Off</span>
                         <span class="segmented-desc">Active test keeps running; no new cycles start.</span>
-                    </button>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <div class="panel">
-        <div class="panel-header">
-            <h2>A/B auto-rotation</h2>
-        </div>
-        <div class="panel-content">
-            <p class="hint" style="margin-top:0;">
-                When on, completed cycles trigger the next type in rotation:
-                <strong><?php echo htmlspecialchars(implode(' &rarr; ', $rotationOrder)); ?></strong> &rarr; (loop).
-                When off, only subject-line cycles auto-create. Body / CTA / preheader stay admin-initiated either way.
-                <?php if ($abAutoRotation): ?>
-                    <br>Next type the pipeline will start: <strong><?php echo htmlspecialchars($abNextType); ?></strong>.
-                <?php endif; ?>
-            </p>
-            <div class="segmented-toggle">
-                <form method="POST" style="display:contents;">
-                    <input type="hidden" name="tab" value="settings">
-                    <input type="hidden" name="action" value="set_ab_auto_rotation">
-                    <input type="hidden" name="enabled" value="1">
-                    <button type="submit" class="segmented-option <?php echo $abAutoRotation ? 'active' : ''; ?>">
-                        <span class="segmented-title">On</span>
-                        <span class="segmented-desc">Cycle across subject, sender, format, personalization.</span>
-                    </button>
-                </form>
-                <form method="POST" style="display:contents;">
-                    <input type="hidden" name="tab" value="settings">
-                    <input type="hidden" name="action" value="set_ab_auto_rotation">
-                    <input type="hidden" name="enabled" value="0">
-                    <button type="submit" class="segmented-option <?php echo !$abAutoRotation ? 'active' : ''; ?>">
-                        <span class="segmented-title">Off</span>
-                        <span class="segmented-desc">Subject-only auto-cycles (default).</span>
                     </button>
                 </form>
             </div>

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -100,10 +100,11 @@ function settings_tab_render($pdo)
     $dailyLimit = (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10);
     $ctrFloor = (float) settings_tab_get_state($pdo, 'ab_ctr_floor', '0.01');
 
-    // Active A/B test snapshot
+    // Active A/B test snapshot — show whichever variant_type is currently
+    // running (only one is active at a time, regardless of type).
     $active = null;
     try {
-        $stmt = $pdo->prepare("SELECT * FROM outreach_ab_tests WHERE status = 'active' AND variant_type = 'subject' ORDER BY started_at DESC, id DESC LIMIT 1");
+        $stmt = $pdo->prepare("SELECT * FROM outreach_ab_tests WHERE status = 'active' ORDER BY started_at DESC, id DESC LIMIT 1");
         $stmt->execute();
         $active = $stmt->fetch();
     } catch (PDOException $e) {
@@ -269,6 +270,10 @@ function settings_tab_render($pdo)
                                 <?php echo htmlspecialchars($active['name']); ?>
                             </a>
                         </div>
+                    </div>
+                    <div class="meta-item">
+                        <div class="meta-label">Type</div>
+                        <div class="meta-value"><?php echo htmlspecialchars($active['variant_type']); ?></div>
                     </div>
                     <div class="meta-item">
                         <div class="meta-label">Running for</div>

--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Settings tab partial.
+ *
+ * Renders toggles for:
+ *   - Auto-send vs Review-before-send (state: auto_send_mode)
+ *   - A/B automation on/off (state: ab_auto_enabled)
+ *
+ * Plus read-only status: current A/B test, daily send limit,
+ * and a tail of today's pipeline log filtered to automation lines.
+ *
+ * Exposes:
+ *   settings_tab_handle_post($pdo)
+ *   settings_tab_render($pdo)
+ *
+ * State values live in outreach_pipeline_state via getState/setState
+ * (defined in cron/outreach_pipeline.php, but those helpers are only
+ * loaded in CLI context — we define local equivalents here that use
+ * the same table).
+ */
+
+/**
+ * Local lightweight wrappers for outreach_pipeline_state.
+ * Matches the CLI getState/setState behaviour.
+ */
+function settings_tab_get_state($pdo, $key, $default = null)
+{
+    try {
+        $stmt = $pdo->prepare("SELECT state_value FROM outreach_pipeline_state WHERE state_key = ?");
+        $stmt->execute([$key]);
+        $row = $stmt->fetch();
+        return $row ? $row['state_value'] : $default;
+    } catch (PDOException $e) {
+        // Table may not exist yet on a fresh install — treat as default
+        return $default;
+    }
+}
+
+function settings_tab_set_state($pdo, $key, $value)
+{
+    $pdo->exec("CREATE TABLE IF NOT EXISTS outreach_pipeline_state (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        state_key VARCHAR(100) NOT NULL UNIQUE,
+        state_value TEXT,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    $stmt = $pdo->prepare("INSERT INTO outreach_pipeline_state (state_key, state_value) VALUES (?, ?)
+        ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)");
+    $stmt->execute([$key, $value]);
+}
+
+function settings_tab_handle_post($pdo)
+{
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'set_outreach_enabled') {
+        $enabled = $_POST['enabled'] ?? '';
+        $val = ($enabled === '1') ? '1' : '0';
+        settings_tab_set_state($pdo, 'outreach_enabled', $val);
+        $_SESSION['message'] = 'Outreach system: ' . ($val === '1' ? 'ENABLED' : 'DISABLED');
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?tab=settings'); exit;
+    }
+
+    if ($action === 'set_auto_send_mode') {
+        $mode = $_POST['mode'] ?? '';
+        if (in_array($mode, ['auto', 'review'], true)) {
+            settings_tab_set_state($pdo, 'auto_send_mode', $mode);
+            $_SESSION['message'] = 'Send mode set to: ' . ($mode === 'auto' ? 'Auto-send' : 'Review before send');
+            $_SESSION['message_type'] = 'success';
+        }
+        header('Location: index.php?tab=settings'); exit;
+    }
+
+    if ($action === 'set_ab_auto_enabled') {
+        $enabled = $_POST['enabled'] ?? '';
+        $val = ($enabled === '1') ? '1' : '0';
+        settings_tab_set_state($pdo, 'ab_auto_enabled', $val);
+        $_SESSION['message'] = 'A/B automation: ' . ($val === '1' ? 'ON' : 'OFF');
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?tab=settings'); exit;
+    }
+
+    header('Location: index.php?tab=settings'); exit;
+}
+
+function settings_tab_render($pdo)
+{
+    // Master enable flag for the whole outreach system — defaults ON so a
+    // fresh install keeps behaving as before.
+    $outreachEnabled = settings_tab_get_state($pdo, 'outreach_enabled', '1') === '1';
+
+    // Current state — default to 'auto' for send mode and '1' for A/B automation
+    $autoSendMode = settings_tab_get_state($pdo, 'auto_send_mode', 'auto');
+    if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = 'auto';
+
+    $abAutoEnabled = settings_tab_get_state($pdo, 'ab_auto_enabled', '1') === '1';
+
+    $dailyLimit = (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10);
+    $ctrFloor = (float) settings_tab_get_state($pdo, 'ab_ctr_floor', '0.01');
+
+    // Active A/B test snapshot
+    $active = null;
+    try {
+        $stmt = $pdo->prepare("SELECT * FROM outreach_ab_tests WHERE status = 'active' AND variant_type = 'subject' ORDER BY started_at DESC, id DESC LIMIT 1");
+        $stmt->execute();
+        $active = $stmt->fetch();
+    } catch (PDOException $e) {
+        $active = null; // Tables may not exist yet
+    }
+
+    $activeStats = null;
+    if ($active) {
+        require_once __DIR__ . '/../../../cron/lib/ab_helpers.php';
+        $variants = load_variants_with_stats($pdo, (int) $active['id']);
+        $leaderIdx = find_leader_idx($variants);
+        $totalSent = array_sum(array_column($variants, 'sent_count'));
+        $totalClicks = array_sum(array_column($variants, 'clicked_count'));
+        $days = max(0, (int) floor((time() - strtotime($active['started_at'] ?: $active['created_at'])) / 86400));
+        $activeStats = [
+            'variants' => count($variants),
+            'sent' => $totalSent,
+            'clicked' => $totalClicks,
+            'days' => $days,
+            'leader' => ($leaderIdx !== null) ? $variants[$leaderIdx]['label'] : null,
+            'leader_ctr' => ($leaderIdx !== null && $variants[$leaderIdx]['sent_count'] > 0)
+                ? $variants[$leaderIdx]['ctr'] : null,
+        ];
+    }
+
+    // Tail today's pipeline log for automation-related lines
+    $logLines = [];
+    $logPath = __DIR__ . '/../../../cron/logs/outreach_pipeline_' . date('Y-m-d') . '.log';
+    if (is_readable($logPath)) {
+        // Read last ~200 lines then filter — avoid loading an enormous file entirely
+        $lines = @file($logPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (is_array($lines)) {
+            $tail = array_slice($lines, -200);
+            foreach ($tail as $line) {
+                if (preg_match('/A\/B|ab_auto|stepManageAbTests|subject cycle|Promoted variant/i', $line)) {
+                    $logLines[] = $line;
+                }
+            }
+            $logLines = array_slice($logLines, -40);
+        }
+    }
+    ?>
+
+    <?php if ($abAutoEnabled === false): ?>
+        <div class="panel" style="border-left:3px solid #f59e0b;">
+            <div class="panel-content">
+                <strong>A/B automation is off.</strong>
+                <?php if (settings_tab_get_state($pdo, 'ab_auto_last_pause_reason')): ?>
+                    The last automated run paused itself: <em><?php echo htmlspecialchars((string) settings_tab_get_state($pdo, 'ab_auto_last_pause_reason')); ?></em>
+                <?php else: ?>
+                    Flip the toggle below to let the pipeline create and promote tests on its own.
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Outreach system</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">
+                Master switch for the whole pipeline. When OFF, the cron exits without touching anything — no discovery, no drafts, no sends — even if it's still scheduled at the server level. Use this when you want a full pause without deleting the cron job.
+            </p>
+            <div class="segmented-toggle">
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_outreach_enabled">
+                    <input type="hidden" name="enabled" value="1">
+                    <button type="submit" class="segmented-option <?php echo $outreachEnabled ? 'active' : ''; ?>">
+                        <span class="segmented-title">Enabled</span>
+                        <span class="segmented-desc">Pipeline runs as normal on its cron schedule.</span>
+                    </button>
+                </form>
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_outreach_enabled">
+                    <input type="hidden" name="enabled" value="0">
+                    <button type="submit" class="segmented-option <?php echo !$outreachEnabled ? 'active' : ''; ?>">
+                        <span class="segmented-title">Disabled</span>
+                        <span class="segmented-desc">Cron exits immediately. Nothing runs until re-enabled.</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Send mode</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">
+                Controls whether the hourly pipeline auto-approves and sends drafts, or stops at draft generation for you to review.
+            </p>
+            <div class="segmented-toggle">
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_auto_send_mode">
+                    <input type="hidden" name="mode" value="auto">
+                    <button type="submit" class="segmented-option <?php echo $autoSendMode === 'auto' ? 'active' : ''; ?>">
+                        <span class="segmented-title">Auto-send</span>
+                        <span class="segmented-desc">Drafts are auto-approved and sent, up to <?php echo $dailyLimit; ?>/day.</span>
+                    </button>
+                </form>
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_auto_send_mode">
+                    <input type="hidden" name="mode" value="review">
+                    <button type="submit" class="segmented-option <?php echo $autoSendMode === 'review' ? 'active' : ''; ?>">
+                        <span class="segmented-title">Review before send</span>
+                        <span class="segmented-desc">Pipeline generates drafts and stops. You approve each from the Leads tab.</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>A/B automation</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">
+                When on, the pipeline runs subject-line tests by itself: it auto-generates 3 variants with OpenAI each cycle,
+                promotes the winner when it has enough data (or after 14&ndash;28 days), and starts the next cycle.
+                It will self-pause if CTR drops below <?php echo number_format($ctrFloor * 100, 1); ?>%.
+            </p>
+            <div class="segmented-toggle">
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_ab_auto_enabled">
+                    <input type="hidden" name="enabled" value="1">
+                    <button type="submit" class="segmented-option <?php echo $abAutoEnabled ? 'active' : ''; ?>">
+                        <span class="segmented-title">On</span>
+                        <span class="segmented-desc">Runs on every hourly cron.</span>
+                    </button>
+                </form>
+                <form method="POST" style="display:contents;">
+                    <input type="hidden" name="tab" value="settings">
+                    <input type="hidden" name="action" value="set_ab_auto_enabled">
+                    <input type="hidden" name="enabled" value="0">
+                    <button type="submit" class="segmented-option <?php echo !$abAutoEnabled ? 'active' : ''; ?>">
+                        <span class="segmented-title">Off</span>
+                        <span class="segmented-desc">Active test keeps running; no new cycles start.</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Current A/B status</h2>
+        </div>
+        <div class="panel-content">
+            <?php if ($active && $activeStats): ?>
+                <div class="test-meta">
+                    <div class="meta-item">
+                        <div class="meta-label">Active test</div>
+                        <div class="meta-value">
+                            <a href="?tab=ab-tests&test_id=<?php echo (int) $active['id']; ?>" class="link-strong">
+                                <?php echo htmlspecialchars($active['name']); ?>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="meta-item">
+                        <div class="meta-label">Running for</div>
+                        <div class="meta-value"><?php echo (int) $activeStats['days']; ?> day<?php echo $activeStats['days'] === 1 ? '' : 's'; ?></div>
+                    </div>
+                    <div class="meta-item">
+                        <div class="meta-label">Variants</div>
+                        <div class="meta-value"><?php echo (int) $activeStats['variants']; ?></div>
+                    </div>
+                    <div class="meta-item">
+                        <div class="meta-label">Sent / clicked</div>
+                        <div class="meta-value"><?php echo (int) $activeStats['sent']; ?> / <?php echo (int) $activeStats['clicked']; ?></div>
+                    </div>
+                    <div class="meta-item">
+                        <div class="meta-label">Current leader</div>
+                        <div class="meta-value">
+                            <?php if ($activeStats['leader']): ?>
+                                <?php echo htmlspecialchars($activeStats['leader']); ?>
+                                <?php if ($activeStats['leader_ctr'] !== null): ?>
+                                    <span class="hint" style="margin:0; font-size:12px;">(<?php echo number_format($activeStats['leader_ctr'] * 100, 1); ?>% CTR)</span>
+                                <?php endif; ?>
+                            <?php else: ?>
+                                —
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            <?php else: ?>
+                <p class="empty-state">No active subject-line test.
+                    <?php if ($abAutoEnabled): ?>
+                        The next pipeline run will create one.
+                    <?php endif; ?>
+                </p>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Today's automation log</h2>
+        </div>
+        <div class="panel-content">
+            <?php if (!empty($logLines)): ?>
+                <pre class="log-tail"><?php echo htmlspecialchars(implode("\n", $logLines)); ?></pre>
+            <?php else: ?>
+                <p class="empty-state">No automation entries in today's log yet.</p>
+            <?php endif; ?>
+        </div>
+    </div>
+    <?php
+}

--- a/admin/payments/index.php
+++ b/admin/payments/index.php
@@ -376,19 +376,19 @@ include __DIR__ . '/../admin_header.php';
     </div>
 
     <!-- Tab Navigation -->
-    <div class="tab-buttons">
-        <div class="tab-button active" onclick="switchTab('overview')">Overview</div>
-        <div class="tab-button" onclick="switchTab('transactions')">Transactions</div>
-        <div class="tab-button" onclick="switchTab('companies')">Companies</div>
-        <div class="tab-button" onclick="switchTab('invoices')">Invoices</div>
-        <div class="tab-button" onclick="switchTab('revenue')">Payment Analytics</div>
-        <div class="tab-button" onclick="switchTab('failures')">Failed & Refunds</div>
+    <div class="section-tabs">
+        <button class="section-tab active" data-tab="overview">Overview</button>
+        <button class="section-tab" data-tab="transactions">Transactions</button>
+        <button class="section-tab" data-tab="companies">Companies</button>
+        <button class="section-tab" data-tab="invoices">Invoices</button>
+        <button class="section-tab" data-tab="revenue">Payment Analytics</button>
+        <button class="section-tab" data-tab="failures">Failed & Refunds</button>
     </div>
 
     <!-- ============================================================ -->
     <!-- TAB 1: OVERVIEW -->
     <!-- ============================================================ -->
-    <div id="overview-tab" class="tab-content active">
+    <div id="overview" class="tab-content active">
         <!-- Stat Cards -->
         <div class="stats-grid">
             <div class="stat-card">
@@ -495,7 +495,7 @@ include __DIR__ . '/../admin_header.php';
     <!-- ============================================================ -->
     <!-- TAB 2: TRANSACTIONS -->
     <!-- ============================================================ -->
-    <div id="transactions-tab" class="tab-content">
+    <div id="transactions" class="tab-content">
         <!-- Filters -->
         <div class="filters-bar">
             <form method="GET" class="filters-form" id="tx-filters-form">
@@ -591,7 +591,7 @@ include __DIR__ . '/../admin_header.php';
     <!-- ============================================================ -->
     <!-- TAB 3: COMPANIES -->
     <!-- ============================================================ -->
-    <div id="companies-tab" class="tab-content">
+    <div id="companies" class="tab-content">
         <div class="table-container">
             <div class="table-header">
                 <h2>Portal Companies</h2>
@@ -733,7 +733,7 @@ include __DIR__ . '/../admin_header.php';
     <!-- ============================================================ -->
     <!-- TAB 4: INVOICES -->
     <!-- ============================================================ -->
-    <div id="invoices-tab" class="tab-content">
+    <div id="invoices" class="tab-content">
         <!-- Filters -->
         <div class="filters-bar">
             <form method="GET" class="filters-form" id="inv-filters-form">
@@ -815,7 +815,7 @@ include __DIR__ . '/../admin_header.php';
     <!-- ============================================================ -->
     <!-- TAB 5: REVENUE ANALYTICS -->
     <!-- ============================================================ -->
-    <div id="revenue-tab" class="tab-content">
+    <div id="revenue" class="tab-content">
         <!-- Summary Metrics -->
         <div class="stats-grid">
             <div class="stat-card">
@@ -885,7 +885,7 @@ include __DIR__ . '/../admin_header.php';
     <!-- ============================================================ -->
     <!-- TAB 6: FAILED PAYMENTS & REFUNDS -->
     <!-- ============================================================ -->
-    <div id="failures-tab" class="tab-content">
+    <div id="failures" class="tab-content">
         <!-- Summary Stats -->
         <div class="stats-grid stats-grid-3">
             <div class="stat-card">
@@ -983,29 +983,7 @@ include __DIR__ . '/../admin_header.php';
 </div>
 
 <script>
-// ============================================================
-// Tab Switching
-// ============================================================
-function switchTab(tabName) {
-    const tabContents = document.querySelectorAll('.tab-content');
-    tabContents.forEach(content => content.classList.remove('active'));
-
-    const tabButtons = document.querySelectorAll('.tab-button');
-    tabButtons.forEach(button => button.classList.remove('active'));
-
-    const selectedTab = document.getElementById(tabName + '-tab');
-    if (selectedTab) selectedTab.classList.add('active');
-
-    event.target.classList.add('active');
-}
-
-// Restore tab from URL parameter
-const urlParams = new URLSearchParams(window.location.search);
-const tabParam = urlParams.get('tab');
-if (tabParam) {
-    const btn = document.querySelector(`.tab-button[onclick*="'${tabParam}'"]`);
-    if (btn) btn.click();
-}
+// Tab switching is handled centrally by admin/section-tabs.js
 
 // ============================================================
 // Company Detail Toggle

--- a/admin/payments/style.css
+++ b/admin/payments/style.css
@@ -48,57 +48,7 @@
     color: var(--amber-800);
 }
 
-/* ============================================================
-   Tab Buttons (matches app-stats pattern)
-   ============================================================ */
-.tab-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin-bottom: 1.5rem;
-    border-bottom: 2px solid var(--gray-border);
-    justify-content: center;
-}
-
-.tab-button {
-    padding: 12px 20px;
-    background: var(--whiteBackground);
-    border: 1px solid var(--gray-input-border);
-    border-bottom: none;
-    border-radius: 8px 8px 0 0;
-    cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 500;
-    color: var(--gray-text);
-    transition: all 0.2s ease;
-    user-select: none;
-}
-
-.tab-button:hover {
-    background: var(--gray-bg-light);
-    color: var(--gray-text-dark);
-}
-
-.tab-button.active {
-    background: var(--white);
-    color: var(--gray-text-darker);
-    box-shadow: 0 -2px 8px var(--shadow-default);
-    font-weight: 600;
-}
-
-.tab-content {
-    display: none;
-    animation: fadeIn 0.3s ease-in-out;
-}
-
-.tab-content.active {
-    display: block;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
+/* Tab styles are shared across admin pages — see admin/common-style.css (.section-tabs / .section-tab / .tab-content) */
 
 /* ============================================================
    Stats Grid
@@ -496,11 +446,11 @@
         padding: 0;
     }
 
-    .tab-buttons {
+    .section-tabs {
         gap: 2px;
     }
 
-    .tab-button {
+    .section-tab {
         padding: 10px 12px;
         font-size: 0.8rem;
     }
@@ -521,7 +471,7 @@
 }
 
 @media (max-width: 480px) {
-    .tab-button {
+    .section-tab {
         padding: 8px 10px;
         font-size: 0.75rem;
     }

--- a/admin/reports/index.php
+++ b/admin/reports/index.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== tru
 
 // Set page variables for the header
 $page_title = "Content Reports";
-$page_description = "Review and moderate reported posts and comments";
+$page_description = "Review and moderate reported posts and comments on the community page";
 
 // Get filter parameters
 $status_filter = $_GET['status'] ?? 'pending';

--- a/admin/section-tabs.js
+++ b/admin/section-tabs.js
@@ -1,0 +1,94 @@
+/**
+ * Shared section-tabs controller for admin pages.
+ *
+ * Auto-wires any `.section-tab[data-tab]` buttons inside a `.section-tabs`
+ * container, toggles matching `.tab-content` siblings, and syncs the
+ * current tab with the URL via `?tab=<id>` for deep linking.
+ *
+ * Each tab's `data-tab` value must equal the id of the .tab-content div
+ * it activates. Markup lives in each admin page; CSS lives in common-style.css.
+ */
+(function () {
+    function activate(tabBtn) {
+        var tabsContainer = tabBtn.closest('.section-tabs');
+        if (!tabsContainer) return;
+        var targetId = tabBtn.dataset.tab;
+        if (!targetId) return;
+
+        tabsContainer.querySelectorAll('.section-tab').forEach(function (b) {
+            b.classList.remove('active');
+        });
+
+        var scope = tabsContainer.parentElement;
+        if (scope) {
+            scope.querySelectorAll(':scope > .tab-content').forEach(function (c) {
+                c.classList.remove('active');
+            });
+        }
+
+        tabBtn.classList.add('active');
+        var target = document.getElementById(targetId);
+        if (target) target.classList.add('active');
+    }
+
+    // Query params that, when present in the current URL, indicate a
+    // server-rendered "detail view". Clicking a tab while one of these is
+    // set should do a real navigation (not just a CSS swap), so the stale
+    // detail markup gets replaced by the fresh list view.
+    var DETAIL_VIEW_PARAMS = ['test_id'];
+
+    function updateUrlOrReload(tabId) {
+        try {
+            var url = new URL(window.location.href);
+            var currentHadDetail = DETAIL_VIEW_PARAMS.some(function (p) {
+                return url.searchParams.has(p);
+            });
+
+            url.searchParams.set('tab', tabId);
+            DETAIL_VIEW_PARAMS.forEach(function (p) { url.searchParams.delete(p); });
+            if (url.hash) url.hash = '';
+
+            if (currentHadDetail) {
+                window.location.assign(url.toString());
+            } else {
+                history.replaceState({}, '', url.toString());
+            }
+        } catch (e) {
+            // URL APIs missing — ignore; click still works visually.
+        }
+    }
+
+    function wireClicks() {
+        document.querySelectorAll('.section-tabs .section-tab[data-tab]').forEach(function (btn) {
+            if (btn.dataset.sectionTabWired === '1') return;
+            btn.dataset.sectionTabWired = '1';
+            btn.addEventListener('click', function () {
+                activate(btn);
+                updateUrlOrReload(btn.dataset.tab);
+            });
+        });
+    }
+
+    function activateInitial() {
+        var urlParams = new URLSearchParams(window.location.search);
+        var tabFromQuery = urlParams.get('tab');
+        var hash = window.location.hash ? window.location.hash.substring(1) : '';
+        var initial = tabFromQuery || hash;
+        if (!initial) return;
+
+        var sel = '.section-tab[data-tab="' + (window.CSS && CSS.escape ? CSS.escape(initial) : initial) + '"]';
+        var btn = document.querySelector(sel);
+        if (btn) activate(btn);
+    }
+
+    function bootstrap() {
+        wireClicks();
+        activateInitial();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bootstrap);
+    } else {
+        bootstrap();
+    }
+})();

--- a/cron/lib/ab_helpers.php
+++ b/cron/lib/ab_helpers.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Shared pure-PHP helpers for the A/B testing subsystem.
+ *
+ * Used by:
+ *   - admin/outreach/tabs/ab-tests.php  (UI partial)
+ *   - cron/lib/outreach_helpers.php     (automation: stepManageAbTests)
+ *
+ * All functions here are side-effect-free. DB access lives in outreach_helpers.
+ */
+
+if (defined('OUTREACH_AB_HELPERS_LOADED')) return;
+define('OUTREACH_AB_HELPERS_LOADED', true);
+
+/**
+ * Two-proportion z-test between a leader variant and another variant.
+ * Returns an advisory tag + label for display.
+ *
+ * 'insufficient' — not enough data, or tied
+ * 'trending'     — z >= 1.28 (~80% one-sided)
+ * 'significant'  — z >= 1.96 (~95% two-sided)
+ *
+ * Fewer than 30 sends on either side is always reported as insufficient.
+ */
+function confidence_vs_leader($leaderSent, $leaderClicks, $otherSent, $otherClicks)
+{
+    if ($leaderSent < 30 || $otherSent < 30) {
+        return ['tag' => 'insufficient', 'label' => 'Low sample'];
+    }
+    $p1 = $leaderClicks / $leaderSent;
+    $p2 = $otherClicks / $otherSent;
+    if ($p1 == $p2) {
+        return ['tag' => 'insufficient', 'label' => 'Tied'];
+    }
+    $pPool = ($leaderClicks + $otherClicks) / ($leaderSent + $otherSent);
+    $se = sqrt($pPool * (1 - $pPool) * (1 / $leaderSent + 1 / $otherSent));
+    if ($se <= 0) {
+        return ['tag' => 'insufficient', 'label' => 'Tied'];
+    }
+    $z = abs(($p1 - $p2) / $se);
+    if ($z >= 1.96) {
+        return ['tag' => 'significant', 'label' => 'Significant (95%)'];
+    }
+    if ($z >= 1.28) {
+        return ['tag' => 'trending', 'label' => 'Trending (80%)'];
+    }
+    return ['tag' => 'insufficient', 'label' => 'Not significant'];
+}
+
+/**
+ * Format a CTR (0.0–1.0 ratio) as a "42.1%" string, or "—" if nothing was sent.
+ */
+function format_ctr($sent, $clicks)
+{
+    if ($sent <= 0) return '—';
+    return number_format(($clicks / $sent) * 100, 1) . '%';
+}
+
+/**
+ * Pull sends/clicks/assigned counts for every variant of a test.
+ * Returns each variant row augmented with 'assigned_count', 'sent_count', 'clicked_count', 'ctr'.
+ */
+function load_variants_with_stats($pdo, $testId)
+{
+    $stmt = $pdo->prepare("
+        SELECT
+            v.*,
+            (SELECT COUNT(*) FROM outreach_leads ol WHERE ol.ab_variant_id = v.id) AS assigned_count,
+            (SELECT COUNT(*) FROM outreach_leads ol WHERE ol.ab_variant_id = v.id AND ol.sent_at IS NOT NULL) AS sent_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN referral_visits rv
+                  ON rv.source_code = CONCAT('outreach-', ol.id, '-v', v.id)
+                WHERE ol.ab_variant_id = v.id) AS clicked_count
+        FROM outreach_ab_variants v
+        WHERE v.test_id = ?
+        ORDER BY v.id ASC
+    ");
+    $stmt->execute([$testId]);
+    $rows = $stmt->fetchAll();
+    foreach ($rows as &$v) {
+        $v['assigned_count'] = (int) $v['assigned_count'];
+        $v['sent_count']     = (int) $v['sent_count'];
+        $v['clicked_count']  = (int) $v['clicked_count'];
+        $v['ctr']            = $v['sent_count'] > 0 ? $v['clicked_count'] / $v['sent_count'] : 0.0;
+    }
+    return $rows;
+}
+
+/**
+ * Find the leader index (highest CTR with sent_count > 0).
+ * Returns null if no variant has any sends yet. Ties broken by lowest id.
+ */
+function find_leader_idx($variants)
+{
+    $leaderIdx = null;
+    foreach ($variants as $i => $v) {
+        if ($v['sent_count'] === 0) continue;
+        if ($leaderIdx === null || $v['ctr'] > $variants[$leaderIdx]['ctr']) {
+            $leaderIdx = $i;
+        }
+    }
+    return $leaderIdx;
+}

--- a/cron/lib/category_pain_points.php
+++ b/cron/lib/category_pain_points.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Hand-curated pain points per outreach category.
+ *
+ * The AI prompt in outreach_helpers.php uses these as generic industry-level
+ * context the AI may gently allude to. They are NOT claims about any specific
+ * business — the prompt enforces that framing.
+ *
+ * Keys must exactly match entries in OUTREACH_CATEGORY_POOL in outreach_helpers.php
+ * (lowercase, plural form). Unknown categories fall back to '_default'.
+ *
+ * Keep each pain point short, concrete, and phrased as a typical day-to-day
+ * bookkeeping/invoicing headache that Argo Books could help with.
+ */
+
+return [
+    'restaurants' => [
+        'reconciling tip splits and daily cash drops',
+        'matching supplier invoices against rising food costs',
+        'end-of-month sales tax without a finance person',
+    ],
+    'plumbers' => [
+        'juggling estimates, invoices, and chasing late payments between jobs',
+        'tracking parts receipts that pile up in the truck',
+        'knowing at a glance what each job actually made',
+    ],
+    'electricians' => [
+        'turning field notes into clean invoices after a long day',
+        'tracking permits and material costs per job',
+        'chasing payment from general contractors',
+    ],
+    'dentists' => [
+        'reconciling insurance payments against what was billed',
+        'tracking supply costs without a full accounting team',
+        'month-end reports that do not take a whole evening',
+    ],
+    'lawyers' => [
+        'tracking billable hours alongside expenses',
+        'trust-account bookkeeping without a dedicated bookkeeper',
+        'clean invoices clients actually understand',
+    ],
+    'accountants' => [
+        'a lightweight tool to recommend to smaller clients who do not need full software',
+        'keeping their own books as tidy as their clients expect',
+    ],
+    'real estate agents' => [
+        'tracking expenses across listings and closings',
+        'separating commission income from deductible costs at tax time',
+        'invoicing referral fees and staging costs',
+    ],
+    'insurance agents' => [
+        'tracking commissions against the expenses of running the office',
+        'simple books that do not require an accounting background',
+    ],
+    'auto repair' => [
+        'parts invoices piling up between jobs',
+        'matching customer payments to work orders',
+        'knowing the margin on each repair',
+    ],
+    'hair salons' => [
+        'tracking product sales alongside service income',
+        'managing booth-rental splits without a spreadsheet',
+        'weekly cash-vs-card reconciliation',
+    ],
+    'fitness gyms' => [
+        'tracking recurring memberships alongside one-off sales',
+        'equipment expenses and vendor invoices in one place',
+    ],
+    'chiropractors' => [
+        'reconciling insurance claims against what patients paid',
+        'tracking supplies and equipment without a full finance setup',
+    ],
+    'veterinarians' => [
+        'tracking drug and supply costs per visit',
+        'invoices that clients can actually read',
+    ],
+    'cleaning services' => [
+        'invoicing recurring clients without forgetting anyone',
+        'tracking supply costs and travel per crew',
+        'chasing late payments from property managers',
+    ],
+    'landscaping' => [
+        'switching between estimates and invoices fast during the busy season',
+        'tracking fuel, equipment, and seasonal labour costs',
+        'knowing which jobs actually turn a profit',
+    ],
+    'roofing contractors' => [
+        'turning a deposit-progress-final schedule into clean invoices',
+        'tracking crew costs and material runs per job',
+    ],
+    'hvac' => [
+        'invoicing service calls without making customers wait for paperwork',
+        'tracking parts and warranty work separately',
+    ],
+    'photographers' => [
+        'deposit invoices, final invoices, and print-sale receipts in one place',
+        'tracking gear and travel expenses at tax time',
+    ],
+    'florists' => [
+        'tracking wholesale flower costs against retail arrangements',
+        'event deposits and balances without double-booking the books',
+    ],
+    'bakeries' => [
+        'tracking ingredient costs against retail prices',
+        'wholesale orders and walk-in sales in one place',
+    ],
+    'coffee shops' => [
+        'daily cash-vs-card reconciliation',
+        'tracking bean and supply costs without spreadsheets',
+    ],
+    'pet stores' => [
+        'inventory costs and retail margins in one view',
+        'grooming-service income separate from product sales',
+    ],
+    'daycare centers' => [
+        'recurring invoices for parents without chasing every month',
+        'tracking supplies, snacks, and staff costs simply',
+    ],
+    'tutoring services' => [
+        'invoicing packages of sessions without getting confused about remaining hours',
+        'tracking contractor tutors vs employee tutors',
+    ],
+    'martial arts studios' => [
+        'recurring memberships alongside belt-test and gear fees',
+        'tracking instructor pay-outs simply',
+    ],
+    'yoga studios' => [
+        'class packs, memberships, and drop-ins in one clean ledger',
+        'tracking instructor splits without a spreadsheet',
+    ],
+    'massage therapists' => [
+        'tracking insurance-billed sessions vs direct-pay clients',
+        'simple books for a solo practice',
+    ],
+    'optometrists' => [
+        'reconciling insurance against the frames and exam charges patients actually owe',
+        'tracking frame inventory simply',
+    ],
+    'pharmacies' => [
+        'reconciling third-party payer reimbursements against dispensed prescriptions',
+        'tracking front-shop retail sales alongside pharmacy income',
+    ],
+    'printing services' => [
+        'quoting jobs and turning them into invoices without re-typing everything',
+        'tracking paper and ink costs against job margins',
+    ],
+    'moving companies' => [
+        'deposit-then-final invoices without losing track',
+        'fuel, truck, and crew costs per move',
+    ],
+    'pest control' => [
+        'recurring quarterly visits that invoice themselves',
+        'tracking chemical and equipment costs per route',
+    ],
+    'locksmiths' => [
+        'quick on-the-road invoicing after a call-out',
+        'tracking parts and travel costs per job',
+    ],
+    'car dealerships' => [
+        'tracking parts, service, and sales revenue separately',
+        'reconciling trade-ins and financing on the books',
+    ],
+    'tire shops' => [
+        'inventory costs vs sale price per tire',
+        'service and retail income in one ledger',
+    ],
+    'furniture stores' => [
+        'tracking delivery and setup fees alongside product revenue',
+        'wholesale cost vs retail margin at a glance',
+    ],
+    'jewelry stores' => [
+        'inventory valuation without a full accountant',
+        'custom-order deposits and balances tracked cleanly',
+    ],
+    'clothing boutiques' => [
+        'seasonal inventory costs against sales',
+        'online and in-store income in one place',
+    ],
+    'tattoo parlors' => [
+        'artist splits without a spreadsheet',
+        'supply costs separate from session income',
+    ],
+    'breweries' => [
+        'tracking ingredient batches against kegs and bottles sold',
+        'taproom sales vs wholesale distribution',
+    ],
+    'catering' => [
+        'event deposits, final invoices, and tips in one ledger',
+        'food-cost-vs-quote margins per event',
+    ],
+    'wedding planners' => [
+        'tracking vendor payments you pass through vs your own fee',
+        'deposit schedules without spreadsheets',
+    ],
+    'interior designers' => [
+        'client retainers, design fees, and procurement markups in one place',
+        'tracking expenses you bill back vs those you eat',
+    ],
+    'architects' => [
+        'billable hours and project expenses on one invoice',
+        'multi-phase project billing without losing track',
+    ],
+    'surveyors' => [
+        'tracking mileage, equipment, and crew time per job',
+        'invoicing fast enough to keep cash flowing',
+    ],
+    'physiotherapists' => [
+        'insurance-paid sessions reconciled against private pay',
+        'simple books for a solo or small-team clinic',
+    ],
+    'psychologists' => [
+        'insurance and direct-pay sessions tracked cleanly',
+        'privacy-minded, simple books for a small practice',
+    ],
+    'counsellors' => [
+        'session billing and sliding-scale income in one ledger',
+        'minimal-fuss books for a solo practice',
+    ],
+    'notaries' => [
+        'fast invoicing for one-off appointments',
+        'tracking travel and supply expenses simply',
+    ],
+    'bookkeepers' => [
+        'a lightweight tool to recommend to smaller clients who just need the basics',
+        'keeping their own practice books as clean as their clients expect',
+    ],
+    'it support' => [
+        'tracking hours, parts, and trip fees on one invoice',
+        'recurring managed-services billing without chasing it',
+    ],
+    'web design' => [
+        'deposit-then-final invoicing for project work',
+        'recurring hosting or retainer income separate from project income',
+    ],
+    'marketing agencies' => [
+        'retainer invoices, ad-spend pass-throughs, and project fees in one ledger',
+        'clean books that do not require an accountant to decipher',
+    ],
+    'sign shops' => [
+        'quote-to-invoice without re-typing job details',
+        'material costs vs job price at a glance',
+    ],
+    'trophy shops' => [
+        'small-batch orders invoiced without friction',
+        'tracking engraving supplies against sales',
+    ],
+    'music schools' => [
+        'recurring lesson packages billed automatically',
+        'tracking instructor pay-outs simply',
+    ],
+    'dance studios' => [
+        'monthly tuition plus costume and recital fees in one ledger',
+        'instructor payments tracked cleanly',
+    ],
+    'dog groomers' => [
+        'walk-in and recurring appointment income tracked together',
+        'product sales separate from service income',
+    ],
+    'boarding kennels' => [
+        'deposit and final invoices for multi-night stays',
+        'tracking food, supplies, and staff costs simply',
+    ],
+    'farm equipment dealers' => [
+        'parts, service, and sales revenue split cleanly',
+        'tracking deposits on big-ticket orders',
+    ],
+    'hardware stores' => [
+        'retail sales vs contractor accounts in one ledger',
+        'inventory cost vs sale price at a glance',
+    ],
+    'building supplies' => [
+        'contractor charge accounts and retail sales tracked together',
+        'tracking delivery fees alongside product revenue',
+    ],
+    'appliance repair' => [
+        'quick on-the-road invoicing after a service call',
+        'tracking parts and trip fees per job',
+    ],
+    'upholstery services' => [
+        'quote-then-invoice without re-typing job details',
+        'tracking materials vs labour per job',
+    ],
+    'tailors' => [
+        'alteration tickets invoiced cleanly',
+        'tracking material and notion costs against small-ticket jobs',
+    ],
+    'dry cleaners' => [
+        'daily ticket reconciliation without a headache',
+        'tracking supply costs against service revenue',
+    ],
+    'spas' => [
+        'service income, product sales, and gift cards in one ledger',
+        'tracking staff pay-outs and tips simply',
+    ],
+    'tanning salons' => [
+        'memberships, single sessions, and product sales tracked together',
+        'simple books for a small staff',
+    ],
+    'nail salons' => [
+        'booth-rental vs commission income tracked cleanly',
+        'product sales separate from service revenue',
+    ],
+    'barber shops' => [
+        'chair-rental or commission income tracked cleanly',
+        'product sales separate from service revenue',
+    ],
+    'optical stores' => [
+        'frame inventory vs exam revenue tracked separately',
+        'insurance reimbursements reconciled against patient charges',
+    ],
+    'hearing aid clinics' => [
+        'device sales, fittings, and service fees in one ledger',
+        'insurance and direct-pay reconciliation',
+    ],
+    'home inspectors' => [
+        'one-off report invoices that go out fast',
+        'tracking mileage and equipment costs at tax time',
+    ],
+    'appraisers' => [
+        'project-based invoicing without re-typing details each time',
+        'tracking travel and research expenses per job',
+    ],
+    'property management' => [
+        'recurring management-fee invoicing that runs itself',
+        'tracking maintenance expenses you bill back to owners',
+    ],
+    'storage facilities' => [
+        'recurring unit invoices that go out on time every month',
+        'late fees handled without chasing each tenant',
+    ],
+    'courier services' => [
+        'per-delivery invoicing that does not bog down the day',
+        'tracking fuel and vehicle costs simply',
+    ],
+    'towing services' => [
+        'quick on-the-road invoicing after a call-out',
+        'tracking fuel, storage fees, and impound charges cleanly',
+    ],
+    'glass repair' => [
+        'insurance-billed jobs vs direct-pay customers tracked cleanly',
+        'parts and trip fees per job',
+    ],
+    'fencing contractors' => [
+        'deposit-progress-final invoices without losing track',
+        'tracking materials and crew time per job',
+    ],
+    'concrete contractors' => [
+        'deposit-then-final invoicing per pour',
+        'materials and crew time tracked per job',
+    ],
+    'paving contractors' => [
+        'quote-to-invoice without re-typing job details',
+        'tracking materials and equipment per job',
+    ],
+    'tree services' => [
+        'fast invoicing after a day in the field',
+        'tracking fuel, equipment, and crew costs simply',
+    ],
+    'snow removal' => [
+        'seasonal contract invoicing that runs itself',
+        'tracking fuel and equipment costs across the winter',
+    ],
+    'pool services' => [
+        'recurring maintenance invoices that go out on time',
+        'chemical and equipment costs tracked simply',
+    ],
+    'septic services' => [
+        'quick on-the-road invoicing after a service call',
+        'tracking truck, fuel, and disposal costs per job',
+    ],
+    'garage door repair' => [
+        'fast on-site invoicing after a service call',
+        'tracking parts and trip fees per job',
+    ],
+    'security companies' => [
+        'recurring monitoring invoices that go out on time',
+        'equipment and install costs tracked simply',
+    ],
+    'staffing agencies' => [
+        'client invoicing and contractor pay-outs tracked together',
+        'margin per placement at a glance',
+    ],
+    'travel agencies' => [
+        'commission income tracked against the expenses of running the office',
+        'client deposits and balances cleanly recorded',
+    ],
+    'event venues' => [
+        'deposit-then-final invoicing per booking',
+        'vendor pass-throughs separate from your own revenue',
+    ],
+    'food trucks' => [
+        'daily cash-vs-card reconciliation',
+        'tracking food and fuel costs against sales',
+    ],
+
+    '_default' => [
+        'keeping books up to date without losing an evening to it',
+        'tracking receipts before they disappear',
+        'pulling together numbers at tax time',
+    ],
+];

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -724,14 +724,18 @@ function generate_draft_for_lead($pdo, $lead)
 
     // A/B variant lookup must happen before the summary block so a
     // personalization test can gate the OpenAI summary call entirely.
-    // Only one type can be active at a time per the framework's invariant.
+    // Only one test can be active at a time across the whole framework
+    // (enforced by the activation handler), so the break below picks the
+    // single match. Iterate over every known type so send-side variants
+    // (sender / preheader / format) still get the lead-variant stamp here
+    // even though they don't inject anything into the prompt.
     $abTestId = null;
     $abVariantId = null;
     $abSubjectOverride = '';
     $abBodyOverride = '';
     $abCtaOverride = '';
     $personalizationOff = false;
-    foreach (['subject', 'body', 'cta', 'sender', 'personalization'] as $eligibleType) {
+    foreach (ab_known_variant_types() as $eligibleType) {
         $active = get_active_ab_test($pdo, $eligibleType);
         if (!$active) continue;
         $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
@@ -744,8 +748,8 @@ function generate_draft_for_lead($pdo, $lead)
         elseif ($eligibleType === 'personalization') {
             $personalizationOff = (trim((string) $variant['content']) === 'off');
         }
-        // sender / preheader / format: assignment alone is what matters; their
-        // dispatched instruction is empty and they apply at send time.
+        // sender / preheader / format: assignment alone is what matters;
+        // their dispatched instruction is empty and they apply at send time.
         break;
     }
 

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -42,6 +42,79 @@ const OUTREACH_CATEGORY_POOL = [
     'travel agencies', 'event venues', 'food trucks',
 ];
 
+// ─── Category Pain Points ───
+
+/**
+ * Look up 2-3 hand-curated pain points for a lead's category, falling back
+ * to a generic '_default' list if the category is not in the map.
+ * The map is loaded once per process.
+ */
+function get_category_pain_points($category)
+{
+    static $map = null;
+    if ($map === null) {
+        $map = require __DIR__ . '/category_pain_points.php';
+    }
+    $key = strtolower(trim((string) $category));
+    return $map[$key] ?? $map['_default'];
+}
+
+// ─── A/B Test Infrastructure ───
+
+require_once __DIR__ . '/ab_helpers.php';
+
+/**
+ * Find the single active A/B test of a given variant type, or null if none.
+ * Returns ['test' => row, 'variants' => [rows]] on hit.
+ */
+function get_active_ab_test($pdo, $variantType)
+{
+    $stmt = $pdo->prepare("SELECT * FROM outreach_ab_tests
+        WHERE status = 'active' AND variant_type = ?
+        ORDER BY started_at DESC, id DESC LIMIT 1");
+    $stmt->execute([$variantType]);
+    $test = $stmt->fetch();
+    if (!$test) return null;
+
+    $vStmt = $pdo->prepare("SELECT * FROM outreach_ab_variants WHERE test_id = ? ORDER BY id ASC");
+    $vStmt->execute([$test['id']]);
+    $variants = $vStmt->fetchAll();
+    if (empty($variants)) return null;
+
+    return ['test' => $test, 'variants' => $variants];
+}
+
+/**
+ * Pick the next variant for an active test using deterministic round-robin.
+ * Counts how many leads are already assigned to this test and assigns the
+ * next lead to index (count % variant_count).
+ */
+function pick_ab_variant($pdo, $test, $variants)
+{
+    $cStmt = $pdo->prepare("SELECT COUNT(*) FROM outreach_leads WHERE ab_test_id = ?");
+    $cStmt->execute([$test['id']]);
+    $assignedSoFar = (int) $cStmt->fetchColumn();
+    $idx = $assignedSoFar % count($variants);
+    return $variants[$idx];
+}
+
+/**
+ * Given a variant row for a 'subject' test, return a prompt instruction
+ * that tells the AI how to handle the subject line.
+ * - If content starts with 'directive:' the rest is a style instruction.
+ * - Otherwise content is a literal subject the AI must use verbatim.
+ */
+function ab_subject_instruction_for_variant($variant)
+{
+    $content = trim((string) $variant['content']);
+    if (stripos($content, 'directive:') === 0) {
+        $directive = trim(substr($content, strlen('directive:')));
+        return "\n- SUBJECT LINE OVERRIDE: write a subject line that follows this directive exactly: \"" . $directive . "\". This overrides any other guidance about subject lines above.";
+    }
+    // Literal subject
+    return "\n- SUBJECT LINE OVERRIDE: use exactly this subject line, word for word, with no changes: \"" . $content . "\". This overrides any other guidance about subject lines above.";
+}
+
 // ─── Activity Logging ───
 
 function log_activity($pdo, $lead_id, $action_type, $details = null)
@@ -79,8 +152,15 @@ function send_outreach_lead($pdo, $lead)
         $tokStmt->execute([$unsubscribeToken, $id]);
     }
 
-    // Replace plain URL with a clickable "argorobots.com" link that carries the tracking param
+    // Replace plain URL with a clickable "argorobots.com" link that carries the tracking param.
+    // If the lead was assigned to an A/B variant, append -v{variantId} so clicks can be attributed per variant.
     $sourceCode = 'outreach-' . $id;
+    $variantId = isset($lead['ab_variant_id']) && $lead['ab_variant_id'] !== null && $lead['ab_variant_id'] !== ''
+        ? (int) $lead['ab_variant_id']
+        : null;
+    if ($variantId) {
+        $sourceCode .= '-v' . $variantId;
+    }
     $trackedUrl = 'https://argorobots.com/?source=' . $sourceCode;
     $anchorHtml = '<a href="' . htmlspecialchars($trackedUrl) . '" style="color:#3b82f6;text-decoration:underline">argorobots.com</a>';
 
@@ -562,6 +642,31 @@ function generate_draft_for_lead($pdo, $lead)
         ? "\n- IMPORTANT: Since this business is in the Saskatoon area, you MUST include an offer for an in-person visit to help them get set up. Work it in naturally, e.g. \"Since I'm right here in Saskatoon, I'd be happy to stop by and help you get set up in person\" or \"I could even swing by to walk you through it\". This is a key selling point for local businesses."
         : "\n- Do NOT mention any in-person visits or stopping by. The business is not in Saskatoon.";
 
+    // Pull industry-level pain points for this category. These are typical
+    // day-to-day headaches for the trade, NOT claims about this business.
+    $painPoints = get_category_pain_points($lead['category'] ?? '');
+    $painPointsList = '';
+    foreach ($painPoints as $pp) {
+        $painPointsList .= "  * " . $pp . "\n";
+    }
+    $categoryLabel = !empty($lead['category']) ? $lead['category'] : 'this industry';
+    $painPointsInstruction = "\n- Small businesses in the '" . $categoryLabel . "' category commonly deal with things like:\n"
+        . $painPointsList
+        . "You MAY gently allude to ONE of these as something Argo Books can help with, phrased as a general industry pattern (e.g. \"businesses like yours often deal with X\"), NEVER as an assertion about this specific business. Pick at most one. If none fit naturally, skip them entirely.";
+
+    // If there is an active subject-line A/B test, pick a variant round-robin
+    // and produce an override instruction the AI must obey.
+    $abTestId = null;
+    $abVariantId = null;
+    $abSubjectOverride = '';
+    $active = get_active_ab_test($pdo, 'subject');
+    if ($active) {
+        $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
+        $abTestId = (int) $active['test']['id'];
+        $abVariantId = (int) $variant['id'];
+        $abSubjectOverride = ab_subject_instruction_for_variant($variant);
+    }
+
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
 
 About Argo Books:
@@ -586,6 +691,7 @@ PERSONALIZATION (this is critical):
 - Only reference Argo Books features that are relevant to their general industry. Do not list every feature
 - If a business summary is provided, use it ONLY to understand their industry and tailor which Argo features to mention. Do NOT parrot back details from the summary as if you personally know about their business
 - If no summary is available, keep it more general but still mention their industry/category if known
+$painPointsInstruction
 
 - Briefly describe Argo Books as a simple bookkeeping and invoicing app that requires no accounting knowledge. Do NOT just say \"check it out\" without explaining what it is
 - Mention you are looking for honest feedback from small business owners
@@ -594,7 +700,7 @@ PERSONALIZATION (this is critical):
 - NEVER use placeholders like [Your Name], [Your Title], [Your Company], etc.
 - ALWAYS include the website link https://argorobots.com/ in the email body. This is required in every single email, no exceptions
 - NEVER use em dashes in the email. Use commas, periods, or regular hyphens instead
-- The subject line should be about the recipient's business, NOT about Argo Books. Make it feel personal and curiosity-driven (e.g. \"Quick question about [business name]\", \"Thought of you guys\")
+- The subject line should be about the recipient's business, NOT about Argo Books. Make it feel personal and curiosity-driven (e.g. \"Quick question about [business name]\", \"Thought of you guys\")$abSubjectOverride
 - You MUST include the line \"You can check it out here: https://argorobots.com/\" (or similar natural phrasing with that exact URL) somewhere in the email body, ideally after mentioning what Argo Books is
 - End the email body with a line like \"Feel free to reply to this email if you have any questions!\" or similar, before the sign-off
 - After that line, add ONE short, respectful unsubscribe line on its own paragraph, such as: \"Not interested? {UNSUBSCRIBE_URL} and I'll stop emailing you.\" The literal token {UNSUBSCRIBE_URL} will be replaced with a tracked unsubscribe link before sending — include it verbatim, do NOT invent or replace the placeholder yourself. Keep the tone soft, brief, and non-pushy.
@@ -629,8 +735,8 @@ Return ONLY the JSON, no other text.";
     if (!$parsed || !isset($parsed['subject']) || !isset($parsed['body'])) {
         // AI returned invalid JSON — save with needs_review so it won't be auto-approved
         $fallbackSubject = "Quick question for {$lead['business_name']}";
-        $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), approval_status = 'needs_review' WHERE id = ?");
-        $stmt->execute([$fallbackSubject, $content, $id]);
+        $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, ab_test_id = ?, ab_variant_id = ?, drafted_at = NOW(), approval_status = 'needs_review' WHERE id = ?");
+        $stmt->execute([$fallbackSubject, $content, $abTestId, $abVariantId, $id]);
 
         return ['success' => true, 'needs_review' => true, 'subject' => $fallbackSubject, 'body' => $content];
     }
@@ -660,8 +766,278 @@ Return ONLY the JSON, no other text.";
     }
 
     // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
-    $stmt->execute([$parsed['subject'], $parsed['body'], $id]);
+    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, ab_test_id = ?, ab_variant_id = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
+    $stmt->execute([$parsed['subject'], $parsed['body'], $abTestId, $abVariantId, $id]);
 
-    return ['success' => true, 'subject' => $parsed['subject'], 'body' => $parsed['body']];
+    return ['success' => true, 'subject' => $parsed['subject'], 'body' => $parsed['body'], 'ab_test_id' => $abTestId, 'ab_variant_id' => $abVariantId];
+}
+
+// ─── A/B Test Automation (called from stepManageAbTests in outreach_pipeline.php) ───
+
+/**
+ * Evaluate the active subject-line test and promote a winner if any exit
+ * criterion is met. Side effect: on trigger, UPDATE the test row to completed
+ * with winner_variant_id set; optionally self-pauses automation if the
+ * winning CTR is below the configured safety floor.
+ *
+ * Returns one of:
+ *   ['action' => 'none', 'reason' => '...', ...]
+ *   ['action' => 'promoted', 'test_id' => N, ...]
+ *   ['action' => 'paused_safety', 'test_id' => N, ...]
+ *
+ * Exit criteria (any one triggers promotion):
+ *   a) leader significant at p<0.05 vs EVERY other variant AND every variant sent >= 30
+ *   b) test age >= 14 days AND every variant sent >= 20
+ *   c) test age >= 28 days (force-close; leader by CTR, ties by assigned then lowest id)
+ */
+function ab_check_and_promote_active_test($pdo)
+{
+    $active = get_active_ab_test($pdo, 'subject');
+    if (!$active) {
+        return ['action' => 'none', 'reason' => 'no_active_test'];
+    }
+    $test = $active['test'];
+
+    $variants = load_variants_with_stats($pdo, (int) $test['id']);
+    if (count($variants) < 2) {
+        return ['action' => 'none', 'reason' => 'too_few_variants'];
+    }
+
+    $leaderIdx = find_leader_idx($variants);
+    $startedAt = strtotime($test['started_at'] ?: $test['created_at']);
+    $ageDays = (int) floor((time() - $startedAt) / 86400);
+    $minSent = min(array_column($variants, 'sent_count'));
+
+    $trigger = null;
+
+    // Criterion (a)
+    if ($leaderIdx !== null && $minSent >= 30) {
+        $allSig = true;
+        foreach ($variants as $i => $v) {
+            if ($i === $leaderIdx) continue;
+            $c = confidence_vs_leader(
+                $variants[$leaderIdx]['sent_count'],
+                $variants[$leaderIdx]['clicked_count'],
+                $v['sent_count'],
+                $v['clicked_count']
+            );
+            if ($c['tag'] !== 'significant') { $allSig = false; break; }
+        }
+        if ($allSig) $trigger = 'significance';
+    }
+
+    // Criterion (b)
+    if (!$trigger && $leaderIdx !== null && $ageDays >= 14 && $minSent >= 20) {
+        $trigger = 'timebox';
+    }
+
+    // Criterion (c) — force-close even if nothing has been sent yet
+    if (!$trigger && $ageDays >= 28) {
+        $trigger = 'hard_timeout';
+        if ($leaderIdx === null) {
+            $leaderIdx = 0;
+            foreach ($variants as $i => $v) {
+                if ($v['assigned_count'] > $variants[$leaderIdx]['assigned_count']) {
+                    $leaderIdx = $i;
+                }
+            }
+        }
+    }
+
+    if (!$trigger) {
+        return [
+            'action' => 'none',
+            'reason' => 'criteria_not_met',
+            'age_days' => $ageDays,
+            'min_sent' => $minSent,
+            'test_id' => (int) $test['id'],
+            'test_name' => $test['name'],
+        ];
+    }
+
+    $winner = $variants[$leaderIdx];
+    $pdo->prepare("UPDATE outreach_ab_tests SET winner_variant_id = ?, status = 'completed', completed_at = NOW() WHERE id = ?")
+        ->execute([$winner['id'], $test['id']]);
+
+    // Safety-floor check
+    $floorStmt = $pdo->prepare("SELECT state_value FROM outreach_pipeline_state WHERE state_key = 'ab_ctr_floor'");
+    $floorStmt->execute();
+    $floorVal = $floorStmt->fetchColumn();
+    $floor = ($floorVal !== false) ? (float) $floorVal : 0.01;
+
+    $pausedForSafety = false;
+    if ($winner['sent_count'] >= 20 && $winner['ctr'] < $floor) {
+        $pauseStmt = $pdo->prepare("INSERT INTO outreach_pipeline_state (state_key, state_value) VALUES (?, ?)
+            ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)");
+        $pauseStmt->execute(['ab_auto_enabled', '0']);
+        $pauseStmt->execute([
+            'ab_auto_last_pause_reason',
+            'Winner CTR ' . number_format($winner['ctr'] * 100, 2) . '% below floor '
+                . number_format($floor * 100, 2) . '% on test #' . (int) $test['id'],
+        ]);
+        $pausedForSafety = true;
+    }
+
+    return [
+        'action' => $pausedForSafety ? 'paused_safety' : 'promoted',
+        'test_id' => (int) $test['id'],
+        'test_name' => $test['name'],
+        'winner_id' => (int) $winner['id'],
+        'winner_label' => $winner['label'],
+        'winner_ctr' => $winner['ctr'],
+        'trigger' => $trigger,
+        'age_days' => $ageDays,
+    ];
+}
+
+/**
+ * Ask OpenAI for N fresh subject-line directives for the next A/B cycle.
+ * Seeds the prompt with the content of the most-recent winners so proven
+ * styles get reinforced. Falls back to a curated seed list if OpenAI errors.
+ *
+ * Returns ['directives' => [...strings...], 'source' => 'ai'|'fallback'].
+ */
+function generate_ab_subject_variants($pdo, $count = 3)
+{
+    $winStmt = $pdo->prepare("
+        SELECT v.content
+        FROM outreach_ab_tests t
+        JOIN outreach_ab_variants v ON v.id = t.winner_variant_id
+        WHERE t.status = 'completed' AND t.variant_type = 'subject'
+        ORDER BY t.completed_at DESC
+        LIMIT 3
+    ");
+    $winStmt->execute();
+    $priorWinners = array_column($winStmt->fetchAll(), 'content');
+
+    $winnersText = '';
+    if (!empty($priorWinners)) {
+        $winnersText = "\n\nRecent winning subject strategies (most recent first):\n";
+        foreach ($priorWinners as $w) {
+            $winnersText .= "- " . trim((string) $w) . "\n";
+        }
+    }
+
+    $systemPrompt = "You generate subject-line directives for an A/B test on a small-business outreach email from Evan, a solo developer, about a simple bookkeeping app called Argo Books.\n\n"
+        . "Return STRICT JSON: { \"directives\": [\"...\", \"...\"] } with exactly $count entries.\n\n"
+        . "Rules for each directive:\n"
+        . "- Start with an imperative verb (Ask, Lead with, Reference, Keep, etc).\n"
+        . "- Describe a STYLE the AI should use when writing the subject for each lead; do NOT write a literal subject line.\n"
+        . "- 8 to 20 words. No em dashes.\n"
+        . "- Each directive must be meaningfully different from the others in tone, angle, or structure (question vs statement vs curiosity tease vs local angle vs ultra-short, etc.).\n"
+        . "- Do not invent product names or facts. Refer to placeholders generically: the business name, their industry, their city.\n"
+        . "- Optimise for cold B2B open rate: personal, curious, short. Avoid marketing-speak.";
+
+    $userPrompt = "Propose $count distinct subject-line directives for the next A/B cycle." . $winnersText;
+
+    $result = call_openai($systemPrompt, $userPrompt);
+    $directives = null;
+    if (!isset($result['error'])) {
+        $content = trim($result['content'] ?? '');
+        $content = preg_replace('/^```json\s*/i', '', $content);
+        $content = preg_replace('/\s*```$/', '', $content);
+        $parsed = json_decode($content, true);
+        if (is_array($parsed) && isset($parsed['directives']) && is_array($parsed['directives'])) {
+            $clean = [];
+            foreach ($parsed['directives'] as $d) {
+                $d = trim((string) $d);
+                if ($d !== '') $clean[] = mb_substr($d, 0, 500);
+            }
+            if (count($clean) >= 2) {
+                $directives = array_slice($clean, 0, $count);
+            }
+        }
+    }
+
+    if (!$directives) {
+        $fallback = [
+            'Ask a short curiosity question that references the business name without making claims about how they operate',
+            'Lead with a single concrete pain point the industry commonly has, phrased as a question',
+            'Reference the city casually to sound local, under 10 words, no exclamation marks',
+            'Keep it ultra-short (under 6 words) and intriguing without mentioning the product',
+            'Open with the industry name as a single-word hook then a brief follow-up question',
+        ];
+        shuffle($fallback);
+        return ['directives' => array_slice($fallback, 0, $count), 'source' => 'fallback'];
+    }
+
+    return ['directives' => $directives, 'source' => 'ai'];
+}
+
+/**
+ * Start a new auto-cycle subject test. The previous winner (if any) is
+ * carried forward as variant A so the established baseline keeps being
+ * measured; newly-generated directives fill the other slots.
+ *
+ * Returns ['action' => 'created', 'test_id' => N, ...]
+ *      or ['action' => 'failed', 'error' => '...'].
+ */
+function ab_start_new_cycle($pdo)
+{
+    $count = 3;
+
+    $priorStmt = $pdo->prepare("
+        SELECT v.content
+        FROM outreach_ab_tests t
+        JOIN outreach_ab_variants v ON v.id = t.winner_variant_id
+        WHERE t.status = 'completed' AND t.variant_type = 'subject'
+        ORDER BY t.completed_at DESC
+        LIMIT 1
+    ");
+    $priorStmt->execute();
+    $prior = $priorStmt->fetchColumn();
+
+    $gen = generate_ab_subject_variants($pdo, $count);
+    $directives = $gen['directives'] ?? [];
+    if (count($directives) < 2) {
+        return ['action' => 'failed', 'error' => 'Variant generation returned fewer than 2 directives'];
+    }
+
+    $name = 'Auto-cycle ' . date('Y-m-d H:i');
+    $notes = 'Auto-generated by stepManageAbTests. Source: ' . ($gen['source'] ?? 'ai')
+        . ($prior ? '. Prior winner carried forward as variant A.' : '.');
+
+    $pdo->beginTransaction();
+    try {
+        $pdo->prepare("INSERT INTO outreach_ab_tests (name, variant_type, status, started_at, notes) VALUES (?, 'subject', 'active', NOW(), ?)")
+            ->execute([$name, $notes]);
+        $testId = (int) $pdo->lastInsertId();
+
+        $vStmt = $pdo->prepare("INSERT INTO outreach_ab_variants (test_id, label, content, is_default) VALUES (?, ?, ?, ?)");
+
+        $label = 'A';
+        $isDefault = 1;
+
+        if ($prior) {
+            $vStmt->execute([$testId, $label, $prior, $isDefault]);
+            $label = 'B';
+            $isDefault = 0;
+        }
+
+        foreach ($directives as $d) {
+            $content = 'directive: ' . $d;
+            $vStmt->execute([$testId, $label, $content, $isDefault]);
+            $isDefault = 0;
+            if ($label === 'D') break;
+            $label = chr(ord($label) + 1);
+        }
+
+        $pdo->commit();
+
+        $varStmt = $pdo->prepare("SELECT COUNT(*) FROM outreach_ab_variants WHERE test_id = ?");
+        $varStmt->execute([$testId]);
+        $variantCount = (int) $varStmt->fetchColumn();
+
+        return [
+            'action' => 'created',
+            'test_id' => $testId,
+            'test_name' => $name,
+            'variant_count' => $variantCount,
+            'carried_winner' => (bool) $prior,
+            'source' => $gen['source'] ?? 'ai',
+        ];
+    } catch (Exception $e) {
+        $pdo->rollBack();
+        return ['action' => 'failed', 'error' => $e->getMessage()];
+    }
 }

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -216,8 +216,8 @@ function send_outreach_lead($pdo, $lead)
         $tokStmt->execute([$unsubscribeToken, $id]);
     }
 
-    // Replace plain URL with a clickable "argorobots.com" link that carries the tracking param.
-    // If the lead was assigned to an A/B variant, append -v{variantId} so clicks can be attributed per variant.
+    // Build the per-lead tracking URL. If the lead was assigned to an A/B
+    // variant, append -v{variantId} so clicks can be attributed per variant.
     $sourceCode = 'outreach-' . $id;
     $variantId = isset($lead['ab_variant_id']) && $lead['ab_variant_id'] !== null && $lead['ab_variant_id'] !== ''
         ? (int) $lead['ab_variant_id']
@@ -226,34 +226,13 @@ function send_outreach_lead($pdo, $lead)
         $sourceCode .= '-v' . $variantId;
     }
     $trackedUrl = 'https://argorobots.com/?source=' . $sourceCode;
-    $anchorHtml = '<a href="' . htmlspecialchars($trackedUrl) . '" style="color:#3b82f6;text-decoration:underline">argorobots.com</a>';
-
-    $escapedBody = htmlspecialchars($lead['draft_body']);
-    $escapedBody = preg_replace('#https?://argorobots\.com/?(?![\w?])#', $anchorHtml, $escapedBody);
-
-    // Replace {UNSUBSCRIBE_URL} placeholder with the tracked unsubscribe link
     $unsubUrl = 'https://argorobots.com/unsubscribe?t=' . $unsubscribeToken;
-    $unsubAnchor = '<a href="' . htmlspecialchars($unsubUrl) . '" style="color:#6b7280;text-decoration:underline">unsubscribe</a>';
-    $escapedBody = str_replace('{UNSUBSCRIBE_URL}', $unsubAnchor, $escapedBody);
 
-    // Fallback: if the AI skipped the placeholder, inject a soft unsubscribe line before the sign-off
-    if (strpos($escapedBody, 'unsubscribe?t=') === false) {
-        $unsubLine = "\n\n<span style=\"color:#9ca3af;font-size:13px\">Not interested? " . $unsubAnchor . " and I'll stop emailing you.</span>";
-        $replaced = preg_replace('#(\nAll the best)#i', $unsubLine . "\n$1", $escapedBody, 1);
-        if ($replaced !== null && strpos($replaced, 'unsubscribe?t=') !== false) {
-            $escapedBody = $replaced;
-        } else {
-            $escapedBody .= $unsubLine;
-        }
-    }
-
-    $htmlBody = '<p>' . nl2br($escapedBody) . '</p>';
-
-    // Send-side A/B variants (sender from-name, preheader; format coming in a
-    // later phase). If the lead is assigned to a variant of any of these
-    // types, fetch the variant + test type and apply.
+    // Send-side A/B variants (sender, preheader, format). Look up first since
+    // format affects how the body is rendered below.
     $fromName = 'Argo Books';
     $preheader = null;
+    $format = 'html';
     if ($variantId) {
         $vStmt = $pdo->prepare("SELECT v.content, t.variant_type
             FROM outreach_ab_variants v
@@ -267,20 +246,61 @@ function send_outreach_lead($pdo, $lead)
                 $fromName = $vContent;
             } elseif ($vRow['variant_type'] === 'preheader') {
                 $preheader = $vContent;
+            } elseif ($vRow['variant_type'] === 'format') {
+                $format = ($vContent === 'plain') ? 'plain' : 'html';
             }
         }
+    }
+
+    if ($format === 'plain') {
+        // Plain text: keep URLs bare so they remain clickable in plain-text
+        // clients while still carrying the tracking source param. No HTML
+        // escaping, no <a> wrapping.
+        $body = (string) $lead['draft_body'];
+        $body = preg_replace('#https?://argorobots\.com/?(?![\w?])#', $trackedUrl, $body);
+        $body = str_replace('{UNSUBSCRIBE_URL}', $unsubUrl, $body);
+        if (strpos($body, 'unsubscribe?t=') === false) {
+            $unsubLine = "\n\nNot interested? " . $unsubUrl . " and I'll stop emailing you.";
+            $replaced = preg_replace('#(\nAll the best)#i', $unsubLine . "\n$1", $body, 1);
+            if ($replaced !== null && strpos($replaced, 'unsubscribe?t=') !== false) {
+                $body = $replaced;
+            } else {
+                $body .= $unsubLine;
+            }
+        }
+        $finalBody = $body;
+    } else {
+        $anchorHtml = '<a href="' . htmlspecialchars($trackedUrl) . '" style="color:#3b82f6;text-decoration:underline">argorobots.com</a>';
+        $escapedBody = htmlspecialchars($lead['draft_body']);
+        $escapedBody = preg_replace('#https?://argorobots\.com/?(?![\w?])#', $anchorHtml, $escapedBody);
+
+        $unsubAnchor = '<a href="' . htmlspecialchars($unsubUrl) . '" style="color:#6b7280;text-decoration:underline">unsubscribe</a>';
+        $escapedBody = str_replace('{UNSUBSCRIBE_URL}', $unsubAnchor, $escapedBody);
+
+        if (strpos($escapedBody, 'unsubscribe?t=') === false) {
+            $unsubLine = "\n\n<span style=\"color:#9ca3af;font-size:13px\">Not interested? " . $unsubAnchor . " and I'll stop emailing you.</span>";
+            $replaced = preg_replace('#(\nAll the best)#i', $unsubLine . "\n$1", $escapedBody, 1);
+            if ($replaced !== null && strpos($replaced, 'unsubscribe?t=') !== false) {
+                $escapedBody = $replaced;
+            } else {
+                $escapedBody .= $unsubLine;
+            }
+        }
+
+        $finalBody = '<p>' . nl2br($escapedBody) . '</p>';
     }
 
     $result = send_styled_email(
         $email,
         $lead['draft_subject'],
-        $htmlBody,
+        $finalBody,
         '',
         'contact@argorobots.com',
         $fromName,
         'contact@argorobots.com',
         [],
-        $preheader
+        $preheader,
+        $format
     );
 
     if ($result) {
@@ -883,7 +903,7 @@ Return ONLY the JSON, no other text.";
  */
 function ab_known_variant_types()
 {
-    return ['subject', 'body', 'sender', 'cta', 'preheader'];
+    return ['subject', 'body', 'sender', 'cta', 'preheader', 'format'];
 }
 
 /**

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -65,7 +65,8 @@ require_once __DIR__ . '/ab_helpers.php';
 
 /**
  * Find the single active A/B test of a given variant type, or null if none.
- * Returns ['test' => row, 'variants' => [rows]] on hit.
+ * Returns ['test' => row, 'variants' => [rows]] on hit. Used by the cron's
+ * promotion sweep, which iterates per type.
  */
 function get_active_ab_test($pdo, $variantType)
 {
@@ -73,6 +74,29 @@ function get_active_ab_test($pdo, $variantType)
         WHERE status = 'active' AND variant_type = ?
         ORDER BY started_at DESC, id DESC LIMIT 1");
     $stmt->execute([$variantType]);
+    $test = $stmt->fetch();
+    if (!$test) return null;
+
+    $vStmt = $pdo->prepare("SELECT * FROM outreach_ab_variants WHERE test_id = ? ORDER BY id ASC");
+    $vStmt->execute([$test['id']]);
+    $variants = $vStmt->fetchAll();
+    if (empty($variants)) return null;
+
+    return ['test' => $test, 'variants' => $variants];
+}
+
+/**
+ * Find THE single active A/B test (any type) and its variants, or null. Use
+ * this when the caller doesn't care which type — the framework's invariant is
+ * one active test at a time, so iterating per-type is wasteful at draft time
+ * (worst case 7 queries per drafted lead just to find the active one).
+ */
+function get_single_active_ab_test($pdo)
+{
+    $stmt = $pdo->prepare("SELECT * FROM outreach_ab_tests
+        WHERE status = 'active'
+        ORDER BY started_at DESC, id DESC LIMIT 1");
+    $stmt->execute();
     $test = $stmt->fetch();
     if (!$test) return null;
 
@@ -242,7 +266,11 @@ function send_outreach_lead($pdo, $lead)
         if ($vRow && trim((string) $vRow['content']) !== '') {
             $vContent = trim((string) $vRow['content']);
             if ($vRow['variant_type'] === 'sender') {
-                $fromName = $vContent;
+                // Strip CR/LF defensively. PHPMailer sanitizes headers, but
+                // the mail() fallback path concatenates $fromName into the
+                // From: header verbatim — a stray newline could enable
+                // header injection if a variant's content was malformed.
+                $fromName = preg_replace('/[\r\n]+/', ' ', $vContent);
             } elseif ($vRow['variant_type'] === 'preheader') {
                 $preheader = $vContent;
             } elseif ($vRow['variant_type'] === 'format') {
@@ -725,10 +753,7 @@ function generate_draft_for_lead($pdo, $lead)
     // A/B variant lookup must happen before the summary block so a
     // personalization test can gate the OpenAI summary call entirely.
     // Only one test can be active at a time across the whole framework
-    // (enforced by the activation handler), so the break below picks the
-    // single match. Iterate over every known type so send-side variants
-    // (sender / preheader / format) still get the lead-variant stamp here
-    // even though they don't inject anything into the prompt.
+    // (enforced by the activation handler), so a single SELECT finds it.
     //
     // If the lead is already assigned to the currently-active test (e.g.
     // admin clicked "Regenerate Draft" after the email went out), keep the
@@ -743,10 +768,10 @@ function generate_draft_for_lead($pdo, $lead)
     $personalizationOff = false;
     $existingAbTestId = isset($lead['ab_test_id']) ? (int) $lead['ab_test_id'] : 0;
     $existingAbVariantId = isset($lead['ab_variant_id']) ? (int) $lead['ab_variant_id'] : 0;
-    foreach (ab_known_variant_types() as $eligibleType) {
-        $active = get_active_ab_test($pdo, $eligibleType);
-        if (!$active) continue;
+    $active = get_single_active_ab_test($pdo);
+    if ($active) {
         $activeTestId = (int) $active['test']['id'];
+        $eligibleType = (string) $active['test']['variant_type'];
 
         $variant = null;
         if ($existingAbTestId === $activeTestId && $existingAbVariantId > 0) {
@@ -772,7 +797,6 @@ function generate_draft_for_lead($pdo, $lead)
         }
         // sender / preheader / format: assignment alone is what matters;
         // their dispatched instruction is empty and they apply at send time.
-        break;
     }
 
     // Generate a business summary if we don't have one yet — unless the lead

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -1117,11 +1117,40 @@ function generate_ab_variants_for_type($pdo, $variantType, $count = 3)
     switch ($variantType) {
         case 'subject':
             return generate_ab_subject_variants($pdo, $count);
-        // Phase 1: case 'body': return generate_ab_body_variants($pdo, $count);
-        // Phase 2: case 'cta':  return generate_ab_cta_variants($pdo, $count);
+        case 'sender':
+            // Small fixed pool — content is the literal from-name.
+            return [
+                'directives' => ['Evan', 'Evan from Argo Books', 'Argo Books'],
+                'source' => 'fixed',
+                'literal' => true,
+            ];
+        case 'format':
+            return [
+                'directives' => ['html', 'plain'],
+                'source' => 'fixed',
+                'literal' => true,
+            ];
+        case 'personalization':
+            return [
+                'directives' => ['on', 'off'],
+                'source' => 'fixed',
+                'literal' => true,
+            ];
+        // body / cta / preheader stay admin-initiated — they need carefully
+        // crafted copy and there's no AI generator yet. The rotation in
+        // stepManageAbTests skips types not represented here.
         default:
             return ['directives' => [], 'source' => 'unsupported'];
     }
+}
+
+/**
+ * Rotation order used by stepManageAbTests when ab_auto_rotation is on.
+ * Every type listed here must have a generator in generate_ab_variants_for_type.
+ */
+function ab_auto_rotation_order()
+{
+    return ['subject', 'sender', 'format', 'personalization'];
 }
 
 /**
@@ -1136,25 +1165,34 @@ function ab_start_new_cycle($pdo, $variantType = 'subject')
 {
     $count = 3;
 
-    $priorStmt = $pdo->prepare("
-        SELECT v.content
-        FROM outreach_ab_tests t
-        JOIN outreach_ab_variants v ON v.id = t.winner_variant_id
-        WHERE t.status = 'completed' AND t.variant_type = ?
-        ORDER BY t.completed_at DESC
-        LIMIT 1
-    ");
-    $priorStmt->execute([$variantType]);
-    $prior = $priorStmt->fetchColumn();
-
     $gen = generate_ab_variants_for_type($pdo, $variantType, $count);
-    $directives = $gen['directives'] ?? [];
-    if (count($directives) < 2) {
+    $items = $gen['directives'] ?? [];
+    $isLiteral = !empty($gen['literal']);
+
+    if (count($items) < 2) {
         return [
             'action' => 'failed',
             'variant_type' => $variantType,
-            'error' => 'Variant generation returned fewer than 2 directives (source: ' . ($gen['source'] ?? 'unknown') . ')',
+            'error' => 'Variant generation returned fewer than 2 entries (source: ' . ($gen['source'] ?? 'unknown') . ')',
         ];
+    }
+
+    // Carry-forward only makes sense for directive-style types where each
+    // cycle generates *new* candidate copy and we want the prior winner kept
+    // as a baseline. Literal types (sender / format / personalization) cycle
+    // over a fixed pool, so carry-forward would just duplicate one variant.
+    $prior = null;
+    if (!$isLiteral) {
+        $priorStmt = $pdo->prepare("
+            SELECT v.content
+            FROM outreach_ab_tests t
+            JOIN outreach_ab_variants v ON v.id = t.winner_variant_id
+            WHERE t.status = 'completed' AND t.variant_type = ?
+            ORDER BY t.completed_at DESC
+            LIMIT 1
+        ");
+        $priorStmt->execute([$variantType]);
+        $prior = $priorStmt->fetchColumn() ?: null;
     }
 
     $name = 'Auto-cycle ' . $variantType . ' ' . date('Y-m-d H:i');
@@ -1178,8 +1216,8 @@ function ab_start_new_cycle($pdo, $variantType = 'subject')
             $isDefault = 0;
         }
 
-        foreach ($directives as $d) {
-            $content = 'directive: ' . $d;
+        foreach ($items as $d) {
+            $content = $isLiteral ? $d : ('directive: ' . $d);
             $vStmt->execute([$testId, $label, $content, $isDefault]);
             $isDefault = 0;
             if ($label === 'D') break;

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -157,12 +157,12 @@ function ab_cta_instruction_for_variant($variant)
 }
 
 /**
- * Per-type prompt-injection dispatch. Future phases register new types here
- * (body, cta, personalization). Send-side types (sender, preheader, format)
- * apply at send time, not here, and return ['' for prompt injection.
- *
- * Returns a string to append to the system prompt — empty if the type has no
- * prompt-side effect (or isn't wired yet).
+ * Per-type prompt-injection dispatch. Returns a string to append to the
+ * system prompt for prompt-side variant types (subject / body / cta).
+ * Send-side types (sender / preheader / format) apply at send time and
+ * return an empty string here. Personalization is handled inline in
+ * generate_draft_for_lead (it gates the OpenAI summary call rather than
+ * injecting into the prompt).
  */
 function ab_instruction_for_variant($variant, $variantType = 'subject')
 {
@@ -173,7 +173,6 @@ function ab_instruction_for_variant($variant, $variantType = 'subject')
             return ab_body_instruction_for_variant($variant);
         case 'cta':
             return ab_cta_instruction_for_variant($variant);
-        // Phase 6: case 'personalization': handled inline in generate_draft_for_lead, not here
         default:
             return '';
     }
@@ -903,9 +902,8 @@ Return ONLY the JSON, no other text.";
 // ─── A/B Test Automation (called from stepManageAbTests in outreach_pipeline.php) ───
 
 /**
- * Variant types the A/B framework knows about. Each later phase that wires
- * in a new type extends this list. The cron iterates over it when looking
- * for tests to promote.
+ * Variant types the A/B framework knows about. The cron iterates over this
+ * list when looking for active tests to promote.
  */
 function ab_known_variant_types()
 {
@@ -1105,12 +1103,13 @@ function generate_ab_subject_variants($pdo, $count = 3)
 }
 
 /**
- * Per-type variant generator dispatch. Phase 0 handles 'subject' only;
- * later phases register additional types here. Returns the same shape
- * generate_ab_subject_variants() returns: ['directives' => [...], 'source' => 'ai'|'fallback'].
- *
- * Returns ['directives' => [], 'source' => 'unsupported'] if no generator
- * is registered for the requested type — caller should treat as failure.
+/**
+ * Per-type variant generator dispatch. Returns
+ *   ['directives' => [...], 'source' => 'ai'|'fallback'|'fixed', 'literal' => bool?]
+ * 'literal' is true when the contents are stored verbatim (no 'directive: '
+ * prefix); ab_start_new_cycle uses that flag to decide whether to carry the
+ * prior winner forward. Returns ['directives' => [], 'source' => 'unsupported']
+ * for types with no generator — caller treats as failure.
  */
 function generate_ab_variants_for_type($pdo, $variantType, $count = 3)
 {
@@ -1137,8 +1136,8 @@ function generate_ab_variants_for_type($pdo, $variantType, $count = 3)
                 'literal' => true,
             ];
         // body / cta / preheader stay admin-initiated — they need carefully
-        // crafted copy and there's no AI generator yet. The rotation in
-        // stepManageAbTests skips types not represented here.
+        // crafted copy and have no AI generator. ab_auto_rotation_order()
+        // omits them so the cron's rotation never lands here.
         default:
             return ['directives' => [], 'source' => 'unsupported'];
     }

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -249,10 +249,11 @@ function send_outreach_lead($pdo, $lead)
 
     $htmlBody = '<p>' . nl2br($escapedBody) . '</p>';
 
-    // Send-side A/B variants (sender from-name today; preheader / format in
-    // later phases). If the lead is assigned to a variant of any of these
+    // Send-side A/B variants (sender from-name, preheader; format coming in a
+    // later phase). If the lead is assigned to a variant of any of these
     // types, fetch the variant + test type and apply.
     $fromName = 'Argo Books';
+    $preheader = null;
     if ($variantId) {
         $vStmt = $pdo->prepare("SELECT v.content, t.variant_type
             FROM outreach_ab_variants v
@@ -260,8 +261,13 @@ function send_outreach_lead($pdo, $lead)
             WHERE v.id = ?");
         $vStmt->execute([$variantId]);
         $vRow = $vStmt->fetch();
-        if ($vRow && $vRow['variant_type'] === 'sender' && trim((string) $vRow['content']) !== '') {
-            $fromName = trim((string) $vRow['content']);
+        if ($vRow && trim((string) $vRow['content']) !== '') {
+            $vContent = trim((string) $vRow['content']);
+            if ($vRow['variant_type'] === 'sender') {
+                $fromName = $vContent;
+            } elseif ($vRow['variant_type'] === 'preheader') {
+                $preheader = $vContent;
+            }
         }
     }
 
@@ -272,7 +278,9 @@ function send_outreach_lead($pdo, $lead)
         '',
         'contact@argorobots.com',
         $fromName,
-        'contact@argorobots.com'
+        'contact@argorobots.com',
+        [],
+        $preheader
     );
 
     if ($result) {
@@ -875,7 +883,7 @@ Return ONLY the JSON, no other text.";
  */
 function ab_known_variant_types()
 {
-    return ['subject', 'body', 'sender', 'cta'];
+    return ['subject', 'body', 'sender', 'cta', 'preheader'];
 }
 
 /**

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -723,9 +723,42 @@ function generate_draft_for_lead($pdo, $lead)
 {
     $id = $lead['id'];
 
-    // Generate business summary if we don't have one yet
+    // A/B variant lookup must happen before the summary block so a
+    // personalization test can gate the OpenAI summary call entirely.
+    // Only one type can be active at a time per the framework's invariant.
+    $abTestId = null;
+    $abVariantId = null;
+    $abSubjectOverride = '';
+    $abBodyOverride = '';
+    $abCtaOverride = '';
+    $personalizationOff = false;
+    foreach (['subject', 'body', 'cta', 'sender', 'personalization'] as $eligibleType) {
+        $active = get_active_ab_test($pdo, $eligibleType);
+        if (!$active) continue;
+        $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
+        $abTestId = (int) $active['test']['id'];
+        $abVariantId = (int) $variant['id'];
+        $instruction = ab_instruction_for_variant($variant, $eligibleType);
+        if ($eligibleType === 'subject') $abSubjectOverride = $instruction;
+        elseif ($eligibleType === 'body') $abBodyOverride = $instruction;
+        elseif ($eligibleType === 'cta') $abCtaOverride = $instruction;
+        elseif ($eligibleType === 'personalization') {
+            $personalizationOff = (trim((string) $variant['content']) === 'off');
+        }
+        // sender / preheader / format: assignment alone is what matters; their
+        // dispatched instruction is empty and they apply at send time.
+        break;
+    }
+
+    // Generate a business summary if we don't have one yet — unless the lead
+    // is in the 'off' arm of an active personalization test, in which case we
+    // skip the OpenAI call entirely. If a stored summary exists from before
+    // the test started, mask it for this draft so the prompt truly operates
+    // without personalization.
     $summary = $lead['business_summary'] ?? null;
-    if (empty($summary) && !empty($lead['website'])) {
+    if ($personalizationOff) {
+        $summary = null;
+    } elseif (empty($summary) && !empty($lead['website'])) {
         $summary = summarize_business($lead['website']);
         if ($summary) {
             $stmt = $pdo->prepare("UPDATE outreach_leads SET business_summary = ? WHERE id = ?");
@@ -761,33 +794,6 @@ function generate_draft_for_lead($pdo, $lead)
     $painPointsInstruction = "\n- Small businesses in the '" . $categoryLabel . "' category commonly deal with things like:\n"
         . $painPointsList
         . "You MAY gently allude to ONE of these as something Argo Books can help with, phrased as a general industry pattern (e.g. \"businesses like yours often deal with X\"), NEVER as an assertion about this specific business. Pick at most one. If none fit naturally, skip them entirely.";
-
-    // Find the single active prompt-side A/B test for this lead (only one
-    // type can be active at a time per the framework's invariant) and build
-    // the override fragment. Send-side types (sender/preheader/format) apply
-    // later in send_outreach_lead, not here.
-    $abTestId = null;
-    $abVariantId = null;
-    $abSubjectOverride = '';
-    $abBodyOverride = '';
-    $abCtaOverride = '';
-    // Iterate over every wired type so a single lead can be assigned to any
-    // active test (one-at-a-time invariant). Send-side types (sender/preheader/
-    // format) get the assignment stamped here but apply at send time, so their
-    // dispatched instruction is empty and no prompt fragment is emitted.
-    foreach (['subject', 'body', 'cta', 'sender'] as $eligibleType) {
-        $active = get_active_ab_test($pdo, $eligibleType);
-        if (!$active) continue;
-        $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
-        $abTestId = (int) $active['test']['id'];
-        $abVariantId = (int) $variant['id'];
-        $instruction = ab_instruction_for_variant($variant, $eligibleType);
-        if ($eligibleType === 'subject') $abSubjectOverride = $instruction;
-        elseif ($eligibleType === 'body') $abBodyOverride = $instruction;
-        elseif ($eligibleType === 'cta') $abCtaOverride = $instruction;
-        // sender: instruction is empty; assignment alone is what matters
-        break;
-    }
 
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
 
@@ -903,7 +909,7 @@ Return ONLY the JSON, no other text.";
  */
 function ab_known_variant_types()
 {
-    return ['subject', 'body', 'sender', 'cta', 'preheader', 'format'];
+    return ['subject', 'body', 'sender', 'cta', 'preheader', 'format', 'personalization'];
 }
 
 /**

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -115,9 +115,8 @@ function ab_parse_variant_content($variant)
 }
 
 /**
- * Subject-line instruction builder (Phase 0 default; subject is the only
- * wired variant type today). Returns a prompt fragment to splice into the
- * system prompt's subject-line bullet.
+ * Subject-line instruction builder. Returns a prompt fragment to splice
+ * into the system prompt's subject-line bullet.
  */
 function ab_subject_instruction_for_variant($variant)
 {
@@ -126,6 +125,21 @@ function ab_subject_instruction_for_variant($variant)
         return "\n- SUBJECT LINE OVERRIDE: write a subject line that follows this directive exactly: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
     }
     return "\n- SUBJECT LINE OVERRIDE: use exactly this subject line, word for word, with no changes: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
+}
+
+/**
+ * Body instruction builder. The override controls body shape — paragraph
+ * count, opener style, tone, length — but explicitly preserves the
+ * non-negotiable structural elements (website URL, {UNSUBSCRIBE_URL}
+ * placeholder, three-line sign-off).
+ */
+function ab_body_instruction_for_variant($variant)
+{
+    $parsed = ab_parse_variant_content($variant);
+    if ($parsed['mode'] === 'directive') {
+        return "\n- BODY OVERRIDE: write the email body in the style described by this directive: \"" . $parsed['text'] . "\". This style guidance overrides the paragraph count, opener style, and tone rules above. You MUST still include the https://argorobots.com/ link, the {UNSUBSCRIBE_URL} placeholder line, and the \"All the best, / Evan / Argo Books\" sign-off exactly as specified.";
+    }
+    return "\n- BODY OVERRIDE: the email body must be exactly this text, word for word: \"" . $parsed['text'] . "\". The {UNSUBSCRIBE_URL} placeholder and the https://argorobots.com/ link inside this text will be processed before sending — keep them as written.";
 }
 
 /**
@@ -141,7 +155,8 @@ function ab_instruction_for_variant($variant, $variantType = 'subject')
     switch ($variantType) {
         case 'subject':
             return ab_subject_instruction_for_variant($variant);
-        // Phase 1: case 'body': return ab_body_instruction_for_variant($variant);
+        case 'body':
+            return ab_body_instruction_for_variant($variant);
         // Phase 2: case 'cta':  return ab_cta_instruction_for_variant($variant);
         // Phase 6: case 'personalization': handled inline in generate_draft_for_lead, not here
         default:
@@ -688,17 +703,24 @@ function generate_draft_for_lead($pdo, $lead)
         . $painPointsList
         . "You MAY gently allude to ONE of these as something Argo Books can help with, phrased as a general industry pattern (e.g. \"businesses like yours often deal with X\"), NEVER as an assertion about this specific business. Pick at most one. If none fit naturally, skip them entirely.";
 
-    // If there is an active subject-line A/B test, pick a variant round-robin
-    // and produce an override instruction the AI must obey.
+    // Find the single active prompt-side A/B test for this lead (only one
+    // type can be active at a time per the framework's invariant) and build
+    // the override fragment. Send-side types (sender/preheader/format) apply
+    // later in send_outreach_lead, not here.
     $abTestId = null;
     $abVariantId = null;
     $abSubjectOverride = '';
-    $active = get_active_ab_test($pdo, 'subject');
-    if ($active) {
+    $abBodyOverride = '';
+    foreach (['subject', 'body'] as $promptType) {
+        $active = get_active_ab_test($pdo, $promptType);
+        if (!$active) continue;
         $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
         $abTestId = (int) $active['test']['id'];
         $abVariantId = (int) $variant['id'];
-        $abSubjectOverride = ab_subject_instruction_for_variant($variant);
+        $instruction = ab_instruction_for_variant($variant, $promptType);
+        if ($promptType === 'subject') $abSubjectOverride = $instruction;
+        elseif ($promptType === 'body') $abBodyOverride = $instruction;
+        break; // one-at-a-time invariant — first hit wins
     }
 
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.
@@ -738,7 +760,7 @@ $painPointsInstruction
 - You MUST include the line \"You can check it out here: https://argorobots.com/\" (or similar natural phrasing with that exact URL) somewhere in the email body, ideally after mentioning what Argo Books is
 - End the email body with a line like \"Feel free to reply to this email if you have any questions!\" or similar, before the sign-off
 - After that line, add ONE short, respectful unsubscribe line on its own paragraph, such as: \"Not interested? {UNSUBSCRIBE_URL} and I'll stop emailing you.\" The literal token {UNSUBSCRIBE_URL} will be replaced with a tracked unsubscribe link before sending — include it verbatim, do NOT invent or replace the placeholder yourself. Keep the tone soft, brief, and non-pushy.
-- Always sign off with three separate lines: \"All the best,\" then \"Evan\" then \"Argo Books\" (each on its own line, separated by \\n)
+- Always sign off with three separate lines: \"All the best,\" then \"Evan\" then \"Argo Books\" (each on its own line, separated by \\n)$abBodyOverride
 
 Return your response as JSON with two fields:
 {\"subject\": \"the email subject line\", \"body\": \"the email body text (plain text, use \\n for line breaks)\"}

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -146,7 +146,7 @@ function ab_subject_instruction_for_variant($variant)
 {
     $parsed = ab_parse_variant_content($variant);
     if ($parsed['mode'] === 'directive') {
-        return "\n- SUBJECT LINE OVERRIDE: write a subject line that follows this directive exactly: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
+        return "\n- SUBJECT LINE OVERRIDE: The text inside the quotes below is a STYLE INSTRUCTION, not the subject itself. Generate your own original short subject line (under 60 characters, no em dashes) in the style described — do NOT copy, echo, paraphrase, or include any of the instruction's wording in your output. Style instruction: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
     }
     return "\n- SUBJECT LINE OVERRIDE: use exactly this subject line, word for word, with no changes: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
 }
@@ -302,6 +302,15 @@ function send_outreach_lead($pdo, $lead)
         $escapedBody = preg_replace('#https?://argorobots\.com/?(?![\w?])#', $anchorHtml, $escapedBody);
 
         $unsubAnchor = '<a href="' . htmlspecialchars($unsubUrl) . '" style="color:#6b7280;text-decoration:underline">unsubscribe</a>';
+        // Drafts since the unsubscribe-URL fix carry the real bare URL in
+        // their body. Wrap any occurrences in the styled "unsubscribe" anchor.
+        $escapedBody = preg_replace(
+            '#https?://argorobots\.com/unsubscribe\?t=[a-f0-9]+#i',
+            $unsubAnchor,
+            $escapedBody
+        );
+        // Defensive: also handle the legacy {UNSUBSCRIBE_URL} placeholder for
+        // any drafts created before the substitution moved to draft time.
         $escapedBody = str_replace('{UNSUBSCRIBE_URL}', $unsubAnchor, $escapedBody);
 
         if (strpos($escapedBody, 'unsubscribe?t=') === false) {
@@ -766,6 +775,7 @@ function generate_draft_for_lead($pdo, $lead)
     $abBodyOverride = '';
     $abCtaOverride = '';
     $personalizationOff = false;
+    $abSubjectDirectiveText = null; // captured for the post-generation echo check
     $existingAbTestId = isset($lead['ab_test_id']) ? (int) $lead['ab_test_id'] : 0;
     $existingAbVariantId = isset($lead['ab_variant_id']) ? (int) $lead['ab_variant_id'] : 0;
     $active = get_single_active_ab_test($pdo);
@@ -789,7 +799,13 @@ function generate_draft_for_lead($pdo, $lead)
         $abTestId = $activeTestId;
         $abVariantId = (int) $variant['id'];
         $instruction = ab_instruction_for_variant($variant, $eligibleType);
-        if ($eligibleType === 'subject') $abSubjectOverride = $instruction;
+        if ($eligibleType === 'subject') {
+            $abSubjectOverride = $instruction;
+            $parsedVariant = ab_parse_variant_content($variant);
+            if ($parsedVariant['mode'] === 'directive') {
+                $abSubjectDirectiveText = $parsedVariant['text'];
+            }
+        }
         elseif ($eligibleType === 'body') $abBodyOverride = $instruction;
         elseif ($eligibleType === 'cta') $abCtaOverride = $instruction;
         elseif ($eligibleType === 'personalization') {
@@ -942,9 +958,44 @@ Return ONLY the JSON, no other text.";
         }
     }
 
-    // Save draft to lead
-    $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, ab_test_id = ?, ab_variant_id = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
-    $stmt->execute([$parsed['subject'], $parsed['body'], $abTestId, $abVariantId, $id]);
+    // Defensive check: the AI is told a subject directive describes a STYLE
+    // and not to copy it, but it occasionally echoes the directive verbatim
+    // anyway. Catch the obvious failures and hold the draft for review
+    // instead of auto-sending an email whose subject is literally the prompt.
+    $needsReviewReason = null;
+    if ($abSubjectDirectiveText !== null) {
+        $genNorm = strtolower(rtrim(trim($parsed['subject']), '.!?'));
+        $dirNorm = strtolower(rtrim(trim($abSubjectDirectiveText), '.!?'));
+        if ($genNorm !== '' && $dirNorm !== '' && ($genNorm === $dirNorm || strpos($genNorm, $dirNorm) !== false)) {
+            $needsReviewReason = 'AI returned the subject directive verbatim instead of generating a subject in that style.';
+        }
+    }
+
+    // Substitute the {UNSUBSCRIBE_URL} placeholder with the real per-lead URL
+    // now (was previously deferred to send time). Saving the real URL means
+    // the admin sees the actual link when reviewing the draft instead of the
+    // raw placeholder. The send-side still handles the placeholder defensively
+    // for any old drafts that pre-date this change.
+    $unsubscribeToken = $lead['unsubscribe_token'] ?? null;
+    if (empty($unsubscribeToken)) {
+        $unsubscribeToken = bin2hex(random_bytes(32));
+        $tokStmt = $pdo->prepare("UPDATE outreach_leads SET unsubscribe_token = ? WHERE id = ?");
+        $tokStmt->execute([$unsubscribeToken, $id]);
+    }
+    $unsubUrl = 'https://argorobots.com/unsubscribe?t=' . $unsubscribeToken;
+    $parsed['body'] = str_replace('{UNSUBSCRIBE_URL}', $unsubUrl, $parsed['body']);
+
+    // Save draft to lead. If the directive-echo check tripped, mark the
+    // draft as needs_review so the auto-approve step skips it and the admin
+    // sees the issue before anything goes out.
+    if ($needsReviewReason !== null) {
+        $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, ab_test_id = ?, ab_variant_id = ?, drafted_at = NOW(), approval_status = 'needs_review', status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
+        $stmt->execute([$parsed['subject'], $parsed['body'], $abTestId, $abVariantId, $id]);
+        log_activity($pdo, $id, 'draft_needs_review', $needsReviewReason);
+    } else {
+        $stmt = $pdo->prepare("UPDATE outreach_leads SET draft_subject = ?, draft_body = ?, ab_test_id = ?, ab_variant_id = ?, drafted_at = NOW(), status = CASE WHEN status IN ('new','awaiting_approval','approved') THEN 'draft_generated' ELSE status END WHERE id = ?");
+        $stmt->execute([$parsed['subject'], $parsed['body'], $abTestId, $abVariantId, $id]);
+    }
 
     return ['success' => true, 'subject' => $parsed['subject'], 'body' => $parsed['body'], 'ab_test_id' => $abTestId, 'ab_variant_id' => $abVariantId];
 }
@@ -1107,14 +1158,17 @@ function generate_ab_subject_variants($pdo, $count = 3)
     }
 
     $systemPrompt = "You generate subject-line directives for an A/B test on a small-business outreach email from Evan, a solo developer, about a simple bookkeeping app called Argo Books.\n\n"
-        . "Return STRICT JSON: { \"directives\": [\"...\", \"...\"] } with exactly $count entries.\n\n"
+        . "Return STRICT JSON: { \"directives\": [\"directive 1\", \"directive 2\", ...] } with exactly $count entries.\n\n"
+        . "CRITICAL: Each directive describes a STYLE for the writer to follow when crafting one specific lead's subject — it is NOT the subject itself. A second AI will read your directive and generate a fresh subject in that style for each lead. Your directive must NOT look like a subject line.\n\n"
+        . "Bad examples (these read like subject lines, not styles): \"Lead with a personal touch about Argo Books\" / \"Quick question for {business}\" / \"Let's simplify your bookkeeping\"\n"
+        . "Good examples (these describe HOW to write, not WHAT to write): \"Open with a one-line curiosity question that mentions the recipient's industry, no product names\" / \"Frame as a peer-to-peer note from one local Saskatoon business owner to another, max 5 words\" / \"Reference a specific category-typical pain point as a question, avoid sounding salesy\"\n\n"
         . "Rules for each directive:\n"
-        . "- Start with an imperative verb (Ask, Lead with, Reference, Keep, etc).\n"
-        . "- Describe a STYLE the AI should use when writing the subject for each lead; do NOT write a literal subject line.\n"
-        . "- 8 to 20 words. No em dashes.\n"
-        . "- Each directive must be meaningfully different from the others in tone, angle, or structure (question vs statement vs curiosity tease vs local angle vs ultra-short, etc.).\n"
-        . "- Do not invent product names or facts. Refer to placeholders generically: the business name, their industry, their city.\n"
-        . "- Optimise for cold B2B open rate: personal, curious, short. Avoid marketing-speak.";
+        . "- Talk ABOUT the writing technique (Open with…, Frame as…, Reference…, Pose…), don't write the subject text.\n"
+        . "- 10 to 25 words. Concrete and specific about the technique.\n"
+        . "- Mention what to AVOID as well as what to do (e.g. 'avoid product names', 'no greeting', 'no question mark').\n"
+        . "- Each directive must be meaningfully different from the others in technique (question vs statement, local angle vs industry angle, ultra-short vs detail-rich, etc.).\n"
+        . "- Refer to placeholders generically: the business name, their industry, their city. Do not invent product names or facts.\n"
+        . "- Target cold B2B open rate: personal, curious, short. Avoid marketing-speak.";
 
     $userPrompt = "Propose $count distinct subject-line directives for the next A/B cycle." . $winnersText;
 

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -249,13 +249,29 @@ function send_outreach_lead($pdo, $lead)
 
     $htmlBody = '<p>' . nl2br($escapedBody) . '</p>';
 
+    // Send-side A/B variants (sender from-name today; preheader / format in
+    // later phases). If the lead is assigned to a variant of any of these
+    // types, fetch the variant + test type and apply.
+    $fromName = 'Argo Books';
+    if ($variantId) {
+        $vStmt = $pdo->prepare("SELECT v.content, t.variant_type
+            FROM outreach_ab_variants v
+            JOIN outreach_ab_tests t ON t.id = v.test_id
+            WHERE v.id = ?");
+        $vStmt->execute([$variantId]);
+        $vRow = $vStmt->fetch();
+        if ($vRow && $vRow['variant_type'] === 'sender' && trim((string) $vRow['content']) !== '') {
+            $fromName = trim((string) $vRow['content']);
+        }
+    }
+
     $result = send_styled_email(
         $email,
         $lead['draft_subject'],
         $htmlBody,
         '',
         'contact@argorobots.com',
-        'Argo Books',
+        $fromName,
         'contact@argorobots.com'
     );
 
@@ -727,17 +743,22 @@ function generate_draft_for_lead($pdo, $lead)
     $abSubjectOverride = '';
     $abBodyOverride = '';
     $abCtaOverride = '';
-    foreach (['subject', 'body', 'cta'] as $promptType) {
-        $active = get_active_ab_test($pdo, $promptType);
+    // Iterate over every wired type so a single lead can be assigned to any
+    // active test (one-at-a-time invariant). Send-side types (sender/preheader/
+    // format) get the assignment stamped here but apply at send time, so their
+    // dispatched instruction is empty and no prompt fragment is emitted.
+    foreach (['subject', 'body', 'cta', 'sender'] as $eligibleType) {
+        $active = get_active_ab_test($pdo, $eligibleType);
         if (!$active) continue;
         $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
         $abTestId = (int) $active['test']['id'];
         $abVariantId = (int) $variant['id'];
-        $instruction = ab_instruction_for_variant($variant, $promptType);
-        if ($promptType === 'subject') $abSubjectOverride = $instruction;
-        elseif ($promptType === 'body') $abBodyOverride = $instruction;
-        elseif ($promptType === 'cta') $abCtaOverride = $instruction;
-        break; // one-at-a-time invariant — first hit wins
+        $instruction = ab_instruction_for_variant($variant, $eligibleType);
+        if ($eligibleType === 'subject') $abSubjectOverride = $instruction;
+        elseif ($eligibleType === 'body') $abBodyOverride = $instruction;
+        elseif ($eligibleType === 'cta') $abCtaOverride = $instruction;
+        // sender: instruction is empty; assignment alone is what matters
+        break;
     }
 
     $systemPrompt = "You are helping write a brief, personal outreach email from Evan, the developer behind Argo Books, to a small business. The goal is to get honest product feedback on Argo Books, a bookkeeping and invoicing app for small businesses.

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -143,6 +143,20 @@ function ab_body_instruction_for_variant($variant)
 }
 
 /**
+ * CTA / offer instruction builder. Replaces the standard "free 1-year
+ * premium license in exchange for feedback" offer with whatever wording
+ * (or directive) the variant specifies.
+ */
+function ab_cta_instruction_for_variant($variant)
+{
+    $parsed = ab_parse_variant_content($variant);
+    if ($parsed['mode'] === 'directive') {
+        return "\n- OFFER OVERRIDE: ignore the \"free 1-year premium license in exchange for feedback\" offer above. Instead, phrase the offer in line with this directive: \"" . $parsed['text'] . "\". Work it in naturally; do not list it like a bullet point.";
+    }
+    return "\n- OFFER OVERRIDE: ignore the \"free 1-year premium license in exchange for feedback\" offer above. The offer in this email must be exactly: \"" . $parsed['text'] . "\". Phrase it naturally inside the body — do not just paste it as a quoted line.";
+}
+
+/**
  * Per-type prompt-injection dispatch. Future phases register new types here
  * (body, cta, personalization). Send-side types (sender, preheader, format)
  * apply at send time, not here, and return ['' for prompt injection.
@@ -157,7 +171,8 @@ function ab_instruction_for_variant($variant, $variantType = 'subject')
             return ab_subject_instruction_for_variant($variant);
         case 'body':
             return ab_body_instruction_for_variant($variant);
-        // Phase 2: case 'cta':  return ab_cta_instruction_for_variant($variant);
+        case 'cta':
+            return ab_cta_instruction_for_variant($variant);
         // Phase 6: case 'personalization': handled inline in generate_draft_for_lead, not here
         default:
             return '';
@@ -711,7 +726,8 @@ function generate_draft_for_lead($pdo, $lead)
     $abVariantId = null;
     $abSubjectOverride = '';
     $abBodyOverride = '';
-    foreach (['subject', 'body'] as $promptType) {
+    $abCtaOverride = '';
+    foreach (['subject', 'body', 'cta'] as $promptType) {
         $active = get_active_ab_test($pdo, $promptType);
         if (!$active) continue;
         $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
@@ -720,6 +736,7 @@ function generate_draft_for_lead($pdo, $lead)
         $instruction = ab_instruction_for_variant($variant, $promptType);
         if ($promptType === 'subject') $abSubjectOverride = $instruction;
         elseif ($promptType === 'body') $abBodyOverride = $instruction;
+        elseif ($promptType === 'cta') $abCtaOverride = $instruction;
         break; // one-at-a-time invariant — first hit wins
     }
 
@@ -751,7 +768,7 @@ $painPointsInstruction
 
 - Briefly describe Argo Books as a simple bookkeeping and invoicing app that requires no accounting knowledge. Do NOT just say \"check it out\" without explaining what it is
 - Mention you are looking for honest feedback from small business owners
-- Mention offering a free 1-year premium license in exchange for feedback
+- Mention offering a free 1-year premium license in exchange for feedback$abCtaOverride
 - Use a casual but professional tone
 - NEVER use placeholders like [Your Name], [Your Title], [Your Company], etc.
 - ALWAYS include the website link https://argorobots.com/ in the email body. This is required in every single email, no exceptions

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -729,17 +729,39 @@ function generate_draft_for_lead($pdo, $lead)
     // single match. Iterate over every known type so send-side variants
     // (sender / preheader / format) still get the lead-variant stamp here
     // even though they don't inject anything into the prompt.
+    //
+    // If the lead is already assigned to the currently-active test (e.g.
+    // admin clicked "Regenerate Draft" after the email went out), keep the
+    // existing variant. Re-running pick_ab_variant on a regenerate would
+    // skew round-robin balance and orphan any clicks already tracked under
+    // the lead's previous "?source=outreach-{id}-v{old}" URL.
     $abTestId = null;
     $abVariantId = null;
     $abSubjectOverride = '';
     $abBodyOverride = '';
     $abCtaOverride = '';
     $personalizationOff = false;
+    $existingAbTestId = isset($lead['ab_test_id']) ? (int) $lead['ab_test_id'] : 0;
+    $existingAbVariantId = isset($lead['ab_variant_id']) ? (int) $lead['ab_variant_id'] : 0;
     foreach (ab_known_variant_types() as $eligibleType) {
         $active = get_active_ab_test($pdo, $eligibleType);
         if (!$active) continue;
-        $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
-        $abTestId = (int) $active['test']['id'];
+        $activeTestId = (int) $active['test']['id'];
+
+        $variant = null;
+        if ($existingAbTestId === $activeTestId && $existingAbVariantId > 0) {
+            foreach ($active['variants'] as $candidate) {
+                if ((int) $candidate['id'] === $existingAbVariantId) {
+                    $variant = $candidate;
+                    break;
+                }
+            }
+        }
+        if ($variant === null) {
+            $variant = pick_ab_variant($pdo, $active['test'], $active['variants']);
+        }
+
+        $abTestId = $activeTestId;
         $abVariantId = (int) $variant['id'];
         $instruction = ab_instruction_for_variant($variant, $eligibleType);
         if ($eligibleType === 'subject') $abSubjectOverride = $instruction;
@@ -1106,7 +1128,6 @@ function generate_ab_subject_variants($pdo, $count = 3)
     return ['directives' => $directives, 'source' => 'ai'];
 }
 
-/**
 /**
  * Per-type variant generator dispatch. Returns
  *   ['directives' => [...], 'source' => 'ai'|'fallback'|'fixed', 'literal' => bool?]

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -99,20 +99,54 @@ function pick_ab_variant($pdo, $test, $variants)
 }
 
 /**
- * Given a variant row for a 'subject' test, return a prompt instruction
- * that tells the AI how to handle the subject line.
- * - If content starts with 'directive:' the rest is a style instruction.
- * - Otherwise content is a literal subject the AI must use verbatim.
+ * Split a variant's `content` into ['mode' => 'directive'|'literal', 'text' => string].
+ * Helper used by every per-type instruction builder.
  */
-function ab_subject_instruction_for_variant($variant)
+function ab_parse_variant_content($variant)
 {
     $content = trim((string) $variant['content']);
     if (stripos($content, 'directive:') === 0) {
-        $directive = trim(substr($content, strlen('directive:')));
-        return "\n- SUBJECT LINE OVERRIDE: write a subject line that follows this directive exactly: \"" . $directive . "\". This overrides any other guidance about subject lines above.";
+        return [
+            'mode' => 'directive',
+            'text' => trim(substr($content, strlen('directive:'))),
+        ];
     }
-    // Literal subject
-    return "\n- SUBJECT LINE OVERRIDE: use exactly this subject line, word for word, with no changes: \"" . $content . "\". This overrides any other guidance about subject lines above.";
+    return ['mode' => 'literal', 'text' => $content];
+}
+
+/**
+ * Subject-line instruction builder (Phase 0 default; subject is the only
+ * wired variant type today). Returns a prompt fragment to splice into the
+ * system prompt's subject-line bullet.
+ */
+function ab_subject_instruction_for_variant($variant)
+{
+    $parsed = ab_parse_variant_content($variant);
+    if ($parsed['mode'] === 'directive') {
+        return "\n- SUBJECT LINE OVERRIDE: write a subject line that follows this directive exactly: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
+    }
+    return "\n- SUBJECT LINE OVERRIDE: use exactly this subject line, word for word, with no changes: \"" . $parsed['text'] . "\". This overrides any other guidance about subject lines above.";
+}
+
+/**
+ * Per-type prompt-injection dispatch. Future phases register new types here
+ * (body, cta, personalization). Send-side types (sender, preheader, format)
+ * apply at send time, not here, and return ['' for prompt injection.
+ *
+ * Returns a string to append to the system prompt — empty if the type has no
+ * prompt-side effect (or isn't wired yet).
+ */
+function ab_instruction_for_variant($variant, $variantType = 'subject')
+{
+    switch ($variantType) {
+        case 'subject':
+            return ab_subject_instruction_for_variant($variant);
+        // Phase 1: case 'body': return ab_body_instruction_for_variant($variant);
+        // Phase 2: case 'cta':  return ab_cta_instruction_for_variant($variant);
+        // Phase 6: case 'personalization': handled inline in generate_draft_for_lead, not here
+        default:
+            return '';
+    }
 }
 
 // ─── Activity Logging ───
@@ -775,26 +809,36 @@ Return ONLY the JSON, no other text.";
 // ─── A/B Test Automation (called from stepManageAbTests in outreach_pipeline.php) ───
 
 /**
- * Evaluate the active subject-line test and promote a winner if any exit
- * criterion is met. Side effect: on trigger, UPDATE the test row to completed
- * with winner_variant_id set; optionally self-pauses automation if the
- * winning CTR is below the configured safety floor.
+ * Variant types the A/B framework knows about. Each later phase that wires
+ * in a new type extends this list. The cron iterates over it when looking
+ * for tests to promote.
+ */
+function ab_known_variant_types()
+{
+    return ['subject', 'body', 'sender', 'cta'];
+}
+
+/**
+ * Evaluate the active test of a given variant type and promote a winner if
+ * any exit criterion is met. Side effect: on trigger, UPDATE the test row to
+ * completed with winner_variant_id set; optionally self-pauses automation if
+ * the winning CTR is below the configured safety floor.
  *
  * Returns one of:
- *   ['action' => 'none', 'reason' => '...', ...]
- *   ['action' => 'promoted', 'test_id' => N, ...]
- *   ['action' => 'paused_safety', 'test_id' => N, ...]
+ *   ['action' => 'none', 'reason' => '...', 'variant_type' => $variantType, ...]
+ *   ['action' => 'promoted', 'test_id' => N, 'variant_type' => $variantType, ...]
+ *   ['action' => 'paused_safety', 'test_id' => N, 'variant_type' => $variantType, ...]
  *
  * Exit criteria (any one triggers promotion):
  *   a) leader significant at p<0.05 vs EVERY other variant AND every variant sent >= 30
  *   b) test age >= 14 days AND every variant sent >= 20
  *   c) test age >= 28 days (force-close; leader by CTR, ties by assigned then lowest id)
  */
-function ab_check_and_promote_active_test($pdo)
+function ab_check_and_promote_active_test($pdo, $variantType = 'subject')
 {
-    $active = get_active_ab_test($pdo, 'subject');
+    $active = get_active_ab_test($pdo, $variantType);
     if (!$active) {
-        return ['action' => 'none', 'reason' => 'no_active_test'];
+        return ['action' => 'none', 'reason' => 'no_active_test', 'variant_type' => $variantType];
     }
     $test = $active['test'];
 
@@ -848,6 +892,7 @@ function ab_check_and_promote_active_test($pdo)
         return [
             'action' => 'none',
             'reason' => 'criteria_not_met',
+            'variant_type' => $variantType,
             'age_days' => $ageDays,
             'min_sent' => $minSent,
             'test_id' => (int) $test['id'],
@@ -880,6 +925,7 @@ function ab_check_and_promote_active_test($pdo)
 
     return [
         'action' => $pausedForSafety ? 'paused_safety' : 'promoted',
+        'variant_type' => $variantType,
         'test_id' => (int) $test['id'],
         'test_name' => $test['name'],
         'winner_id' => (int) $winner['id'],
@@ -965,14 +1011,34 @@ function generate_ab_subject_variants($pdo, $count = 3)
 }
 
 /**
- * Start a new auto-cycle subject test. The previous winner (if any) is
- * carried forward as variant A so the established baseline keeps being
- * measured; newly-generated directives fill the other slots.
+ * Per-type variant generator dispatch. Phase 0 handles 'subject' only;
+ * later phases register additional types here. Returns the same shape
+ * generate_ab_subject_variants() returns: ['directives' => [...], 'source' => 'ai'|'fallback'].
  *
- * Returns ['action' => 'created', 'test_id' => N, ...]
- *      or ['action' => 'failed', 'error' => '...'].
+ * Returns ['directives' => [], 'source' => 'unsupported'] if no generator
+ * is registered for the requested type — caller should treat as failure.
  */
-function ab_start_new_cycle($pdo)
+function generate_ab_variants_for_type($pdo, $variantType, $count = 3)
+{
+    switch ($variantType) {
+        case 'subject':
+            return generate_ab_subject_variants($pdo, $count);
+        // Phase 1: case 'body': return generate_ab_body_variants($pdo, $count);
+        // Phase 2: case 'cta':  return generate_ab_cta_variants($pdo, $count);
+        default:
+            return ['directives' => [], 'source' => 'unsupported'];
+    }
+}
+
+/**
+ * Start a new auto-cycle test for a given variant type. The previous winner
+ * for that type (if any) is carried forward as variant A so the established
+ * baseline keeps being measured; newly-generated directives fill the other slots.
+ *
+ * Returns ['action' => 'created', 'test_id' => N, 'variant_type' => ..., ...]
+ *      or ['action' => 'failed', 'variant_type' => ..., 'error' => '...'].
+ */
+function ab_start_new_cycle($pdo, $variantType = 'subject')
 {
     $count = 3;
 
@@ -980,27 +1046,31 @@ function ab_start_new_cycle($pdo)
         SELECT v.content
         FROM outreach_ab_tests t
         JOIN outreach_ab_variants v ON v.id = t.winner_variant_id
-        WHERE t.status = 'completed' AND t.variant_type = 'subject'
+        WHERE t.status = 'completed' AND t.variant_type = ?
         ORDER BY t.completed_at DESC
         LIMIT 1
     ");
-    $priorStmt->execute();
+    $priorStmt->execute([$variantType]);
     $prior = $priorStmt->fetchColumn();
 
-    $gen = generate_ab_subject_variants($pdo, $count);
+    $gen = generate_ab_variants_for_type($pdo, $variantType, $count);
     $directives = $gen['directives'] ?? [];
     if (count($directives) < 2) {
-        return ['action' => 'failed', 'error' => 'Variant generation returned fewer than 2 directives'];
+        return [
+            'action' => 'failed',
+            'variant_type' => $variantType,
+            'error' => 'Variant generation returned fewer than 2 directives (source: ' . ($gen['source'] ?? 'unknown') . ')',
+        ];
     }
 
-    $name = 'Auto-cycle ' . date('Y-m-d H:i');
+    $name = 'Auto-cycle ' . $variantType . ' ' . date('Y-m-d H:i');
     $notes = 'Auto-generated by stepManageAbTests. Source: ' . ($gen['source'] ?? 'ai')
         . ($prior ? '. Prior winner carried forward as variant A.' : '.');
 
     $pdo->beginTransaction();
     try {
-        $pdo->prepare("INSERT INTO outreach_ab_tests (name, variant_type, status, started_at, notes) VALUES (?, 'subject', 'active', NOW(), ?)")
-            ->execute([$name, $notes]);
+        $pdo->prepare("INSERT INTO outreach_ab_tests (name, variant_type, status, started_at, notes) VALUES (?, ?, 'active', NOW(), ?)")
+            ->execute([$name, $variantType, $notes]);
         $testId = (int) $pdo->lastInsertId();
 
         $vStmt = $pdo->prepare("INSERT INTO outreach_ab_variants (test_id, label, content, is_default) VALUES (?, ?, ?, ?)");
@@ -1030,6 +1100,7 @@ function ab_start_new_cycle($pdo)
 
         return [
             'action' => 'created',
+            'variant_type' => $variantType,
             'test_id' => $testId,
             'test_name' => $name,
             'variant_count' => $variantCount,
@@ -1038,6 +1109,6 @@ function ab_start_new_cycle($pdo)
         ];
     } catch (Exception $e) {
         $pdo->rollBack();
-        return ['action' => 'failed', 'error' => $e->getMessage()];
+        return ['action' => 'failed', 'variant_type' => $variantType, 'error' => $e->getMessage()];
     }
 }

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -413,15 +413,10 @@ function stepManageAbTests($pdo, $dryRun)
             }
         }
         if (!$anyActive) {
-            $rotationOn = getState($pdo, 'ab_auto_rotation', '0') === '1';
-            if ($rotationOn) {
-                $order = ab_auto_rotation_order();
-                $next = getState($pdo, 'ab_auto_next_type', $order[0]);
-                if (!in_array($next, $order, true)) $next = $order[0];
-                logPipeline("[DRY RUN] Would create a new auto-cycle for variant_type '$next' (rotation on).");
-            } else {
-                logPipeline('[DRY RUN] Would create a new auto-cycle subject-line test (rotation off).');
-            }
+            $order = ab_auto_rotation_order();
+            $next = getState($pdo, 'ab_auto_next_type', $order[0]);
+            if (!in_array($next, $order, true)) $next = $order[0];
+            logPipeline("[DRY RUN] Would create a new auto-cycle for variant_type '$next'.");
         }
         return;
     }
@@ -476,21 +471,14 @@ function stepManageAbTests($pdo, $dryRun)
     // — keep the one-active-test-at-a-time invariant.
     if ($anyStillRunning) return;
 
-    // 2) Auto-create the next cycle. By default this is subject-only; when
-    //    ab_auto_rotation is on, the pointer ab_auto_next_type rotates across
-    //    the order returned by ab_auto_rotation_order() so the pipeline runs
-    //    cycles for each automatable type in turn. body/cta/preheader stay
-    //    admin-initiated either way (no AI generators wired for them yet).
-    $rotationOn = getState($pdo, 'ab_auto_rotation', '0') === '1';
-    if ($rotationOn) {
-        $order = ab_auto_rotation_order();
-        $nextType = getState($pdo, 'ab_auto_next_type', $order[0]);
-        if (!in_array($nextType, $order, true)) {
-            $nextType = $order[0];
-        }
-        $cycleType = $nextType;
-    } else {
-        $cycleType = 'subject';
+    // 2) Auto-create the next cycle. The ab_auto_next_type pointer rotates
+    //    across ab_auto_rotation_order() so the pipeline tests one lever,
+    //    then the next, and so on. body / cta / preheader aren't in the
+    //    rotation — they need crafted copy and stay admin-initiated.
+    $order = ab_auto_rotation_order();
+    $cycleType = getState($pdo, 'ab_auto_next_type', $order[0]);
+    if (!in_array($cycleType, $order, true)) {
+        $cycleType = $order[0];
     }
 
     $newCycle = ab_start_new_cycle($pdo, $cycleType);
@@ -504,18 +492,16 @@ function stepManageAbTests($pdo, $dryRun)
             $newCycle['source'],
             $newCycle['carried_winner'] ? ', prior winner carried forward' : ''
         ));
-        if ($rotationOn) {
-            $idx = array_search($cycleType, $order, true);
-            $advanced = $order[($idx + 1) % count($order)];
-            setState($pdo, 'ab_auto_next_type', $advanced);
-            logPipeline("A/B auto-rotation pointer advanced: next type will be '$advanced'.");
-        }
+        $idx = array_search($cycleType, $order, true);
+        $advanced = $order[($idx + 1) % count($order)];
+        setState($pdo, 'ab_auto_next_type', $advanced);
+        logPipeline("A/B auto-rotation pointer advanced: next type will be '$advanced'.");
     } else {
         logPipeline('A/B auto-create failed for ' . $cycleType . ': ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
         // Advance the pointer past an unsupported type so rotation doesn't
         // get stuck. Other failure modes (DB error, OpenAI down) are retried
         // on the next run with the same pointer.
-        if ($rotationOn && (strpos((string) ($newCycle['error'] ?? ''), 'unsupported') !== false)) {
+        if (strpos((string) ($newCycle['error'] ?? ''), 'unsupported') !== false) {
             $idx = array_search($cycleType, $order, true);
             $advanced = $order[($idx + 1) % count($order)];
             setState($pdo, 'ab_auto_next_type', $advanced);

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -401,63 +401,88 @@ function stepManageAbTests($pdo, $dryRun)
         return;
     }
 
+    $allTypes = ab_known_variant_types();
+
     if ($dryRun) {
-        $active = get_active_ab_test($pdo, 'subject');
-        if ($active) {
-            logPipeline("[DRY RUN] Would evaluate active A/B test #{$active['test']['id']} '{$active['test']['name']}' for promotion.");
-        } else {
+        $anyActive = false;
+        foreach ($allTypes as $type) {
+            $active = get_active_ab_test($pdo, $type);
+            if ($active) {
+                logPipeline("[DRY RUN] Would evaluate active $type test #{$active['test']['id']} '{$active['test']['name']}' for promotion.");
+                $anyActive = true;
+            }
+        }
+        if (!$anyActive) {
             logPipeline('[DRY RUN] Would create a new auto-cycle subject-line test.');
         }
         return;
     }
 
-    // 1) Evaluate the active test; promote if any exit criterion fires.
-    $evalResult = ab_check_and_promote_active_test($pdo);
-    if ($evalResult['action'] === 'promoted') {
-        logPipeline(sprintf(
-            "A/B auto-promoted winner: test #%d '%s' — variant %s wins (CTR %.2f%%) via %s after %d days.",
-            $evalResult['test_id'],
-            $evalResult['test_name'],
-            $evalResult['winner_label'],
-            $evalResult['winner_ctr'] * 100,
-            $evalResult['trigger'],
-            $evalResult['age_days']
-        ));
-    } elseif ($evalResult['action'] === 'paused_safety') {
-        logPipeline(sprintf(
-            "A/B auto-paused for safety: test #%d promoted variant %s but CTR %.2f%% fell below floor. ab_auto_enabled set to 0.",
-            $evalResult['test_id'],
-            $evalResult['winner_label'],
-            $evalResult['winner_ctr'] * 100
-        ), 'WARN');
-        return; // Don't start a new cycle — admin needs to review and Resume.
-    } elseif ($evalResult['action'] === 'none' && $evalResult['reason'] === 'criteria_not_met') {
-        logPipeline(sprintf(
-            "A/B test #%d '%s' still running (age %d days, min sent %d) — no promotion criteria met yet.",
-            $evalResult['test_id'] ?? 0,
-            $evalResult['test_name'] ?? '',
-            $evalResult['age_days'] ?? 0,
-            $evalResult['min_sent'] ?? 0
-        ));
-        return; // Test still in flight; don't start a new one.
+    // 1) Evaluate the active test of every known type. Today only subject can
+    //    be active (other types are admin-initiated until later phases enable
+    //    auto-creation), but iterating now means new types light up cleanly.
+    $anyStillRunning = false;
+    $anyPaused = false;
+    foreach ($allTypes as $type) {
+        $evalResult = ab_check_and_promote_active_test($pdo, $type);
+        $type = $evalResult['variant_type'] ?? $type;
+
+        if ($evalResult['action'] === 'promoted') {
+            logPipeline(sprintf(
+                "A/B auto-promoted winner: %s test #%d '%s' — variant %s wins (CTR %.2f%%) via %s after %d days.",
+                $type,
+                $evalResult['test_id'],
+                $evalResult['test_name'],
+                $evalResult['winner_label'],
+                $evalResult['winner_ctr'] * 100,
+                $evalResult['trigger'],
+                $evalResult['age_days']
+            ));
+        } elseif ($evalResult['action'] === 'paused_safety') {
+            logPipeline(sprintf(
+                "A/B auto-paused for safety: %s test #%d promoted variant %s but CTR %.2f%% fell below floor. ab_auto_enabled set to 0.",
+                $type,
+                $evalResult['test_id'],
+                $evalResult['winner_label'],
+                $evalResult['winner_ctr'] * 100
+            ), 'WARN');
+            $anyPaused = true;
+        } elseif ($evalResult['action'] === 'none' && ($evalResult['reason'] ?? '') === 'criteria_not_met') {
+            logPipeline(sprintf(
+                "A/B %s test #%d '%s' still running (age %d days, min sent %d) — no promotion criteria met yet.",
+                $type,
+                $evalResult['test_id'] ?? 0,
+                $evalResult['test_name'] ?? '',
+                $evalResult['age_days'] ?? 0,
+                $evalResult['min_sent'] ?? 0
+            ));
+            $anyStillRunning = true;
+        }
     }
 
-    // 2) Start a new cycle if nothing is active right now.
-    $active = get_active_ab_test($pdo, 'subject');
-    if (!$active) {
-        $newCycle = ab_start_new_cycle($pdo);
-        if ($newCycle['action'] === 'created') {
-            logPipeline(sprintf(
-                "A/B auto-created subject cycle: test #%d '%s' with %d variants (source: %s%s).",
-                $newCycle['test_id'],
-                $newCycle['test_name'],
-                $newCycle['variant_count'],
-                $newCycle['source'],
-                $newCycle['carried_winner'] ? ', prior winner carried forward' : ''
-            ));
-        } else {
-            logPipeline('A/B auto-create failed: ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
-        }
+    // Safety-pause shorts-circuits new-cycle creation across all types — admin
+    // needs to review and click Resume in Settings.
+    if ($anyPaused) return;
+
+    // If any test is still running (any type), don't start a new subject cycle
+    // yet — keep the one active test at a time invariant.
+    if ($anyStillRunning) return;
+
+    // 2) Auto-create the next subject cycle if nothing is active. Other types
+    //    (body/cta/sender/preheader/format/personalization) are admin-initiated
+    //    in v1 — see plan Phase 7 for optional cross-type auto-rotation.
+    $newCycle = ab_start_new_cycle($pdo, 'subject');
+    if ($newCycle['action'] === 'created') {
+        logPipeline(sprintf(
+            "A/B auto-created subject cycle: test #%d '%s' with %d variants (source: %s%s).",
+            $newCycle['test_id'],
+            $newCycle['test_name'],
+            $newCycle['variant_count'],
+            $newCycle['source'],
+            $newCycle['carried_winner'] ? ', prior winner carried forward' : ''
+        ));
+    } else {
+        logPipeline('A/B auto-create failed: ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
     }
 }
 

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -426,9 +426,9 @@ function stepManageAbTests($pdo, $dryRun)
         return;
     }
 
-    // 1) Evaluate the active test of every known type. Today only subject can
-    //    be active (other types are admin-initiated until later phases enable
-    //    auto-creation), but iterating now means new types light up cleanly.
+    // 1) Evaluate the active test of every known type for promotion. Only
+    //    one test can be active at a time per the framework's invariant; the
+    //    loop is type-agnostic so any wired type can promote cleanly.
     $anyStillRunning = false;
     $anyPaused = false;
     foreach ($allTypes as $type) {
@@ -472,8 +472,8 @@ function stepManageAbTests($pdo, $dryRun)
     // needs to review and click Resume in Settings.
     if ($anyPaused) return;
 
-    // If any test is still running (any type), don't start a new subject cycle
-    // yet — keep the one active test at a time invariant.
+    // If any test is still running (any type), don't start a new cycle yet
+    // — keep the one-active-test-at-a-time invariant.
     if ($anyStillRunning) return;
 
     // 2) Auto-create the next cycle. By default this is subject-only; when

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -174,9 +174,23 @@ try {
     global $pdo;
     ensureStateTable($pdo);
 
+    // ─── Master kill-switch: admin can disable the entire outreach system
+    // from the Settings tab. When off, the server cron still fires but does
+    // nothing until re-enabled.
+    $outreachEnabled = getState($pdo, 'outreach_enabled', '1');
+    if ($outreachEnabled !== '1') {
+        logPipeline('Outreach is DISABLED via admin Settings (outreach_enabled != "1"). Pipeline exiting without running any steps.');
+        return;
+    }
+
     // ─── STEP 1 & 2: Discover + Import ───
     if ($runAll || $discoverOnly) {
         stepDiscover($pdo, $dryRun);
+    }
+
+    // ─── STEP 2.5: Manage A/B Tests (auto-promote winners, auto-create next cycle) ───
+    if ($runAll || $draftOnly) {
+        stepManageAbTests($pdo, $dryRun);
     }
 
     // ─── STEP 3: Generate AI Drafts ───
@@ -185,8 +199,14 @@ try {
     }
 
     // ─── STEP 4: Auto-Approve ───
-    if (($runAll || $draftOnly) && AUTO_APPROVE) {
+    // Runtime-toggled via outreach_pipeline_state.auto_send_mode
+    // ('auto' | 'review'); falls back to the OUTREACH_AUTO_APPROVE env seed
+    // on a DB that hasn't had the toggle set yet.
+    $autoSendMode = getState($pdo, 'auto_send_mode', AUTO_APPROVE ? 'auto' : 'review');
+    if (($runAll || $draftOnly) && $autoSendMode === 'auto') {
         stepAutoApprove($pdo, $dryRun);
+    } elseif (($runAll || $draftOnly) && $autoSendMode === 'review') {
+        logPipeline('Send mode: review — drafts generated but auto-approve skipped.');
     }
 
     // ─── STEP 5: Send Emails ───
@@ -371,6 +391,76 @@ function stepDiscover($pdo, $dryRun)
     setState($pdo, 'last_discovery_city', "$city, $province");
 }
 
+function stepManageAbTests($pdo, $dryRun)
+{
+    logPipeline('--- Step 2.5: Manage A/B Tests ---');
+
+    $enabled = getState($pdo, 'ab_auto_enabled', '1');
+    if ($enabled !== '1') {
+        logPipeline('A/B automation is OFF (ab_auto_enabled != 1). Skipping.');
+        return;
+    }
+
+    if ($dryRun) {
+        $active = get_active_ab_test($pdo, 'subject');
+        if ($active) {
+            logPipeline("[DRY RUN] Would evaluate active A/B test #{$active['test']['id']} '{$active['test']['name']}' for promotion.");
+        } else {
+            logPipeline('[DRY RUN] Would create a new auto-cycle subject-line test.');
+        }
+        return;
+    }
+
+    // 1) Evaluate the active test; promote if any exit criterion fires.
+    $evalResult = ab_check_and_promote_active_test($pdo);
+    if ($evalResult['action'] === 'promoted') {
+        logPipeline(sprintf(
+            "A/B auto-promoted winner: test #%d '%s' — variant %s wins (CTR %.2f%%) via %s after %d days.",
+            $evalResult['test_id'],
+            $evalResult['test_name'],
+            $evalResult['winner_label'],
+            $evalResult['winner_ctr'] * 100,
+            $evalResult['trigger'],
+            $evalResult['age_days']
+        ));
+    } elseif ($evalResult['action'] === 'paused_safety') {
+        logPipeline(sprintf(
+            "A/B auto-paused for safety: test #%d promoted variant %s but CTR %.2f%% fell below floor. ab_auto_enabled set to 0.",
+            $evalResult['test_id'],
+            $evalResult['winner_label'],
+            $evalResult['winner_ctr'] * 100
+        ), 'WARN');
+        return; // Don't start a new cycle — admin needs to review and Resume.
+    } elseif ($evalResult['action'] === 'none' && $evalResult['reason'] === 'criteria_not_met') {
+        logPipeline(sprintf(
+            "A/B test #%d '%s' still running (age %d days, min sent %d) — no promotion criteria met yet.",
+            $evalResult['test_id'] ?? 0,
+            $evalResult['test_name'] ?? '',
+            $evalResult['age_days'] ?? 0,
+            $evalResult['min_sent'] ?? 0
+        ));
+        return; // Test still in flight; don't start a new one.
+    }
+
+    // 2) Start a new cycle if nothing is active right now.
+    $active = get_active_ab_test($pdo, 'subject');
+    if (!$active) {
+        $newCycle = ab_start_new_cycle($pdo);
+        if ($newCycle['action'] === 'created') {
+            logPipeline(sprintf(
+                "A/B auto-created subject cycle: test #%d '%s' with %d variants (source: %s%s).",
+                $newCycle['test_id'],
+                $newCycle['test_name'],
+                $newCycle['variant_count'],
+                $newCycle['source'],
+                $newCycle['carried_winner'] ? ', prior winner carried forward' : ''
+            ));
+        } else {
+            logPipeline('A/B auto-create failed: ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
+        }
+    }
+}
+
 function stepGenerateDrafts($pdo, $dryRun)
 {
     logPipeline('--- Step 3: Generate AI Drafts ---');
@@ -499,7 +589,7 @@ function stepSendEmails($pdo, $dryRun)
 
     // Find approved leads with drafts that haven't been sent
     $stmt = $pdo->prepare("
-        SELECT id, business_name, email, draft_subject, draft_body
+        SELECT id, business_name, email, draft_subject, draft_body, unsubscribe_token, ab_test_id, ab_variant_id
         FROM outreach_leads
         WHERE approval_status = 'approved'
           AND draft_subject IS NOT NULL AND draft_subject != ''
@@ -536,8 +626,11 @@ function stepSendEmails($pdo, $dryRun)
 
         try {
             if (send_outreach_lead($pdo, $lead)) {
-                log_activity($pdo, $id, 'email_sent', 'Outreach email sent automatically via pipeline to: ' . $email);
-                logPipeline("Sent email to $businessName <$email> (lead #$id)");
+                $variantTag = !empty($lead['ab_variant_id'])
+                    ? ' [A/B test #' . (int) $lead['ab_test_id'] . ', variant #' . (int) $lead['ab_variant_id'] . ']'
+                    : '';
+                log_activity($pdo, $id, 'email_sent', 'Outreach email sent automatically via pipeline to: ' . $email . $variantTag);
+                logPipeline("Sent email to $businessName <$email> (lead #$id)" . $variantTag);
                 $successCount++;
             } else {
                 log_activity($pdo, $id, 'email_failed', 'Pipeline email send failed for: ' . $email);

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -413,7 +413,15 @@ function stepManageAbTests($pdo, $dryRun)
             }
         }
         if (!$anyActive) {
-            logPipeline('[DRY RUN] Would create a new auto-cycle subject-line test.');
+            $rotationOn = getState($pdo, 'ab_auto_rotation', '0') === '1';
+            if ($rotationOn) {
+                $order = ab_auto_rotation_order();
+                $next = getState($pdo, 'ab_auto_next_type', $order[0]);
+                if (!in_array($next, $order, true)) $next = $order[0];
+                logPipeline("[DRY RUN] Would create a new auto-cycle for variant_type '$next' (rotation on).");
+            } else {
+                logPipeline('[DRY RUN] Would create a new auto-cycle subject-line test (rotation off).');
+            }
         }
         return;
     }
@@ -468,21 +476,51 @@ function stepManageAbTests($pdo, $dryRun)
     // yet — keep the one active test at a time invariant.
     if ($anyStillRunning) return;
 
-    // 2) Auto-create the next subject cycle if nothing is active. Other types
-    //    (body/cta/sender/preheader/format/personalization) are admin-initiated
-    //    in v1 — see plan Phase 7 for optional cross-type auto-rotation.
-    $newCycle = ab_start_new_cycle($pdo, 'subject');
+    // 2) Auto-create the next cycle. By default this is subject-only; when
+    //    ab_auto_rotation is on, the pointer ab_auto_next_type rotates across
+    //    the order returned by ab_auto_rotation_order() so the pipeline runs
+    //    cycles for each automatable type in turn. body/cta/preheader stay
+    //    admin-initiated either way (no AI generators wired for them yet).
+    $rotationOn = getState($pdo, 'ab_auto_rotation', '0') === '1';
+    if ($rotationOn) {
+        $order = ab_auto_rotation_order();
+        $nextType = getState($pdo, 'ab_auto_next_type', $order[0]);
+        if (!in_array($nextType, $order, true)) {
+            $nextType = $order[0];
+        }
+        $cycleType = $nextType;
+    } else {
+        $cycleType = 'subject';
+    }
+
+    $newCycle = ab_start_new_cycle($pdo, $cycleType);
     if ($newCycle['action'] === 'created') {
         logPipeline(sprintf(
-            "A/B auto-created subject cycle: test #%d '%s' with %d variants (source: %s%s).",
+            "A/B auto-created %s cycle: test #%d '%s' with %d variants (source: %s%s).",
+            $cycleType,
             $newCycle['test_id'],
             $newCycle['test_name'],
             $newCycle['variant_count'],
             $newCycle['source'],
             $newCycle['carried_winner'] ? ', prior winner carried forward' : ''
         ));
+        if ($rotationOn) {
+            $idx = array_search($cycleType, $order, true);
+            $advanced = $order[($idx + 1) % count($order)];
+            setState($pdo, 'ab_auto_next_type', $advanced);
+            logPipeline("A/B auto-rotation pointer advanced: next type will be '$advanced'.");
+        }
     } else {
-        logPipeline('A/B auto-create failed: ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
+        logPipeline('A/B auto-create failed for ' . $cycleType . ': ' . ($newCycle['error'] ?? 'unknown'), 'ERROR');
+        // Advance the pointer past an unsupported type so rotation doesn't
+        // get stuck. Other failure modes (DB error, OpenAI down) are retried
+        // on the next run with the same pointer.
+        if ($rotationOn && (strpos((string) ($newCycle['error'] ?? ''), 'unsupported') !== false)) {
+            $idx = array_search($cycleType, $order, true);
+            $advanced = $order[($idx + 1) % count($order)];
+            setState($pdo, 'ab_auto_next_type', $advanced);
+            logPipeline("A/B auto-rotation skipped unsupported type '$cycleType'; pointer advanced to '$advanced'.");
+        }
     }
 }
 

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -53,7 +53,6 @@ if (!flock($lockFp, LOCK_EX | LOCK_NB)) {
 
 define('DAILY_SEND_LIMIT', (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10));
 define('AUTO_APPROVE', filter_var($_ENV['OUTREACH_AUTO_APPROVE'] ?? 'true', FILTER_VALIDATE_BOOLEAN));
-define('CATEGORIES_PER_RUN', 5);
 
 // Parse CLI flags ($argv is null under CGI, fall back to empty array)
 $args = array_slice($argv ?? [], 1);
@@ -254,28 +253,22 @@ function stepDiscover($pdo, $dryRun)
         logPipeline('All cities searched. Wrapping around to start.');
     }
 
-    // Track which categories we've searched for the current city.
-    // Each run searches CATEGORIES_PER_RUN categories starting from this offset.
-    // Only when we've cycled through ALL categories without finding
-    // new leads do we consider the city truly exhausted.
+    // Track which categories we've searched for the current city. We keep
+    // walking the pool starting from this offset and only stop when we've
+    // collected DAILY_SEND_LIMIT businesses or cycled through every
+    // category. Each run picks up where the last left off so the daily
+    // cap actually gets hit instead of being limited by an arbitrary
+    // categories-per-run constant.
     $categoryOffset = (int) getState($pdo, 'current_city_category_offset', '0');
 
     $target = $targetCities[$cityIndex];
     $city = $target['city'];
     $province = $target['province'];
 
-    // Pick the next batch of categories to search (wrapping around the pool)
-    $categoriesToSearch = [];
-    for ($i = 0; $i < CATEGORIES_PER_RUN; $i++) {
-        $categoriesToSearch[] = OUTREACH_CATEGORY_POOL[($categoryOffset + $i) % $totalCategories];
-    }
-
-    $endCategory = min($categoryOffset + CATEGORIES_PER_RUN, $totalCategories);
-    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", categories " . ($categoryOffset + 1) . "-$endCategory/$totalCategories) ---");
-    logPipeline("Searching categories: " . implode(', ', $categoriesToSearch));
+    logPipeline("--- Step 1: Discovery for $city, $province (city #" . ($cityIndex + 1) . "/" . count($targetCities) . ", starting at category " . ($categoryOffset + 1) . "/$totalCategories) ---");
 
     if ($dryRun) {
-        logPipeline("[DRY RUN] Would search Google Places for businesses in $city, $province");
+        logPipeline("[DRY RUN] Would search Google Places for businesses in $city, $province until cap of " . DAILY_SEND_LIMIT . " is reached or all $totalCategories categories are exhausted");
         return;
     }
 
@@ -284,19 +277,26 @@ function stepDiscover($pdo, $dryRun)
     $stmt->execute();
     $existingPlaceIds = array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'places_id');
 
-    // Search each category individually and collect results.
-    // Pass maxRounds=1 since each category is already specific — we don't need
-    // 5 query variations per category like the admin dashboard does.
+    // Walk the category pool from $categoryOffset, wrapping at the end. Stop
+    // as soon as we have DAILY_SEND_LIMIT businesses OR have visited every
+    // category in the pool (which signals the city is exhausted for this
+    // pass). Pass maxRounds=1 since each category is already specific — we
+    // don't need 5 query variations per category like the admin dashboard.
     $businesses = [];
-    $roundsUsed = 0;
+    $categoriesSearched = 0;
     $apiErrors = 0;
+    $categoriesUsed = [];
 
-    foreach ($categoriesToSearch as $cat) {
+    for ($i = 0; $i < $totalCategories; $i++) {
         if (count($businesses) >= DAILY_SEND_LIMIT) break;
+
+        $catIdx = ($categoryOffset + $i) % $totalCategories;
+        $cat = OUTREACH_CATEGORY_POOL[$catIdx];
+        $categoriesUsed[] = $cat;
 
         $remaining = DAILY_SEND_LIMIT - count($businesses);
         $result = search_businesses_core($city, $province, $cat, $remaining, $apiKey, $existingPlaceIds, 1);
-        $roundsUsed++;
+        $categoriesSearched++;
 
         if (isset($result['error'])) {
             logPipeline("API error searching '$cat' in $city: {$result['error']}", 'WARN');
@@ -314,12 +314,12 @@ function stepDiscover($pdo, $dryRun)
     }
 
     // If every single API call failed, don't advance — retry same categories next run
-    if ($apiErrors === $roundsUsed) {
+    if ($apiErrors > 0 && $apiErrors === $categoriesSearched) {
         logPipeline("All $apiErrors API calls failed for $city. Will retry same categories next run.", 'ERROR');
         return;
     }
 
-    logPipeline("Discovered " . count($businesses) . " businesses with emails in $city ($roundsUsed category searches, $apiErrors errors)");
+    logPipeline("Discovered " . count($businesses) . " businesses with emails in $city ($categoriesSearched category searches: " . implode(', ', $categoriesUsed) . "; $apiErrors errors)");
 
     // Import discovered businesses
     $imported = 0;
@@ -368,23 +368,26 @@ function stepDiscover($pdo, $dryRun)
 
     logPipeline("Imported $imported new leads, skipped $skipped duplicates from $city");
 
-    // Advance the category offset for the next run
-    $newOffset = $categoryOffset + CATEGORIES_PER_RUN;
+    // Advance the category offset by however many categories we actually
+    // walked. If we hit the daily cap early, the pointer stays close to
+    // where we stopped so the next run picks up at the next category. If
+    // we cycled through the entire pool without hitting the cap, the city
+    // is considered exhausted and we move on.
+    $cycledThroughAll = ($categoriesSearched >= $totalCategories);
 
-    if ($newOffset >= $totalCategories) {
-        // We've cycled through every category for this city
+    if ($cycledThroughAll) {
         if ($imported === 0) {
             logPipeline("All $totalCategories categories searched for $city with no new leads. City exhausted, advancing.");
             setState($pdo, 'current_city_index', (string)($cityIndex + 1));
             setState($pdo, 'current_city_category_offset', '0');
         } else {
-            logPipeline("Completed full category cycle for $city but still finding leads. Resetting categories.");
+            logPipeline("Completed full category cycle for $city while still finding leads. Resetting offset for next run.");
             setState($pdo, 'current_city_category_offset', '0');
         }
     } else {
+        $newOffset = ($categoryOffset + $categoriesSearched) % $totalCategories;
         setState($pdo, 'current_city_category_offset', (string)$newOffset);
-        $nextEnd = min($newOffset + CATEGORIES_PER_RUN, $totalCategories);
-        logPipeline("Next run will search categories " . ($newOffset + 1) . "-$nextEnd/$totalCategories for $city.");
+        logPipeline("Hit daily cap after $categoriesSearched categories. Next run picks up at category " . ($newOffset + 1) . "/$totalCategories for $city.");
     }
 
     setState($pdo, 'last_discovery_date', date('Y-m-d'));

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -463,8 +463,8 @@ function stepManageAbTests($pdo, $dryRun)
         }
     }
 
-    // Safety-pause shorts-circuits new-cycle creation across all types — admin
-    // needs to review and click Resume in Settings.
+    // Safety-pause short-circuits new-cycle creation across all types — admin
+    // needs to flip A/B automation back on in Settings before anything moves.
     if ($anyPaused) return;
 
     // If any test is still running (any type), don't start a new cycle yet

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -471,7 +471,35 @@ function stepManageAbTests($pdo, $dryRun)
     // — keep the one-active-test-at-a-time invariant.
     if ($anyStillRunning) return;
 
-    // 2) Auto-create the next cycle. The ab_auto_next_type pointer rotates
+    // 2) Defensive backstop: never start a new cycle while ANY status='active'
+    //    test row exists, even one the per-type promotion sweep couldn't
+    //    evaluate (e.g. zero or one variant attached, which can't happen via
+    //    the UI but could from direct DB edits). Two active tests would
+    //    silently corrupt the one-active-test invariant.
+    $activeCheck = $pdo->query("SELECT id, name, variant_type,
+        (SELECT COUNT(*) FROM outreach_ab_variants v WHERE v.test_id = t.id) AS variant_count
+        FROM outreach_ab_tests t WHERE status = 'active' ORDER BY id ASC LIMIT 1")->fetch();
+    if ($activeCheck) {
+        if ((int) $activeCheck['variant_count'] < 2) {
+            logPipeline(sprintf(
+                "A/B auto-cycle blocked: active %s test #%d '%s' is misconfigured (%d variant(s)). Admin intervention required.",
+                $activeCheck['variant_type'],
+                (int) $activeCheck['id'],
+                $activeCheck['name'],
+                (int) $activeCheck['variant_count']
+            ), 'WARN');
+        } else {
+            logPipeline(sprintf(
+                "A/B auto-cycle blocked: active %s test #%d '%s' still exists. Not creating a second active test.",
+                $activeCheck['variant_type'],
+                (int) $activeCheck['id'],
+                $activeCheck['name']
+            ));
+        }
+        return;
+    }
+
+    // 3) Auto-create the next cycle. The ab_auto_next_type pointer rotates
     //    across ab_auto_rotation_order() so the pipeline tests one lever,
     //    then the next, and so on. body / cta / preheader aren't in the
     //    rotation — they need crafted copy and stay admin-initiated.

--- a/email_sender.php
+++ b/email_sender.php
@@ -61,13 +61,18 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
             $header_inline = $header_style;
         }
 
+        // Subjects can be admin-authored or AI-generated; escape for the
+        // HTML <title> context. The raw subject still goes to SMTP/mail()
+        // as the email Subject header below.
+        $titleEscaped = htmlspecialchars((string) $subject, ENT_QUOTES, 'UTF-8');
+
         $email_body = <<<HTML
             <!DOCTYPE html>
             <html>
             <head>
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-                <title>{$subject}</title>
+                <title>{$titleEscaped}</title>
                 <style>
                     {$css}
                 </style>

--- a/email_sender.php
+++ b/email_sender.php
@@ -25,12 +25,19 @@ function _premium_feature_list_items($prefix = '')
  * @param string $subject Email subject
  * @param string $body_content HTML content for the email body (will be wrapped in template)
  * @param string $header_style Optional custom header style (default: blue gradient)
+ * @param string|null $preheader Optional inbox-preview snippet; rendered as a hidden element so it appears next to the subject in most mail clients without being visible in the body
  * @return bool True if successful, false otherwise
  */
-function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [])
+function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [], $preheader = null)
 {
     $css = file_get_contents(__DIR__ . '/email.css');
     $site_url = site_url();
+
+    $preheaderHtml = '';
+    if ($preheader !== null && trim((string) $preheader) !== '') {
+        $safePreheader = htmlspecialchars((string) $preheader, ENT_QUOTES, 'UTF-8');
+        $preheaderHtml = '<div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:transparent;mso-hide:all;">' . $safePreheader . '</div>';
+    }
 
     // Map style keywords to CSS classes, or use inline style for backwards compatibility
     $header_class = '';
@@ -56,6 +63,7 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
             </style>
         </head>
         <body>
+            {$preheaderHtml}
             <div class="container">
                 <div class="header {$header_class}" style="{$header_inline}">
                     <img src="{$site_url}/resources/images/argo-logo/argo-logo-white.png" alt="Argo Logo" width="140">

--- a/email_sender.php
+++ b/email_sender.php
@@ -19,15 +19,19 @@ function _premium_feature_list_items($prefix = '')
 }
 
 /**
- * Base function to send an email with standard Argo styling
+ * Base function to send an email with standard Argo styling.
  *
- * @param string $to_email Recipient email address
- * @param string $subject Email subject
- * @param string $body_content HTML content for the email body (will be wrapped in template). When $format === 'plain', this is used as-is as plain text and no template is applied.
- * @param string $header_style Optional custom header style (default: blue gradient)
- * @param string|null $preheader Optional inbox-preview snippet; rendered as a hidden element so it appears next to the subject in most mail clients without being visible in the body. Ignored when $format === 'plain'.
- * @param string $format 'html' (default, full styled template) or 'plain' (no wrapper, sent as text/plain)
- * @return bool True if successful, false otherwise
+ * @param string      $to_email      Recipient email address
+ * @param string      $subject       Email subject
+ * @param string      $body_content  HTML content for the email body (will be wrapped in template). When $format === 'plain', this is used as-is as plain text and no template is applied.
+ * @param string      $header_style  Optional header style ('blue', 'purple', '' for default, or a raw inline style string for backwards compatibility)
+ * @param string|null $from_email    Sender email address; falls back to noreply@argorobots.com when null
+ * @param string|null $from_name     Sender display name; defaults to 'Argo Books' when null
+ * @param string|null $reply_to      Reply-To address; defaults to support@argorobots.com when null
+ * @param array       $extra_headers Optional associative array of additional headers (added to the SMTP message via addCustomHeader)
+ * @param string|null $preheader     Optional inbox-preview snippet; rendered as a hidden element so it appears next to the subject in most mail clients without being visible in the body. Ignored when $format === 'plain'.
+ * @param string      $format        'html' (default, full styled template) or 'plain' (no wrapper, sent as text/plain)
+ * @return bool                      True if successful, false otherwise
  */
 function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [], $preheader = null, $format = 'html')
 {

--- a/email_sender.php
+++ b/email_sender.php
@@ -23,58 +23,65 @@ function _premium_feature_list_items($prefix = '')
  *
  * @param string $to_email Recipient email address
  * @param string $subject Email subject
- * @param string $body_content HTML content for the email body (will be wrapped in template)
+ * @param string $body_content HTML content for the email body (will be wrapped in template). When $format === 'plain', this is used as-is as plain text and no template is applied.
  * @param string $header_style Optional custom header style (default: blue gradient)
- * @param string|null $preheader Optional inbox-preview snippet; rendered as a hidden element so it appears next to the subject in most mail clients without being visible in the body
+ * @param string|null $preheader Optional inbox-preview snippet; rendered as a hidden element so it appears next to the subject in most mail clients without being visible in the body. Ignored when $format === 'plain'.
+ * @param string $format 'html' (default, full styled template) or 'plain' (no wrapper, sent as text/plain)
  * @return bool True if successful, false otherwise
  */
-function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [], $preheader = null)
+function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [], $preheader = null, $format = 'html')
 {
-    $css = file_get_contents(__DIR__ . '/email.css');
-    $site_url = site_url();
+    $isPlain = ($format === 'plain');
 
-    $preheaderHtml = '';
-    if ($preheader !== null && trim((string) $preheader) !== '') {
-        $safePreheader = htmlspecialchars((string) $preheader, ENT_QUOTES, 'UTF-8');
-        $preheaderHtml = '<div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:transparent;mso-hide:all;">' . $safePreheader . '</div>';
-    }
-
-    // Map style keywords to CSS classes, or use inline style for backwards compatibility
-    $header_class = '';
-    $header_inline = '';
-    if ($header_style === 'purple') {
-        $header_class = 'header-purple';
-    } elseif ($header_style === 'blue' || empty($header_style)) {
-        $header_class = 'header-blue';
+    if ($isPlain) {
+        $email_body = (string) $body_content;
     } else {
-        // Assume it's an inline style for backwards compatibility
-        $header_inline = $header_style;
-    }
+        $css = file_get_contents(__DIR__ . '/email.css');
+        $site_url = site_url();
 
-    $email_html = <<<HTML
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-            <title>{$subject}</title>
-            <style>
-                {$css}
-            </style>
-        </head>
-        <body>
-            {$preheaderHtml}
-            <div class="container">
-                <div class="header {$header_class}" style="{$header_inline}">
-                    <img src="{$site_url}/resources/images/argo-logo/argo-logo-white.png" alt="Argo Logo" width="140">
+        $preheaderHtml = '';
+        if ($preheader !== null && trim((string) $preheader) !== '') {
+            $safePreheader = htmlspecialchars((string) $preheader, ENT_QUOTES, 'UTF-8');
+            $preheaderHtml = '<div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:transparent;mso-hide:all;">' . $safePreheader . '</div>';
+        }
+
+        // Map style keywords to CSS classes, or use inline style for backwards compatibility
+        $header_class = '';
+        $header_inline = '';
+        if ($header_style === 'purple') {
+            $header_class = 'header-purple';
+        } elseif ($header_style === 'blue' || empty($header_style)) {
+            $header_class = 'header-blue';
+        } else {
+            // Assume it's an inline style for backwards compatibility
+            $header_inline = $header_style;
+        }
+
+        $email_body = <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+                <title>{$subject}</title>
+                <style>
+                    {$css}
+                </style>
+            </head>
+            <body>
+                {$preheaderHtml}
+                <div class="container">
+                    <div class="header {$header_class}" style="{$header_inline}">
+                        <img src="{$site_url}/resources/images/argo-logo/argo-logo-white.png" alt="Argo Logo" width="140">
+                    </div>
+                    <div class="content">
+                        {$body_content}
+                    </div>
                 </div>
-                <div class="content">
-                    {$body_content}
-                </div>
-            </div>
-        </body>
-        </html>
-        HTML;
+            </body>
+            </html>
+            HTML;
+    }
 
     // Use SMTP relay if configured, otherwise fall back to mail()
     $mailer = create_smtp_mailer();
@@ -86,7 +93,10 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
             $mailer->addAddress($to_email);
             $mailer->addReplyTo($reply_to ?? 'support@argorobots.com');
             $mailer->Subject = $subject;
-            $mailer->Body = $email_html;
+            if ($isPlain) {
+                $mailer->isHTML(false);
+            }
+            $mailer->Body = $email_body;
             if (!empty($extra_headers) && is_array($extra_headers)) {
                 foreach ($extra_headers as $name => $value) {
                     $mailer->addCustomHeader($name, $value);
@@ -101,15 +111,16 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
     }
 
     $actualFrom = $from_email ? ($from_name ?? 'Argo Books') . " <{$from_email}>" : 'Argo Books <noreply@argorobots.com>';
+    $contentType = $isPlain ? 'text/plain; charset=UTF-8' : 'text/html; charset=UTF-8';
     $headers = [
         'MIME-Version: 1.0',
-        'Content-Type: text/html; charset=UTF-8',
+        'Content-Type: ' . $contentType,
         'From: ' . $actualFrom,
         'Reply-To: ' . ($reply_to ?? 'support@argorobots.com'),
         'X-Mailer: PHP/' . phpversion()
     ];
 
-    return mail($to_email, $subject, $email_html, implode("\r\n", $headers));
+    return mail($to_email, $subject, $email_body, implode("\r\n", $headers));
 }
 
 /**

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -551,6 +551,8 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     notes TEXT DEFAULT NULL,
     feedback_summary TEXT DEFAULT NULL,
     draft_subject VARCHAR(500) DEFAULT NULL,
+    ab_test_id INT DEFAULT NULL,
+    ab_variant_id INT DEFAULT NULL,
     draft_body TEXT DEFAULT NULL,
     drafted_at DATETIME DEFAULT NULL,
     approved_at DATETIME DEFAULT NULL,
@@ -565,8 +567,15 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     INDEX idx_outreach_city (city),
     INDEX idx_outreach_approval (approval_status),
     INDEX idx_outreach_company_size (company_size),
-    INDEX idx_unsubscribe_token (unsubscribe_token)
+    INDEX idx_unsubscribe_token (unsubscribe_token),
+    INDEX idx_outreach_ab (ab_test_id, ab_variant_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- For existing installs, add the A/B columns:
+--   ALTER TABLE outreach_leads
+--     ADD COLUMN ab_test_id INT NULL AFTER draft_subject,
+--     ADD COLUMN ab_variant_id INT NULL AFTER ab_test_id,
+--     ADD INDEX idx_outreach_ab (ab_test_id, ab_variant_id);
 
 -- Email suppression list (unsubscribes, opt-outs across all email contexts)
 CREATE TABLE IF NOT EXISTS email_suppressions (
@@ -589,4 +598,31 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (lead_id) REFERENCES outreach_leads(id) ON DELETE CASCADE,
     INDEX idx_outreach_activity_lead (lead_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- A/B tests for outreach email variants (subject lines in v1; body/sender/cta later)
+CREATE TABLE IF NOT EXISTS outreach_ab_tests (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(120) NOT NULL,
+    variant_type ENUM('subject','body','sender','cta') NOT NULL DEFAULT 'subject',
+    status ENUM('draft','active','paused','completed') NOT NULL DEFAULT 'draft',
+    notes TEXT DEFAULT NULL,
+    started_at DATETIME DEFAULT NULL,
+    completed_at DATETIME DEFAULT NULL,
+    winner_variant_id INT DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_ab_test_status (status),
+    INDEX idx_ab_test_type_status (variant_type, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Variants that belong to an A/B test
+CREATE TABLE IF NOT EXISTS outreach_ab_variants (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    test_id INT NOT NULL,
+    label VARCHAR(60) NOT NULL,
+    content TEXT NOT NULL,
+    is_default TINYINT(1) NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (test_id) REFERENCES outreach_ab_tests(id) ON DELETE CASCADE,
+    INDEX idx_ab_variant_test (test_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -604,7 +604,7 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
 CREATE TABLE IF NOT EXISTS outreach_ab_tests (
     id INT PRIMARY KEY AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,
-    variant_type ENUM('subject','body','sender','cta') NOT NULL DEFAULT 'subject',
+    variant_type ENUM('subject','body','sender','cta','preheader') NOT NULL DEFAULT 'subject',
     status ENUM('draft','active','paused','completed') NOT NULL DEFAULT 'draft',
     notes TEXT DEFAULT NULL,
     started_at DATETIME DEFAULT NULL,

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -600,7 +600,9 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
     INDEX idx_outreach_activity_lead (lead_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- A/B tests for outreach email variants (subject lines in v1; body/sender/cta later)
+-- A/B tests for outreach email variants. variant_type covers every test type
+-- the framework supports: subject, body, sender, cta, preheader, format,
+-- personalization. Only one test of any type can be active at a time.
 CREATE TABLE IF NOT EXISTS outreach_ab_tests (
     id INT PRIMARY KEY AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -604,7 +604,7 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
 CREATE TABLE IF NOT EXISTS outreach_ab_tests (
     id INT PRIMARY KEY AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,
-    variant_type ENUM('subject','body','sender','cta','preheader') NOT NULL DEFAULT 'subject',
+    variant_type ENUM('subject','body','sender','cta','preheader','format') NOT NULL DEFAULT 'subject',
     status ENUM('draft','active','paused','completed') NOT NULL DEFAULT 'draft',
     notes TEXT DEFAULT NULL,
     started_at DATETIME DEFAULT NULL,

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -568,14 +568,18 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     INDEX idx_outreach_approval (approval_status),
     INDEX idx_outreach_company_size (company_size),
     INDEX idx_unsubscribe_token (unsubscribe_token),
-    INDEX idx_outreach_ab (ab_test_id, ab_variant_id)
+    INDEX idx_outreach_ab (ab_test_id, ab_variant_id),
+    INDEX idx_outreach_ab_variant (ab_variant_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- For existing installs, add the A/B columns:
 --   ALTER TABLE outreach_leads
 --     ADD COLUMN ab_test_id INT NULL AFTER draft_subject,
 --     ADD COLUMN ab_variant_id INT NULL AFTER ab_test_id,
---     ADD INDEX idx_outreach_ab (ab_test_id, ab_variant_id);
+--     ADD INDEX idx_outreach_ab (ab_test_id, ab_variant_id),
+--     ADD INDEX idx_outreach_ab_variant (ab_variant_id);
+-- (Existing installs that already added idx_outreach_ab need only:
+--   ALTER TABLE outreach_leads ADD INDEX idx_outreach_ab_variant (ab_variant_id);)
 
 -- Email suppression list (unsubscribes, opt-outs across all email contexts)
 CREATE TABLE IF NOT EXISTS email_suppressions (

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -604,7 +604,7 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
 CREATE TABLE IF NOT EXISTS outreach_ab_tests (
     id INT PRIMARY KEY AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,
-    variant_type ENUM('subject','body','sender','cta','preheader','format') NOT NULL DEFAULT 'subject',
+    variant_type ENUM('subject','body','sender','cta','preheader','format','personalization') NOT NULL DEFAULT 'subject',
     status ENUM('draft','active','paused','completed') NOT NULL DEFAULT 'draft',
     notes TEXT DEFAULT NULL,
     started_at DATETIME DEFAULT NULL,

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -1,6 +1,6 @@
 # Email Outreach
 
-Argo Books has a built-in outreach system that finds local small businesses, writes them a personal-sounding email about trying Argo Books, and sends it. You can run it fully hands-off — the cron finds new leads, writes emails, tests subject lines, and learns which ones work — or flip it to 'Review before send' mode, where it still generates everything but waits for you to approve each draft in the Leads tab before anything goes out.
+Argo Books has a built-in outreach system that finds local small businesses, writes them a personal-sounding email about trying Argo Books, and sends it. You can run it fully hands-off — the cron finds new leads, writes emails, runs A/B tests to learn what works, and promotes the winners — or flip it to 'Review before send' mode, where it still generates everything but waits for you to approve each draft in the Leads tab before anything goes out.
 
 Everything lives in the admin dashboard under **Outreach**, which has three tabs: **Leads**, **A/B Tests**, and **Settings**.
 
@@ -11,7 +11,7 @@ Once a day the outreach cron does a routine:
 1. **Picks a city**, rotating through Saskatchewan first and then expanding outward into the rest of Canada.
 2. **Finds small businesses** there by category (plumbers, cafes, salons, and 90-odd other small-business types) and grabs their public contact email from their website.
 3. **Writes each one a short email** with OpenAI (currently `gpt-4o-mini`). The email references the kind of business they run and the everyday headaches that category tends to have.
-4. **Runs a quiet subject-line A/B test** alongside the send. It splits traffic across 2–4 variant styles and keeps the one that gets clicks.
+4. **Runs a quiet A/B test** alongside the send. It splits traffic across 2–4 variants and keeps the one that gets clicks. By default it tests subject lines; you can extend it to other things (body, CTA, sender name, preheader, HTML-vs-plain, with-vs-without personalization).
 5. **Sends the emails**, up to the daily cap (`OUTREACH_DAILY_SEND_LIMIT`), with a tracked link so clicks can be attributed back to the lead and variant.
 
 You decide whether to let all of that run on its own or pause at each step for you to review. Both modes are just a toggle.
@@ -32,18 +32,33 @@ Every outreach email's `argorobots.com` link is rewritten to include a `?source=
 
 ## The A/B Tests tab
 
-This is where the system runs experiments on your subject lines. You don't have to create tests yourself — when automation is on, it does it for you. But you can also run your own if you want to try a specific idea.
+This is where the system runs experiments on the things that affect open and click rate. You don't have to create tests yourself — when automation is on, it does it for you. But you can also run your own if you want to try a specific idea.
 
-### What it tests
+### What it can test
 
-Right now the system tests **subject lines only**. That's the biggest single factor in whether someone opens a cold email, so it's the most useful thing to optimise. The schema is ready for body / sender / CTA tests later.
+Each test targets one **variant type**:
 
-Each test has 2–4 variants. A variant can be either:
+- **Subject line** — the biggest single factor in whether a cold email gets opened.
+- **Email body** — the AI's writing style and structure for the message itself.
+- **CTA / offer** — the framing of what the recipient gets ("free 1-year license for feedback" vs other offers).
+- **Sender from-name** — the name the email appears to come from (e.g. `Evan` vs `Evan from Argo Books` vs `Argo Books`).
+- **Preheader** — the snippet most inboxes show next to the subject as a preview.
+- **Format** — full HTML email with logo and styling vs plain text. Plain text often outperforms styled HTML in cold outreach because it looks like a human's email rather than marketing.
+- **Personalization depth** — with vs without the AI-generated business summary (which costs an OpenAI call per lead). Use this to find out whether that extra call is worth keeping.
 
-- **A literal subject line** — used exactly as written for every email in that variant. Good for "I have a specific subject I want to try."
-- **A style directive** — a short instruction prefixed with `directive:` (e.g. `directive: ask a curiosity question referencing their city`). The AI writes a different subject for each lead but in that style. Good for testing *kinds* of subject lines, not specific wordings. Anything not prefixed with `directive:` is treated as a literal.
+Only one test can be active at a time, regardless of type — that keeps the math clean. The auto-loop creates the next cycle as soon as the current one promotes.
 
-When you create a test by hand, you can mix both. When the system creates a test automatically, it always uses directives (because they generalise across different businesses).
+### How variants work
+
+Each test has 2–4 variants. The way variant content is interpreted depends on the type:
+
+- **Subject / body / CTA** can be either:
+  - **A literal value** — used exactly as written for every email in that variant. Good for "I have a specific wording I want to try."
+  - **A style directive** prefixed with `directive:` (e.g. `directive: ask a curiosity question referencing their city`). The AI generates fresh content in that style for each lead. Good for testing *kinds* of writing, not specific wordings. Anything without the prefix is treated as a literal.
+- **Sender / preheader** are always literal strings.
+- **Format / personalization** use a fixed two-variant template (`html` vs `plain`, `on` vs `off`). The form fills these automatically when you pick the type — you don't author them.
+
+When you create a test by hand, the form adapts to the type you pick. When the system creates a test automatically, it uses directives for subject (so they generalise across different businesses) or the fixed pool for sender / format / personalization.
 
 ### How the experiment runs
 
@@ -59,7 +74,11 @@ With automation on, the cron ends a test and promotes the leader when **any** of
 - **Time-boxed** — the test is ≥14 days old and every variant has ≥20 sends.
 - **Hard timeout** — the test is ≥28 days old; leader picked by CTR so the loop doesn't stall on low volume.
 
-Once a winner is promoted, the cron immediately starts the next cycle. It carries the winning variant forward as variant A (so the current champion keeps being measured) and asks OpenAI for three new directive styles to test against it. If OpenAI errors, it falls back to a curated set of seed directives so the loop never stalls. The first-ever cycle has no prior winner, so it runs with three fresh directives only.
+Once a winner is promoted, the cron immediately starts the next cycle.
+
+For directive-style types (subject / body / CTA), it carries the winning variant forward as variant A so the current champion keeps being measured, and asks OpenAI for three new directive styles to test against it. If OpenAI errors, it falls back to a curated set of seed directives so the loop never stalls. The first-ever cycle has no prior winner, so it runs with three fresh directives only.
+
+For fixed-pool types (sender / format / personalization), the next cycle just re-runs the fixed variants — there's no carry-forward, since the pool itself is the test. Each new cycle is a fresh measurement against current conditions.
 
 You can also stop a test early, pause it, or promote a winner manually from the detail page.
 
@@ -84,8 +103,15 @@ You can flip between the two at any time. The next scheduled run honours whichev
 
 Two options: **On** or **Off**.
 
-- **On** — the system manages subject-line tests for you, as described above.
+- **On** — the system manages tests for you, as described above: it creates new cycles, picks winners, and starts the next one.
 - **Off** — any test that's currently running keeps running, but no new ones get started and no winners get promoted automatically. You can still run tests by hand from the A/B Tests tab.
+
+### A/B auto-rotation
+
+Two options: **On** or **Off**. Off by default.
+
+- **Off** — auto-cycles only run for subject-line tests. Other types stay admin-initiated; you start them manually from the A/B Tests tab.
+- **On** — completed cycles trigger the next type in rotation: **subject → sender → format → personalization → (loop)**. The Settings panel shows which type is queued next. Body / CTA / preheader stay admin-initiated either way (they need crafted copy and the system has no AI generator for them). Manual tests of any type still work in both modes — they just delay the rotation while they run, since only one test can be active at a time.
 
 ### Current status
 
@@ -101,7 +127,7 @@ Underneath the toggles you'll see a live read-out: active test, days running, va
 **The cautious setup:**
 
 1. Settings → **Review before send**, A/B automation **on**.
-2. You open each day's drafts in the Leads tab and approve/edit/send manually. The subject-line experiments still run, measured against whatever you actually send.
+2. You open each day's drafts in the Leads tab and approve/edit/send manually. The A/B experiments still run, measured against whatever you actually send.
 
 **The hands-on setup:**
 

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -1,232 +1,121 @@
-# Email Outreach System
+# Email Outreach
 
-Argo Books includes an automated email outreach system that discovers local businesses, generates personalized AI-drafted emails, and sends them on a daily schedule. The system can run fully hands-off via a cron pipeline or be operated manually through an admin dashboard.
+Argo Books has a built-in outreach system that finds local small businesses, writes them a personal-sounding email about trying Argo Books, and sends it. You can run it fully hands-off — the cron finds new leads, writes emails, tests subject lines, and learns which ones work — or flip it to 'Review before send' mode, where it still generates everything but waits for you to approve each draft in the Leads tab before anything goes out.
 
-## Overview
+Everything lives in the admin dashboard under **Outreach**, which has three tabs: **Leads**, **A/B Tests**, and **Settings**.
 
-The outreach system has three main components:
+## How it works
 
-| Component | Path | Purpose |
-|-----------|------|---------|
-| **Admin Dashboard** | `/admin/outreach/` | Web UI for manual lead management, discovery, and sending |
-| **Cron Pipeline** | `/cron/outreach_pipeline.php` | Automated daily workflow |
-| **Shared Helpers** | `/cron/lib/outreach_helpers.php` | Core business logic used by both |
+Once a day the outreach cron does a routine:
 
-## Pipeline Flow
+1. **Picks a city**, rotating through Saskatchewan first and then expanding outward into the rest of Canada.
+2. **Finds small businesses** there by category (plumbers, cafes, salons, and 90-odd other small-business types) and grabs their public contact email from their website.
+3. **Writes each one a short email** with OpenAI (currently `gpt-4o-mini`). The email references the kind of business they run and the everyday headaches that category tends to have.
+4. **Runs a quiet subject-line A/B test** alongside the send. It splits traffic across 2–4 variant styles and keeps the one that gets clicks.
+5. **Sends the emails**, up to the daily cap (`OUTREACH_DAILY_SEND_LIMIT`), with a tracked link so clicks can be attributed back to the lead and variant.
 
-The automated pipeline runs daily and executes five steps in sequence:
+You decide whether to let all of that run on its own or pause at each step for you to review. Both modes are just a toggle.
 
-### Step 1: Business Discovery
+## The Leads tab
 
-The pipeline picks the next city from a rotating list of 45+ Canadian cities (Saskatchewan first, then expanding outward to Alberta, Manitoba, BC, and Ontario) and searches the Google Places API for businesses.
+This is the list of businesses the system has found or that you've added manually. Each row shows the business name, category, city, status (new / draft ready / contacted / replied / etc.), whether they've clicked, and whether they've replied.
 
-For each result the system:
+From here you can:
 
-1. Fetches place details (phone, website, address) from the Google Place Details API
-2. Scrapes the business website for a contact email — checks `mailto:` links first, then falls back to regex patterns, and follows links to `/contact` or `/about` pages if needed
-3. Filters out false-positive emails from CDNs and platforms (e.g. `wixpress.com`, `wordpress.org`)
-4. Skips businesses that have no website or no discoverable email
-5. Deduplicates against existing leads by Google Places ID and email address
+- **Search the web for new businesses** in a specific city and category, preview the results, and pick which ones to import.
+- **Add a lead by hand** or import a spreadsheet.
+- **Open a lead** to see the AI-generated email, edit the draft before it's sent, or mark the conversation status (interested / not interested / onboarded / replied).
+- **Bulk-generate drafts** or **bulk-send emails** for a group of leads you've selected.
+- **See the full activity history** for any lead — every draft, every send, every click.
 
-After completing a city the pipeline advances the index so the next run searches a different city. When all cities have been visited it wraps around to the start.
+Every outreach email's `argorobots.com` link is rewritten to include a `?source=outreach-{leadId}` parameter (plus `-v{variantId}` when the lead was assigned to an A/B variant). Hits land in `referral_visits` and show up on the Leads table as "Clicked" automatically.
 
-### Step 2: Lead Import
+## The A/B Tests tab
 
-Discovered businesses are inserted into the `outreach_leads` table with source `google_places_auto`. Each import is logged in the activity timeline.
+This is where the system runs experiments on your subject lines. You don't have to create tests yourself — when automation is on, it does it for you. But you can also run your own if you want to try a specific idea.
 
-### Step 3: AI Draft Generation
+### What it tests
 
-Leads that have an email but no draft are picked up in batches. For each lead the system:
+Right now the system tests **subject lines only**. That's the biggest single factor in whether someone opens a cold email, so it's the most useful thing to optimise. The schema is ready for body / sender / CTA tests later.
 
-1. Fetches the business website and extracts readable text (up to 3,000 characters)
-2. Sends the text to OpenAI to generate a 3–5 sentence business summary covering services, customers, billing approach, and pain points
-3. Sends the summary along with a detailed brand prompt to OpenAI to generate a personalized email subject and body
+Each test has 2–4 variants. A variant can be either:
 
-The brand prompt instructs the AI to:
+- **A literal subject line** — used exactly as written for every email in that variant. Good for "I have a specific subject I want to try."
+- **A style directive** — a short instruction prefixed with `directive:` (e.g. `directive: ask a curiosity question referencing their city`). The AI writes a different subject for each lead but in that style. Good for testing *kinds* of subject lines, not specific wordings. Anything not prefixed with `directive:` is treated as a literal.
 
-- Position Argo Books as a simpler alternative to QuickBooks
-- Reference specific details from the business summary
-- Emphasize a local connection if the business is in Saskatchewan
-- Keep the email under 100 words across 2–3 paragraphs
-- Include the Argo Books URL (`https://argorobots.com/`)
-- Sign off as "Evan" from Argo Books
+When you create a test by hand, you can mix both. When the system creates a test automatically, it always uses directives (because they generalise across different businesses).
 
-If the AI returns invalid JSON the draft is saved with `approval_status = 'needs_review'` for manual editing.
+### How the experiment runs
 
-### Step 4: Auto-Approve
+While a test is active, every new email gets assigned to a variant by deterministic round-robin (A, B, C, A, B, C…), so the split stays exactly even regardless of cron run boundaries. The `-v{id}` suffix on the `?source=` URL is how clicks get credited to the right variant.
 
-When auto-approve is enabled (the default), all drafts that have a subject, body, and recipient email are approved automatically. This step can be disabled via the `OUTREACH_AUTO_APPROVE` environment variable to require manual review in the admin dashboard before any email is sent.
+On the test's detail page you'll see, for each variant: assigned count, sends, clicks, CTR, and — once there's enough data — a confidence tag vs the current leader (two-proportion z-test, with 80% and 95% thresholds).
 
-### Step 5: Send Emails
+### How a winner gets picked
 
-Approved leads are sent up to the daily limit. Each email is wrapped in the Argo Books branded HTML template and dispatched via SMTP (or PHP `mail()` as a fallback). After sending, the lead status is updated to `contacted` and timestamps are recorded.
+With automation on, the cron ends a test and promotes the leader when **any** of these is true:
 
-A 2-second pause between sends avoids triggering rate limits.
+- **Significant** — the leader's z-test vs every other variant is significant at p<0.05, and every variant has ≥30 sends.
+- **Time-boxed** — the test is ≥14 days old and every variant has ≥20 sends.
+- **Hard timeout** — the test is ≥28 days old; leader picked by CTR so the loop doesn't stall on low volume.
 
-## Admin Dashboard
+Once a winner is promoted, the cron immediately starts the next cycle. It carries the winning variant forward as variant A (so the current champion keeps being measured) and asks OpenAI for three new directive styles to test against it. If OpenAI errors, it falls back to a curated set of seed directives so the loop never stalls. The first-ever cycle has no prior winner, so it runs with three fresh directives only.
 
-The admin dashboard at `/admin/outreach/` provides manual control over every step of the pipeline.
+You can also stop a test early, pause it, or promote a winner manually from the detail page.
 
-### Dashboard Features
+### Safety pause
 
-| Feature | Description |
-|---------|-------------|
-| **Stats Panel** | Real-time counts of leads by status (new, drafted, contacted, replied, interested, onboarded) |
-| **Business Discovery** | Search Google Places by city and category, preview results, and import selected businesses |
-| **Leads Table** | Filter, sort, search, and bulk-operate on leads |
-| **Lead Detail Modal** | Edit lead info, review/edit AI drafts, view activity timeline |
-| **Bulk Operations** | Generate drafts, send emails, or delete multiple leads at once |
-| **CSV Import/Export** | Upload leads from a spreadsheet or download the current list |
-| **Company Size Classification** | AI-powered bulk classification of businesses as small, medium, or large |
+If the cron's own pick turns out badly — winner CTR under the configured floor (default 1%, stored in `outreach_pipeline_state.ab_ctr_floor`) — automation sets `ab_auto_enabled = '0'` and surfaces a Resume banner in the Settings tab. This is so a run of bad cycles can't quietly drag CTR downward.
 
-### API Endpoints
+## The Settings tab
 
-The dashboard frontend communicates with `/admin/outreach/api.php`, which exposes the following actions:
 
-| Action | Description |
-|--------|-------------|
-| `get_leads` | Fetch leads with filters (status, response, company size, search text) |
-| `get_lead` | Fetch a single lead by ID |
-| `create_lead` | Create a lead manually |
-| `update_lead` | Edit lead fields |
-| `delete_lead` | Delete a lead and its activity log |
-| `get_stats` | Dashboard statistics |
-| `search_businesses` | Google Places business discovery |
-| `import_leads` | Bulk import from discovery results |
-| `generate_draft` | Generate an AI email draft for one lead |
-| `send_email` | Send an approved email |
-| `get_activity` | Activity timeline for a lead |
-| `classify_company_sizes` | AI-classify selected leads by company size |
-| `export_csv` / `import_csv` | CSV export and import |
 
-All state-changing endpoints require admin session authentication and CSRF token validation.
+### Send mode
 
-## Lead Lifecycle
+Two options, shown as big side-by-side buttons:
 
-Each lead progresses through two parallel status tracks:
+- **Auto-send.** The system generates drafts, approves them, and sends them up to the daily limit. No touch from you.
+- **Review before send.** The system still generates drafts, but stops there. You open each lead in the Leads tab, read the email, then send it (or tweak it and then send it). Nothing goes out until you click.
 
-### Lead Status
+You can flip between the two at any time. The next scheduled run honours whichever one is set.
 
-Tracks the overall stage of engagement:
+### A/B automation
 
-`new` → `draft_generated` → `awaiting_approval` → `approved` → `contacted` → `replied` → `interested` → `onboarded`
+Two options: **On** or **Off**.
 
-(A lead can also be marked `not_interested` at any point.)
+- **On** — the system manages subject-line tests for you, as described above.
+- **Off** — any test that's currently running keeps running, but no new ones get started and no winners get promoted automatically. You can still run tests by hand from the A/B Tests tab.
 
-### Approval Status
+### Current status
 
-Tracks the email draft workflow:
+Underneath the toggles you'll see a live read-out: active test, days running, variants, sends/clicks, and current leader. Plus the daily send limit and a tail of today's `cron/logs/outreach_pipeline_<date>.log` filtered to A/B automation events — so you can see things like "Promoted variant B after 15 days via timebox" without tailing the log file on the server.
 
-`not_drafted` → `draft_ready` → `needs_review` → `approved` → `sent`
+## What you should do, practically
 
-### Response Status
+**The no-touch setup:**
 
-Tracks how the business responded after contact: `no_response`, `positive`, `neutral`, or `negative`.
+1. Go to **Outreach → Settings**, turn both **Auto-send** and **A/B automation** on.
+2. That's it. Leave it alone. Check back once a week or so on the A/B Tests tab to see which styles are winning.
 
-## Database Schema
+**The cautious setup:**
 
-### outreach_leads
+1. Settings → **Review before send**, A/B automation **on**.
+2. You open each day's drafts in the Leads tab and approve/edit/send manually. The subject-line experiments still run, measured against whatever you actually send.
 
-Stores all lead data including contact info, AI-generated drafts, and status tracking.
+**The hands-on setup:**
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INT | Primary key |
-| `business_name` | VARCHAR(255) | Business name from Google Places or manual entry |
-| `contact_name` | VARCHAR(255) | Contact person (if known) |
-| `email` | VARCHAR(255) | Scraped or manually entered email |
-| `phone` | VARCHAR(50) | Phone number |
-| `website` | VARCHAR(500) | Business website URL |
-| `address` | VARCHAR(500) | Physical address |
-| `category` | VARCHAR(100) | Business category (e.g. "plumber", "restaurant") |
-| `city` | VARCHAR(100) | City name |
-| `source` | VARCHAR(100) | How the lead was added (`manual`, `google_places_auto`, `csv_import`) |
-| `status` | ENUM | Lead lifecycle status |
-| `response_status` | ENUM | How the business responded |
-| `approval_status` | ENUM | Draft approval workflow status |
-| `company_size` | ENUM | AI or manual classification (`small`, `medium`, `large`) |
-| `draft_subject` | VARCHAR(500) | AI-generated email subject |
-| `draft_body` | TEXT | AI-generated email body |
-| `business_summary` | TEXT | Cached AI summary of the business website |
-| `places_id` | VARCHAR(255) | Google Places ID for deduplication |
-| `drafted_at` | DATETIME | When the draft was generated |
-| `sent_at` | DATETIME | When the email was sent |
-| `first_contact_date` | DATETIME | Date of first email |
-| `last_contact_date` | DATETIME | Date of most recent email |
+1. Settings → A/B automation **off**.
+2. Run your own tests by hand in the A/B Tests tab when you have specific ideas to try.
 
-### outreach_activity_log
+You can switch between these whenever — nothing about the data changes; only future behaviour does.
 
-Audit trail of all actions performed on each lead.
+## What actually gets sent
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INT | Primary key |
-| `lead_id` | INT | Foreign key to `outreach_leads` (cascading delete) |
-| `action_type` | VARCHAR(50) | Action identifier (e.g. `lead_created`, `draft_generated`, `email_sent`) |
-| `details` | TEXT | Human-readable description |
-| `created_at` | DATETIME | Timestamp |
+Emails are short (2–3 short paragraphs, under 100 words), mention that Evan is a local Saskatchewan developer (or a Canadian developer if the business isn't in Saskatchewan), and reference the kind of business they run — in general industry terms, never with made-up specifics about the recipient. Every email includes a link to argorobots.com and a soft one-line unsubscribe. Sign-off is always Evan / Argo Books.
 
-### outreach_pipeline_state
+If OpenAI returns invalid JSON (or leaves out the required fields), the draft is saved with `approval_status = 'needs_review'` and held back from auto-approve until an admin edits it.
 
-Key-value store used by the cron pipeline to track its position across runs.
+## Pausing everything quickly
 
-| Key | Description |
-|-----|-------------|
-| `current_city_index` | Index into the target cities list |
-| `last_discovery_date` | Date of the last discovery run |
-| `last_discovery_city` | Name of the last city searched |
-
-## Configuration
-
-### Pipeline Settings
-
-| Environment Variable | Default | Description |
-|---------------------|---------|-------------|
-| `OUTREACH_DAILY_SEND_LIMIT` | `10` | Maximum emails sent per day (also controls discovery and draft batch sizes) |
-| `OUTREACH_AUTO_APPROVE` | `true` | Automatically approve generated drafts |
-
-### Required API Keys
-
-| Environment Variable | Service | Used For |
-|---------------------|---------|----------|
-| `GOOGLE_PLACES_API_KEY` | Google Places | Business discovery and details |
-| `OPENAI_API_KEY` | OpenAI | Draft generation and business summarization |
-| `OPENAI_MODEL` | OpenAI | Model selection (default: `gpt-4o-mini`) |
-
-### SMTP
-
-Email sending uses the shared SMTP configuration defined in `/smtp_mailer.php`:
-
-| Environment Variable | Description |
-|---------------------|-------------|
-| `SMTP_HOST` | SMTP server (Resend: `smtp.resend.com`) |
-| `SMTP_PORT` | Port (default: `587`) |
-| `SMTP_USERNAME` | Always the literal string `resend` |
-| `SMTP_PASSWORD` | Resend API key (starts with `re_`) |
-| `SMTP_FROM_EMAIL` | Sender address (default: `noreply@argorobots.com`) |
-| `SMTP_FROM_NAME` | Sender name (default: `Argo Books`) |
-
-Falls back to PHP `mail()` if SMTP is not configured.
-
-## Target Cities
-
-The pipeline rotates through cities in this order, starting with Saskatchewan and expanding outward:
-
-| Province | Cities |
-|----------|--------|
-| **Saskatchewan** | Saskatoon, Regina, Prince Albert, Moose Jaw, Swift Current, Yorkton, North Battleford, Estevan, Weyburn, Martensville, Warman, Humboldt, Melfort, Meadow Lake, Lloydminster |
-| **Alberta** | Edmonton, Calgary, Red Deer, Lethbridge, Medicine Hat, Grande Prairie, Airdrie, Spruce Grove, St. Albert |
-| **Manitoba** | Winnipeg, Brandon, Steinbach, Thompson, Portage la Prairie |
-| **British Columbia** | Vancouver, Victoria, Kelowna, Kamloops, Nanaimo |
-| **Ontario** | Toronto, Ottawa, Hamilton, London, Kitchener, Windsor, Barrie, Sudbury, Thunder Bay |
-
-## Key Files
-
-| File | Responsibility |
-|------|----------------|
-| `admin/outreach/index.php` | Admin dashboard UI |
-| `admin/outreach/api.php` | Admin API endpoints |
-| `cron/outreach_pipeline.php` | Automated daily pipeline |
-| `cron/lib/outreach_helpers.php` | Shared logic: discovery, scraping, draft generation, sending, activity logging |
-| `email_sender.php` | Branded HTML email rendering |
-| `smtp_mailer.php` | SMTP transport |
+If you ever want to stop cold: flip **Send mode** to *Review before send*. Nothing new goes out. Your existing leads are untouched and nothing is lost. Flip it back to *Auto-send* whenever you're ready to resume.

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -84,7 +84,7 @@ You can also stop a test early, pause it, or promote a winner manually from the 
 
 ### Safety pause
 
-If the cron's own pick turns out badly — winner CTR under the configured floor (default 1%, stored in `outreach_pipeline_state.ab_ctr_floor`) — automation sets `ab_auto_enabled = '0'` and surfaces a Resume banner in the Settings tab. This is so a run of bad cycles can't quietly drag CTR downward.
+If the cron's own pick turns out badly — winner CTR under the configured floor (default 1%, stored in `outreach_pipeline_state.ab_ctr_floor`) — automation sets `ab_auto_enabled = '0'` and shows an "A/B automation is off" banner at the top of the Settings tab with the pause reason. Flip the toggle below it to resume. This is so a run of bad cycles can't quietly drag CTR downward.
 
 ## The Settings tab
 
@@ -103,15 +103,8 @@ You can flip between the two at any time. The next scheduled run honours whichev
 
 Two options: **On** or **Off**.
 
-- **On** — the system manages tests for you, as described above: it creates new cycles, picks winners, and starts the next one.
+- **On** — the system manages tests for you: it creates new cycles, picks winners, and starts the next cycle as soon as one promotes. Successive cycles rotate across types in this order: **subject line → sender from-name → format (HTML vs plain) → personalization (with vs without business summary) → (loop back to subject)**. The Settings panel shows which type is queued next. Body, CTA, and preheader tests aren't in the rotation — those need wording you write yourself, so they're always started manually from the A/B Tests tab. Manual tests of any type still work — they just delay the rotation while they run, since only one test can be active at a time.
 - **Off** — any test that's currently running keeps running, but no new ones get started and no winners get promoted automatically. You can still run tests by hand from the A/B Tests tab.
-
-### A/B auto-rotation
-
-Two options: **On** or **Off**. Off by default.
-
-- **Off** — auto-cycles only run for subject-line tests. Other types stay admin-initiated; you start them manually from the A/B Tests tab.
-- **On** — completed cycles trigger the next type in rotation: **subject → sender → format → personalization → (loop)**. The Settings panel shows which type is queued next. Body / CTA / preheader stay admin-initiated either way (they need crafted copy and the system has no AI generator for them). Manual tests of any type still work in both modes — they just delay the rotation while they run, since only one test can be active at a time.
 
 ### Current status
 

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -1,6 +1,6 @@
 # Email Outreach
 
-Argo Books has a built-in outreach system that finds local small businesses, writes them a personal-sounding email about trying Argo Books, and sends it. You can run it fully hands-off — the cron finds new leads, writes emails, runs A/B tests to learn what works, and promotes the winners — or flip it to 'Review before send' mode, where it still generates everything but waits for you to approve each draft in the Leads tab before anything goes out.
+Argo Books has a built-in outreach system that finds local small businesses, writes them a personal-sounding email about trying Argo Books, and sends it. You can run it fully hands-off — the cron finds new leads, writes emails, runs A/B tests to learn what works, and promotes the winners — or flip it to 'Review before send' mode, where it still generates everything but waits for you to review (or edit) each draft in the Leads tab and click **Send Email** before anything goes out.
 
 Everything lives in the admin dashboard under **Outreach**, which has three tabs: **Leads**, **A/B Tests**, and **Settings**.
 
@@ -120,7 +120,7 @@ Underneath the toggles you'll see a live read-out: active test, days running, va
 **The cautious setup:**
 
 1. Settings → **Review before send**, A/B automation **on**.
-2. You open each day's drafts in the Leads tab and approve/edit/send manually. The A/B experiments still run, measured against whatever you actually send.
+2. You open each day's drafts in the Leads tab, review or edit them, then click Send Email (or use bulk send) to put them in the queue. The A/B experiments still run, measured against whatever you actually send.
 
 **The hands-on setup:**
 

--- a/resources/styles/button.css
+++ b/resources/styles/button.css
@@ -133,7 +133,8 @@
 }
 
 .btn-small {
-  width: 100px;
-  padding: 5px 0;
+  width: auto;
+  min-width: 100px;
+  padding: 5px 12px;
   font-size: 12px;
 }


### PR DESCRIPTION
## Summary

Extends the outreach A/B framework from subject-line-only to every realistic variant type, with full automation across the ones that can be auto-generated.

**Variant types now wired:**
- **subject** — AI-generated style directives (existing)
- **body** — admin-authored body directives or literals
- **CTA** — admin-authored offer wording
- **sender** — from-name on the email envelope (e.g. `Evan` vs `Evan from Argo Books`)
- **preheader** — the inbox-preview snippet next to the subject (NEW ENUM value)
- **format** — full styled HTML vs plain text (NEW ENUM value)
- **personalization** — with vs without the AI-generated `business_summary` (gates an OpenAI call per lead) (NEW ENUM value)

**Automation:**
- Once a cycle promotes, the cron auto-creates the next cycle, rotating across `subject → sender → format → personalization → (loop)`. Body / CTA / preheader stay admin-initiated since they need crafted copy.
- One A/B test active at a time, regardless of type — the activation handler now pauses every other active test so the draft generator never starves a second test.
- Safety pause stays: if winner CTR drops below the 1% floor (after ≥20 sends), automation flips itself off until the admin re-enables it.

**Schema change required before deploying:**

```sql
ALTER TABLE outreach_ab_tests
    MODIFY COLUMN variant_type
    ENUM('subject','body','sender','cta','preheader','format','personalization')
    NOT NULL DEFAULT 'subject';
```

22 files changed. Most of the diff is in `cron/lib/outreach_helpers.php`, `cron/outreach_pipeline.php`, `admin/outreach/tabs/ab-tests.php`, `admin/outreach/tabs/settings.php`, `email_sender.php`, `mysql_schema.sql`, and `read-me/Email outreach.md`.

## Test plan

- [ ] Run the schema ALTER on the server.
- [ ] Deploy. Confirm the existing subject-line auto-loop still works with no regressions.
- [ ] Settings tab: confirm rotation order list and "next type queued" readout match `ab_auto_rotation_order()`.
- [ ] Manually create a `preheader` test with two strings (e.g. `Quick question` vs `Free 1-year license inside`). Send to your own inbox via auto-send → confirm the preheader text appears next to the subject in Gmail / Outlook / Apple Mail.
- [ ] Manually create a `format` test → confirm the html variant arrives styled and the plain variant arrives as text/plain with the bare clickable `argorobots.com/?source=outreach-{id}-v{vid}` URL still tracking clicks per variant.
- [ ] Manually create a `personalization` test → run draft generation against ~20 leads → confirm `business_summary` is null on `off`-variant leads and populated on `on`-variant leads.
- [ ] Manually create a `sender` test → confirm the from-name on each variant matches what was set.
- [ ] Activate a body test while a subject test is already active → confirm the subject test gets paused (one-active-test invariant).
- [ ] Run `php cron/outreach_pipeline.php --dry-run` → confirm the log shows the queued rotation type.
- [ ] Watch the Settings tab log tail for "auto-cycle" / "auto-rotation" lines after the first promotion of each type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)