### PR TITLE
Outreach: connect Resend webhook, add bounce/open metrics to A/B

### DIFF
--- a/admin/outreach/tabs/ab-tests.php
+++ b/admin/outreach/tabs/ab-tests.php
@@ -189,6 +189,16 @@ function ab_tests_tab_render_list($pdo)
                 JOIN referral_visits rv
                   ON rv.source_code = CONCAT('outreach-', ol.id, '-v', ol.ab_variant_id)
                 WHERE ol.ab_test_id = t.id) AS clicked_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN outreach_email_events e
+                  ON e.lead_id = ol.id AND e.event_type = 'opened'
+                WHERE ol.ab_test_id = t.id) AS opened_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN outreach_email_events e
+                  ON e.lead_id = ol.id AND e.event_type = 'bounced'
+                WHERE ol.ab_test_id = t.id) AS bounced_count,
             (SELECT COUNT(*) FROM outreach_leads ol
                 WHERE ol.ab_test_id = t.id
                   AND ol.status IN ('replied','interested','onboarded')) AS replied_count
@@ -199,12 +209,14 @@ function ab_tests_tab_render_list($pdo)
     ");
     $tests = $testsQuery->fetchAll();
 
-    $stats = ['active' => 0, 'completed' => 0, 'assigned' => 0, 'clicked' => 0, 'replied' => 0];
+    $stats = ['active' => 0, 'completed' => 0, 'assigned' => 0, 'clicked' => 0, 'opened' => 0, 'bounced' => 0, 'replied' => 0];
     foreach ($tests as $t) {
         if ($t['status'] === 'active') $stats['active']++;
         if ($t['status'] === 'completed') $stats['completed']++;
         $stats['assigned'] += (int) $t['assigned_count'];
         $stats['clicked']  += (int) $t['clicked_count'];
+        $stats['opened']   += (int) $t['opened_count'];
+        $stats['bounced']  += (int) $t['bounced_count'];
         $stats['replied']  += (int) $t['replied_count'];
     }
     ?>
@@ -223,12 +235,20 @@ function ab_tests_tab_render_list($pdo)
             <div class="stat-value"><?php echo (int) $stats['assigned']; ?></div>
         </div>
         <div class="stat-card">
+            <div class="stat-label">Leads Opened</div>
+            <div class="stat-value stat-opened-ab"><?php echo (int) $stats['opened']; ?></div>
+        </div>
+        <div class="stat-card">
             <div class="stat-label">Leads Clicked</div>
             <div class="stat-value stat-clicked-ab"><?php echo (int) $stats['clicked']; ?></div>
         </div>
         <div class="stat-card">
             <div class="stat-label">Leads Replied</div>
             <div class="stat-value stat-replied-ab"><?php echo (int) $stats['replied']; ?></div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Leads Bounced</div>
+            <div class="stat-value stat-bounced-ab"><?php echo (int) $stats['bounced']; ?></div>
         </div>
     </div>
 
@@ -324,6 +344,10 @@ function ab_tests_tab_render_list($pdo)
                                 <th>Reply rate</th>
                                 <th>Clicks</th>
                                 <th>CTR</th>
+                                <th>Opens</th>
+                                <th>Open rate</th>
+                                <th>Bounces</th>
+                                <th>Bounce rate</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
@@ -348,6 +372,10 @@ function ab_tests_tab_render_list($pdo)
                                     <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['replied_count']); ?></td>
                                     <td><?php echo (int) $t['clicked_count']; ?></td>
                                     <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['clicked_count']); ?></td>
