### PR TITLE
Outreach: make Pause / Details / End / Save notes buttons blue

### DIFF
--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -353,10 +353,10 @@ function ab_tests_tab_render_list($pdo)
                                                 <input type="hidden" name="action" value="status_change">
                                                 <input type="hidden" name="test_id" value="<?php echo (int) $t['id']; ?>">
                                                 <input type="hidden" name="status" value="paused">
-                                                <button type="submit" class="btn btn-small btn-neutral">Pause</button>
+                                                <button type="submit" class="btn btn-small btn-blue">Pause</button>
                                             </form>
                                         <?php endif; ?>
-                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="btn btn-small btn-neutral">Details</a>
+                                        <a href="?tab=ab-tests&test_id=<?php echo (int) $t['id']; ?>" class="btn btn-small btn-blue">Details</a>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>
@@ -507,7 +507,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="paused">
-                        <button type="submit" class="btn btn-small btn-neutral">Pause</button>
+                        <button type="submit" class="btn btn-small btn-blue">Pause</button>
                     </form>
                     <form method="POST" style="display:inline;" onsubmit="return confirm('End this test without picking a winner? Existing leads keep their variant; new leads stop getting assigned.');">
                         <input type="hidden" name="tab" value="ab-tests">
@@ -515,7 +515,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                         <input type="hidden" name="action" value="status_change">
                         <input type="hidden" name="test_id" value="<?php echo (int) $test['id']; ?>">
                         <input type="hidden" name="status" value="completed">
-                        <button type="submit" class="btn btn-small btn-neutral">End</button>
+                        <button type="submit" class="btn btn-small btn-blue">End</button>
                     </form>
                 <?php endif; ?>
             </div>
@@ -569,7 +569,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                     <textarea id="abNotesField" name="notes" rows="2" placeholder="Why you ran this test, any context for later."><?php echo htmlspecialchars((string) $test['notes']); ?></textarea>
                 </div>
                 <div style="margin-top:8px;">
-                    <button type="submit" class="btn btn-small btn-neutral">Save notes</button>
+                    <button type="submit" class="btn btn-small btn-blue">Save notes</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #304. The neutral-style action buttons in the A/B Tests tab were too close in tone to the panel background in dark mode — especially in the actions-cell where \`border: none\` strips the outline. Switched them to \`btn-blue\` so they have clear contrast in both themes and match the rest of the admin's secondary action buttons (View, Draft, Promote to winner, etc.).

Affects: Pause and Details on the All Tests row; Pause, End, and Save notes on the test detail panel.

## Test plan

- [ ] Open Outreach → A/B Tests in dark theme. Confirm Pause and Details on the All Tests row are clearly visible (blue background, white text) and same size.
- [ ] Click Details on an active test. Confirm Pause, End, and Save notes are also blue and readable.
- [ ] Repeat in light theme. No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)