+                                    <td><?php echo (int) $t['opened_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['opened_count']); ?></td>
+                                    <td><?php echo (int) $t['bounced_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $t['sent_count'], (int) $t['bounced_count']); ?></td>
                                     <td class="actions-cell">
                                         <?php if ($t['status'] === 'draft' || $t['status'] === 'paused'): ?>
                                             <form method="POST" style="display:inline;" onsubmit="return confirm('Activate this test? Any other currently active test will be paused (only one A/B test can be active at a time).');">
@@ -495,12 +523,16 @@ function ab_tests_tab_render_detail($pdo, $testId)
     $ctrLeaderIdx = find_leader_idx($variants, 'ctr');
     $replyLeaderIdx = $totalReplies > 0 ? find_leader_idx($variants, 'reply_rate') : null;
 
-    $chartLabels  = array_map(fn($v) => $v['label'], $variants);
-    $chartCtrs    = array_map(fn($v) => round($v['ctr'] * 100, 2), $variants);
-    $chartReplies = array_map(fn($v) => round($v['reply_rate'] * 100, 2), $variants);
-    $chartClicks  = array_map(fn($v) => (int) $v['clicked_count'], $variants);
-    $chartReplyCounts = array_map(fn($v) => (int) $v['replied_count'], $variants);
-    $chartSent    = array_map(fn($v) => (int) $v['sent_count'], $variants);
+    $chartLabels       = array_map(fn($v) => $v['label'], $variants);
+    $chartCtrs         = array_map(fn($v) => round($v['ctr'] * 100, 2), $variants);
+    $chartReplies      = array_map(fn($v) => round($v['reply_rate'] * 100, 2), $variants);
+    $chartOpens        = array_map(fn($v) => round($v['open_rate'] * 100, 2), $variants);
+    $chartBounces      = array_map(fn($v) => round($v['bounce_rate'] * 100, 2), $variants);
+    $chartClicks       = array_map(fn($v) => (int) $v['clicked_count'], $variants);
+    $chartReplyCounts  = array_map(fn($v) => (int) $v['replied_count'], $variants);
+    $chartOpenCounts   = array_map(fn($v) => (int) $v['opened_count'], $variants);
+    $chartBounceCounts = array_map(fn($v) => (int) $v['bounced_count'], $variants);
+    $chartSent         = array_map(fn($v) => (int) $v['sent_count'], $variants);
     ?>
 
     <p style="margin-top:0;"><a href="?tab=ab-tests" class="link-strong">&larr; All tests</a></p>
@@ -645,6 +677,10 @@ function ab_tests_tab_render_detail($pdo, $testId)
                                 <th>Reply rate</th>
                                 <th>Clicks</th>
                                 <th>CTR</th>
+                                <th>Opens</th>
+                                <th>Open rate</th>
+                                <th>Bounces</th>
+                                <th>Bounce rate</th>
                                 <th>Confidence vs leader</th>
                                 <th>Actions</th>
                             </tr>
@@ -676,6 +712,10 @@ function ab_tests_tab_render_detail($pdo, $testId)
                                     <td><?php echo format_ctr((int) $v['sent_count'], (int) $v['replied_count']); ?></td>
                                     <td><?php echo (int) $v['clicked_count']; ?></td>
                                     <td><?php echo format_ctr((int) $v['sent_count'], (int) $v['clicked_count']); ?></td>
+                                    <td><?php echo (int) $v['opened_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $v['sent_count'], (int) $v['opened_count']); ?></td>
+                                    <td><?php echo (int) $v['bounced_count']; ?></td>
+                                    <td><?php echo format_ctr((int) $v['sent_count'], (int) $v['bounced_count']); ?></td>
                                     <td>
                                         <?php if ($isLeader): ?>
                                             <span class="hint" style="margin:0;">leader</span>
@@ -704,7 +744,7 @@ function ab_tests_tab_render_detail($pdo, $testId)
                 </div>
 
                 <div class="chart-card">
-                    <h3>Reply rate &amp; CTR by variant</h3>
+                    <h3>Engagement rates by variant</h3>
                     <div class="chart-wrap">
                         <canvas id="abCtrChart"></canvas>
                     </div>
@@ -720,27 +760,35 @@ function ab_tests_tab_render_detail($pdo, $testId)
 
         var ctrs = <?php echo json_encode($chartCtrs); ?>;
         var replies = <?php echo json_encode($chartReplies); ?>;
+        var opens = <?php echo json_encode($chartOpens); ?>;
+        var bounces = <?php echo json_encode($chartBounces); ?>;
         var clicks = <?php echo json_encode($chartClicks); ?>;
         var replyCounts = <?php echo json_encode($chartReplyCounts); ?>;
+        var openCounts = <?php echo json_encode($chartOpenCounts); ?>;
+        var bounceCounts = <?php echo json_encode($chartBounceCounts); ?>;
         var sent = <?php echo json_encode($chartSent); ?>;
         var leaderIdx = <?php echo $leaderIdx === null ? '-1' : (int) $leaderIdx; ?>;
         var scoringMetric = <?php echo json_encode($scoringMetric); ?>;
 
-        // Highlight the leader bar in green for whichever metric is currently
-        // driving promotion. The other metric uses a neutral palette.
+        // Highlight the leader bar in green only on the metric that is
+        // currently driving promotion (reply rate when any replies exist,
+        // otherwise CTR). Open rate / bounce rate are diagnostic — bars use
+        // a uniform color so they don't compete with the leader signal.
         function leaderColors(arr, color) {
             return arr.map(function(_, i) { return i === leaderIdx ? '#22c55e' : color; });
         }
 
+        var replyDs   = { label: 'Reply rate %',  data: replies, backgroundColor: scoringMetric === 'reply_rate' ? leaderColors(replies, '#3b82f6') : '#94a3b8', borderRadius: 4 };
+        var ctrDs     = { label: 'CTR %',         data: ctrs,    backgroundColor: scoringMetric === 'ctr'        ? leaderColors(ctrs,    '#3b82f6') : '#94a3b8', borderRadius: 4 };
+        var openDs    = { label: 'Open rate %',   data: opens,   backgroundColor: '#f59e0b', borderRadius: 4 };
+        var bounceDs  = { label: 'Bounce rate %', data: bounces, backgroundColor: '#ef4444', borderRadius: 4 };
+
+        // Order: scoring metric first (leader-highlighted), other primary
+        // metric next, then opens, then bounces — left-to-right roughly
+        // tracks importance for choosing a winner.
         var datasets = scoringMetric === 'reply_rate'
-            ? [
-                { label: 'Reply rate %', data: replies, backgroundColor: leaderColors(replies, '#3b82f6'), borderRadius: 4 },
-                { label: 'CTR %',        data: ctrs,    backgroundColor: leaderColors(ctrs,    '#94a3b8'), borderRadius: 4 }
-              ]
-            : [
-                { label: 'CTR %',        data: ctrs,    backgroundColor: leaderColors(ctrs,    '#3b82f6'), borderRadius: 4 },
-                { label: 'Reply rate %', data: replies, backgroundColor: leaderColors(replies, '#94a3b8'), borderRadius: 4 }
-              ];
+            ? [replyDs, ctrDs, openDs, bounceDs]
+            : [ctrDs, replyDs, openDs, bounceDs];
 
         new Chart(el.getContext('2d'), {
             type: 'bar',
@@ -757,10 +805,12 @@ function ab_tests_tab_render_detail($pdo, $testId)
                         callbacks: {
                             label: function(ctx) {
                                 var i = ctx.dataIndex;
-                                if (ctx.dataset.label === 'Reply rate %') {
-                                    return 'Reply rate: ' + replies[i].toFixed(1) + '% (' + replyCounts[i] + ' replies of ' + sent[i] + ' sent)';
-                                }
-                                return 'CTR: ' + ctrs[i].toFixed(1) + '% (' + clicks[i] + ' clicks of ' + sent[i] + ' sent)';
+                                var label = ctx.dataset.label;
+                                if (label === 'Reply rate %')  return 'Reply rate: '  + replies[i].toFixed(1) + '% (' + replyCounts[i]  + ' replies of '  + sent[i] + ' sent)';
+                                if (label === 'CTR %')         return 'CTR: '         + ctrs[i].toFixed(1)    + '% (' + clicks[i]       + ' clicks of '   + sent[i] + ' sent)';
+                                if (label === 'Open rate %')   return 'Open rate: '   + opens[i].toFixed(1)   + '% (' + openCounts[i]   + ' opens of '    + sent[i] + ' sent)';
+                                if (label === 'Bounce rate %') return 'Bounce rate: ' + bounces[i].toFixed(1) + '% (' + bounceCounts[i] + ' bounces of '  + sent[i] + ' sent)';
+                                return label + ': ' + ctx.parsed.y.toFixed(1) + '%';
                             }
                         }
                     }

--- a/cron/lib/ab_helpers.php
+++ b/cron/lib/ab_helpers.php
@@ -57,9 +57,16 @@ function format_ctr($sent, $clicks)
 }
 
 /**
- * Pull sends/clicks/replies/assigned counts for every variant of a test.
- * Returns each variant row augmented with 'assigned_count', 'sent_count',
- * 'clicked_count', 'replied_count', 'ctr', 'reply_rate'.
+ * Pull sends/clicks/opens/bounces/replies/assigned counts for every variant
+ * of a test. Returns each variant row augmented with 'assigned_count',
+ * 'sent_count', 'clicked_count', 'opened_count', 'bounced_count',
+ * 'replied_count', 'ctr', 'open_rate', 'bounce_rate', 'reply_rate'.
+ *
+ * 'opened_count' / 'bounced_count' come from outreach_email_events
+ * (populated by webhooks/resend.php) and count DISTINCT leads, so a single
+ * lead opening multiple times is one open. They will be zero for any test
+ * that ran before the Resend webhook was wired up, since events are only
+ * recorded going forward.
  *
  * 'replied_count' counts leads whose status indicates a positive human
  * response (replied / interested / onboarded). 'not_interested' is excluded
@@ -79,6 +86,16 @@ function load_variants_with_stats($pdo, $testId)
                 JOIN referral_visits rv
                   ON rv.source_code = CONCAT('outreach-', ol.id, '-v', v.id)
                 WHERE ol.ab_variant_id = v.id) AS clicked_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN outreach_email_events e
+                  ON e.lead_id = ol.id AND e.event_type = 'opened'
+                WHERE ol.ab_variant_id = v.id) AS opened_count,
+            (SELECT COUNT(DISTINCT ol.id)
+                FROM outreach_leads ol
+                JOIN outreach_email_events e
+                  ON e.lead_id = ol.id AND e.event_type = 'bounced'
+                WHERE ol.ab_variant_id = v.id) AS bounced_count,
             (SELECT COUNT(*) FROM outreach_leads ol
                 WHERE ol.ab_variant_id = v.id
                   AND ol.status IN ('replied','interested','onboarded')) AS replied_count
@@ -92,8 +109,12 @@ function load_variants_with_stats($pdo, $testId)
         $v['assigned_count'] = (int) $v['assigned_count'];
         $v['sent_count']     = (int) $v['sent_count'];
         $v['clicked_count']  = (int) $v['clicked_count'];
+        $v['opened_count']   = (int) $v['opened_count'];
+        $v['bounced_count']  = (int) $v['bounced_count'];
         $v['replied_count']  = (int) $v['replied_count'];
         $v['ctr']            = $v['sent_count'] > 0 ? $v['clicked_count'] / $v['sent_count'] : 0.0;
+        $v['open_rate']      = $v['sent_count'] > 0 ? $v['opened_count']  / $v['sent_count'] : 0.0;
+        $v['bounce_rate']    = $v['sent_count'] > 0 ? $v['bounced_count'] / $v['sent_count'] : 0.0;
         $v['reply_rate']     = $v['sent_count'] > 0 ? $v['replied_count'] / $v['sent_count'] : 0.0;
     }
     return $rows;

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -394,7 +394,7 @@ function send_outreach_lead($pdo, $lead, &$reason = null)
         // a transient failure) won't overwrite the original Message-ID or
         // push out the follow-up schedule.
         $stmt = $pdo->prepare("UPDATE outreach_leads SET
-            status = CASE WHEN status NOT IN ('replied','interested','not_interested','onboarded') THEN 'contacted' ELSE status END,
+            status = CASE WHEN status NOT IN ('replied','interested','not_interested','onboarded','email_bounced') THEN 'contacted' ELSE status END,
             first_contact_date = COALESCE(first_contact_date, NOW()),
             last_contact_date = NOW(),
             original_message_id = COALESCE(original_message_id, ?),

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -582,7 +582,7 @@ function stepGenerateDrafts($pdo, $dryRun)
         WHERE email IS NOT NULL AND email != ''
           AND (draft_subject IS NULL OR draft_subject = '')
           AND sent_at IS NULL
-          AND status NOT IN ('contacted', 'replied', 'interested', 'not_interested', 'onboarded')
+          AND status NOT IN ('contacted', 'replied', 'interested', 'not_interested', 'onboarded', 'email_bounced')
         ORDER BY date_added ASC
         LIMIT ?
     ");

--- a/cron/reply_checker.php
+++ b/cron/reply_checker.php
@@ -81,7 +81,7 @@ try {
     $updateStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'replied' WHERE id = ? AND status = 'contacted'");
     $suppressStmt = $pdo->prepare("INSERT IGNORE INTO email_suppressions (email, context, reason, source_id) VALUES (?, 'outreach', ?, ?)");
     $leadByEmailStmt = $pdo->prepare("SELECT id FROM outreach_leads WHERE LOWER(email) = ? ORDER BY sent_at DESC, id DESC LIMIT 1");
-    $markNotInterestedStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'not_interested' WHERE id = ? AND status NOT IN ('replied','interested','not_interested','onboarded')");
+    $markNotInterestedStmt = $pdo->prepare("UPDATE outreach_leads SET status = 'not_interested' WHERE id = ? AND status NOT IN ('replied','interested','not_interested','onboarded','email_bounced')");
 
     foreach ($messages as $msg) {
         if (empty($msg['sender_email'])) continue;

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -546,7 +546,7 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
     category VARCHAR(100) DEFAULT NULL,
     city VARCHAR(100) DEFAULT NULL,
     source VARCHAR(100) DEFAULT 'manual',
-    status ENUM('new','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded') DEFAULT 'new',
+    status ENUM('new','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded','email_bounced') DEFAULT 'new',
     response_status ENUM('no_response','positive','neutral','negative') DEFAULT 'no_response',
     approval_status ENUM('not_drafted','draft_ready','needs_review','approved','sent') DEFAULT 'not_drafted',
     date_added DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -590,6 +590,11 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
 --     ADD INDEX idx_outreach_ab_variant (ab_variant_id);
 -- (Existing installs that already added idx_outreach_ab need only:
 --   ALTER TABLE outreach_leads ADD INDEX idx_outreach_ab_variant (ab_variant_id);)
+--
+-- Existing installs also need 'email_bounced' added to the status ENUM
+-- so the Resend webhook can flag bounced/complained recipients:
+--   ALTER TABLE outreach_leads
+--     MODIFY COLUMN status ENUM('new','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded','email_bounced') DEFAULT 'new';
 
 -- Email suppression list (unsubscribes, opt-outs across all email contexts)
 CREATE TABLE IF NOT EXISTS email_suppressions (
@@ -612,6 +617,23 @@ CREATE TABLE IF NOT EXISTS outreach_activity_log (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (lead_id) REFERENCES outreach_leads(id) ON DELETE CASCADE,
     INDEX idx_outreach_activity_lead (lead_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Per-event delivery / engagement records from the Resend webhook
+-- (webhooks/resend.php). One row per (message_id, event_type); the unique key
+-- gives idempotency on Svix retries.
+CREATE TABLE IF NOT EXISTS outreach_email_events (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    lead_id INT NOT NULL,
+    event_type VARCHAR(40) NOT NULL,
+    message_id VARCHAR(255) DEFAULT NULL,
+    occurred_at DATETIME NOT NULL,
+    raw_payload TEXT DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (lead_id) REFERENCES outreach_leads(id) ON DELETE CASCADE,
+    UNIQUE KEY unique_message_event (message_id, event_type),
+    INDEX idx_email_events_lead_type (lead_id, event_type),
+    INDEX idx_email_events_occurred (occurred_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- A/B tests for outreach email variants. variant_type covers every test type

--- a/webhooks/resend.php
+++ b/webhooks/resend.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Resend Webhook Handler
+ *
+ * Receives delivery / engagement events from Resend (delivered, opened, clicked,
+ * bounced, complained, failed, delivery_delayed) and stores them in
+ * outreach_email_events. Permanent bounces and spam complaints additionally
+ * flip the lead's status to email_bounced and add the address to
+ * email_suppressions so we never re-send to it.
+ *
+ * Configure in Resend dashboard:
+ *   - URL: https://argorobots.com/webhooks/resend.php
+ *   - Events: email.delivered, email.bounced, email.complained, email.opened,
+ *             email.clicked, email.failed, email.delivery_delayed
+ *   - Copy the signing secret (whsec_...) into RESEND_WEBHOOK_SECRET in .env
+ *
+ * Resend uses Svix for delivery, so signature verification is the standard
+ * Svix scheme: HMAC-SHA256(secret, "{svix-id}.{svix-timestamp}.{body}").
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->load();
+
+require_once __DIR__ . '/../db_connect.php';
+
+// Only accept POST.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Method not allowed');
+}
+
+$rawBody = file_get_contents('php://input');
+if ($rawBody === '' || $rawBody === false) {
+    http_response_code(400);
+    exit('Empty body');
+}
+
+$svixId        = $_SERVER['HTTP_SVIX_ID']        ?? '';
+$svixTimestamp = $_SERVER['HTTP_SVIX_TIMESTAMP'] ?? '';
+$svixSignature = $_SERVER['HTTP_SVIX_SIGNATURE'] ?? '';
+
+if ($svixId === '' || $svixTimestamp === '' || $svixSignature === '') {
+    http_response_code(400);
+    exit('Missing Svix headers');
+}
+
+$secret = $_ENV['RESEND_WEBHOOK_SECRET'] ?? '';
+if ($secret === '') {
+    error_log('Resend webhook: RESEND_WEBHOOK_SECRET is not set; rejecting all requests.');
+    http_response_code(500);
+    exit('Webhook secret not configured');
+}
+
+if (!verify_svix_signature($rawBody, $svixId, $svixTimestamp, $svixSignature, $secret)) {
+    http_response_code(401);
+    exit('Invalid signature');
+}
+
+$event = json_decode($rawBody, true);
+if (!is_array($event) || !isset($event['type'], $event['data']) || !is_array($event['data'])) {
+    http_response_code(400);
+    exit('Malformed payload');
+}
+
+$eventType = (string) $event['type'];
+$data      = $event['data'];
+
+$resendEmailId = isset($data['email_id']) ? (string) $data['email_id'] : null;
+$recipients    = isset($data['to']) && is_array($data['to']) ? $data['to'] : [];
+$primaryTo     = '';
+foreach ($recipients as $r) {
+    $candidate = strtolower(trim((string) $r));
+    if ($candidate !== '' && filter_var($candidate, FILTER_VALIDATE_EMAIL)) {
+        $primaryTo = $candidate;
+        break;
+    }
+}
+
+// Strip the "email." prefix so the stored event_type matches our short keys
+// (delivered, bounced, opened, clicked, complained, failed, delivery_delayed).
+$shortType = (strpos($eventType, 'email.') === 0)
+    ? substr($eventType, strlen('email.'))
+    : $eventType;
+
+$occurredAt = isset($event['created_at']) ? (string) $event['created_at'] : '';
+$occurredAtSql = $occurredAt !== '' ? format_iso8601_for_mysql($occurredAt) : date('Y-m-d H:i:s');
+
+// Match the event back to an outreach lead by recipient address. We send each
+// lead at most once, so the most recent contacted lead with a matching email
+// is the right target. If no match, this is almost certainly a non-outreach
+// email sent through the same Resend account (premium receipts, etc.) — we
+// 200 OK silently so Resend doesn't retry, but we don't store the event.
+$leadId = null;
+if ($primaryTo !== '') {
+    try {
+        $stmt = $pdo->prepare("SELECT id FROM outreach_leads
+            WHERE LOWER(email) = ?
+              AND sent_at IS NOT NULL
+              AND sent_at > DATE_SUB(NOW(), INTERVAL 60 DAY)
+            ORDER BY sent_at DESC
+            LIMIT 1");
+        $stmt->execute([$primaryTo]);
+        $row = $stmt->fetch();
+        if ($row && isset($row['id'])) {
+            $leadId = (int) $row['id'];
+        }
+    } catch (PDOException $e) {
+        error_log('Resend webhook: lead lookup failed: ' . $e->getMessage());
+    }
+}
+
+if ($leadId === null) {
+    // Not an outreach email (or send is older than 60d). Acknowledge so
+    // Resend doesn't keep retrying.
+    http_response_code(200);
+    echo '{}';
+    exit;
+}
+
+// Insert the event row. The (message_id, event_type) UNIQUE key gives us
+// idempotency on retries.
+try {
+    $insStmt = $pdo->prepare("INSERT INTO outreach_email_events
+        (lead_id, event_type, message_id, occurred_at, raw_payload)
+        VALUES (?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE id = id");
+    $insStmt->execute([
+        $leadId,
+        $shortType,
+        $resendEmailId,
+        $occurredAtSql,
+        json_encode($event, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+    ]);
+} catch (PDOException $e) {
+    error_log('Resend webhook: event insert failed: ' . $e->getMessage());
+    http_response_code(500);
+    exit('DB error');
+}
+
+// Side effects for terminal-bad events. Permanent bounce and spam complaint
+// both mean we should never re-send to this address. Temporary bounces (soft)
+// are recorded but don't suppress.
+$shouldSuppress = false;
+$suppressReason = null;
+if ($shortType === 'bounced') {
+    $bounceType = isset($data['bounce']['type']) ? strtolower((string) $data['bounce']['type']) : '';
+    if ($bounceType === 'permanent') {
+        $shouldSuppress = true;
+        $bounceMsg = isset($data['bounce']['message']) ? (string) $data['bounce']['message'] : '';
+        $suppressReason = 'hard_bounce: ' . mb_substr($bounceMsg, 0, 200);
+    }
+} elseif ($shortType === 'complained') {
+    $shouldSuppress = true;
+    $suppressReason = 'spam_complaint';
+}
+
+if ($shouldSuppress && $primaryTo !== '') {
+    try {
+        $pdo->prepare("UPDATE outreach_leads SET status = 'email_bounced'
+            WHERE id = ? AND status NOT IN ('replied','interested','onboarded')")
+            ->execute([$leadId]);
+
+        $supStmt = $pdo->prepare("INSERT INTO email_suppressions (email, context, reason, source_id, suppressed_at)
+            VALUES (?, 'outreach', ?, ?, NOW())
+            ON DUPLICATE KEY UPDATE reason = VALUES(reason), suppressed_at = VALUES(suppressed_at)");
+        $supStmt->execute([$primaryTo, $suppressReason, $leadId]);
+
+        $logStmt = $pdo->prepare("INSERT INTO outreach_activity_log (lead_id, action_type, details)
+            VALUES (?, 'email_suppressed', ?)");
+        $logStmt->execute([$leadId, $suppressReason]);
+    } catch (PDOException $e) {
+        error_log('Resend webhook: suppression update failed: ' . $e->getMessage());
+        // Don't fail the webhook on side-effect errors — the event row is
+        // already saved and a future job can reconcile.
+    }
+}
+
+http_response_code(200);
+echo '{}';
+
+/**
+ * Verify a Svix-signed webhook request (Resend uses Svix). Returns true when
+ * the signature header contains at least one valid HMAC-SHA256 signature over
+ * "{svix-id}.{svix-timestamp}.{body}", and the timestamp is within ±5 minutes
+ * of now.
+ *
+ * The secret is the `whsec_<base64>` string from the Resend dashboard.
+ */
+function verify_svix_signature($body, $svixId, $svixTimestamp, $svixSignatureHeader, $secret)
+{
+    // Reject replayed events outside the 5-minute window.
+    $ts = (int) $svixTimestamp;
+    if ($ts <= 0 || abs(time() - $ts) > 300) {
+        return false;
+    }
+
+    if (strpos($secret, 'whsec_') !== 0) {
+        return false;
+    }
+    $secretBytes = base64_decode(substr($secret, strlen('whsec_')), true);
+    if ($secretBytes === false || $secretBytes === '') {
+        return false;
+    }
+
+    $signedPayload = $svixId . '.' . $svixTimestamp . '.' . $body;
+    $expectedSig = base64_encode(hash_hmac('sha256', $signedPayload, $secretBytes, true));
+
+    // Header format is space-separated "v1,<base64sig>" entries; multiple
+    // signatures may appear during secret rotation.
+    foreach (explode(' ', $svixSignatureHeader) as $entry) {
+        $parts = explode(',', $entry, 2);
+        if (count($parts) !== 2) continue;
+        if ($parts[0] !== 'v1') continue;
+        if (hash_equals($expectedSig, $parts[1])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Convert an ISO 8601 timestamp (with or without fractional seconds) to MySQL
+ * DATETIME format in UTC. Returns the current UTC time if parsing fails.
+ */
+function format_iso8601_for_mysql($iso)
+{
+    try {
+        $dt = new DateTimeImmutable($iso);
+        $dt = $dt->setTimezone(new DateTimeZone('UTC'));
+        return $dt->format('Y-m-d H:i:s');
+    } catch (Exception $e) {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/webhooks/resend.php
+++ b/webhooks/resend.php
@@ -24,6 +24,15 @@ $dotenv->load();
 
 require_once __DIR__ . '/../db_connect.php';
 
+// db_connect.php sets $pdo = null on PDOException. Without this guard the
+// later $pdo->prepare(...) would throw a PHP Error (not PDOException), bypass
+// our catches, and fall back to an unhandled 500. Tell Resend to retry instead.
+if (!($pdo instanceof PDO)) {
+    error_log('Resend webhook: $pdo is not available (db_connect failed).');
+    http_response_code(500);
+    exit('DB unavailable');
+}
+
 // Only accept POST.
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -67,6 +76,20 @@ $eventType = (string) $event['type'];
 $data      = $event['data'];
 
 $resendEmailId = isset($data['email_id']) ? (string) $data['email_id'] : null;
+
+// Resend always includes email_id on the email.* events we subscribe to.
+// If it's missing, the event is malformed (or a non-email event we don't
+// store). We can't dedupe without it — the (message_id, event_type) UNIQUE
+// key treats NULLs as distinct, so a NULL message_id would let retries
+// accumulate duplicate rows. 200 OK so Resend stops retrying, but skip the
+// insert. Defense-in-depth — should never fire in normal Resend traffic.
+if ($resendEmailId === null || $resendEmailId === '') {
+    error_log('Resend webhook: event missing email_id; skipping insert.');
+    http_response_code(200);
+    echo '{}';
+    exit;
+}
+
 $recipients    = isset($data['to']) && is_array($data['to']) ? $data['to'] : [];
 $primaryTo     = '';
 foreach ($recipients as $r) {
@@ -84,7 +107,9 @@ $shortType = (strpos($eventType, 'email.') === 0)
     : $eventType;
 
 $occurredAt = isset($event['created_at']) ? (string) $event['created_at'] : '';
-$occurredAtSql = $occurredAt !== '' ? format_iso8601_for_mysql($occurredAt) : date('Y-m-d H:i:s');
+// Use gmdate (UTC) for the fallback so occurred_at is always UTC — matches
+// what format_iso8601_for_mysql() does when created_at is present.
+$occurredAtSql = $occurredAt !== '' ? format_iso8601_for_mysql($occurredAt) : gmdate('Y-m-d H:i:s');
 
 // Match the event back to an outreach lead by recipient address. We send each
 // lead at most once, so the most recent contacted lead with a matching email


### PR DESCRIPTION
## Summary

- Wire up the previously-orphaned `webhooks/resend.php` so Resend delivery / engagement events actually land in the database. Adds the missing `outreach_email_events` table, adds `'email_bounced'` to the `outreach_leads.status` ENUM, and updates three NOT IN status filters so bounced leads stop pulling new drafts on the next pipeline cycle.
- Surface the new event stream in the A/B testing admin: per-variant **opens / open rate / bounces / bounce rate** columns on both the list and detail tables, two new **Leads Opened / Leads Bounced** stat cards on the list page, and the detail bar chart now plots all four engagement rates (leader-highlight kept on whichever metric is currently driving promotion).

## Server steps

> :warning: This PR ships schema changes. After merging, run on the production DB:

```sql
ALTER TABLE outreach_leads
  MODIFY COLUMN status ENUM(
    'new','draft_generated','awaiting_approval','approved',
    'contacted','replied','interested','not_interested','onboarded',
    'email_bounced'
  ) DEFAULT 'new';

CREATE TABLE IF NOT EXISTS outreach_email_events (
    id BIGINT PRIMARY KEY AUTO_INCREMENT,
    lead_id INT NOT NULL,
    event_type VARCHAR(40) NOT NULL,
    message_id VARCHAR(255) DEFAULT NULL,
    occurred_at DATETIME NOT NULL,
    raw_payload TEXT DEFAULT NULL,
    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    FOREIGN KEY (lead_id) REFERENCES outreach_leads(id) ON DELETE CASCADE,
    UNIQUE KEY unique_message_event (message_id, event_type),
    INDEX idx_email_events_lead_type (lead_id, event_type),
    INDEX idx_email_events_occurred (occurred_at)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

Then in the **Resend dashboard**, register a webhook endpoint at `https://argorobots.com/webhooks/resend.php` subscribed to `email.delivered`, `email.bounced`, `email.complained`, `email.opened`, `email.clicked`, `email.failed`, `email.delivery_delayed`, copy the `whsec_...` signing secret, and paste it into the production `.env` as `RESEND_WEBHOOK_SECRET`.

## Test plan

- [ ] Run the SQL above on local DB, then load `/admin/outreach/?tab=ab-tests` and confirm the page renders without errors and shows the new Opens / Open rate / Bounces / Bounce rate columns and the two new stat cards.
- [ ] Open an existing test detail page and confirm the variant table shows the four new columns and the bar chart renders all four rate datasets with sensible tooltips.
- [ ] Set a local `RESEND_WEBHOOK_SECRET` and POST a synthetic Svix-signed `email.bounced` payload at `/webhooks/resend.php`; verify a row appears in `outreach_email_events`, the lead flips to `email_bounced`, and the address is added to `email_suppressions`.
- [ ] Re-run `cron/outreach_pipeline.php` and confirm a lead with `status='email_bounced'` is not picked up for re-drafting.
- [ ] Send an unsubscribe-classified message via `cron/reply_checker.php` against a bounced lead and verify the status is preserved (not downgraded to `not_interested`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)