### PR TITLE
Premium: PayPal billing cycle switching (Phase 2)

### DIFF
--- a/community/users/subscription.php
+++ b/community/users/subscription.php
@@ -194,7 +194,7 @@ if ($premium_subscription) {
                             // AJAX endpoint would reject them anyway.
                             $canSwitchCycle = in_array(
                                 strtolower($premium_subscription['payment_method'] ?? ''),
-                                ['stripe', 'square'],
+                                ['stripe', 'square', 'paypal'],
                                 true
                             );
                         ?>

--- a/community/users/switch-billing-cycle.php
+++ b/community/users/switch-billing-cycle.php
@@ -43,11 +43,23 @@ if (!empty($premium_subscription['last_cycle_change_at'])
 $payment_method = strtolower($premium_subscription['payment_method'] ?? '');
 $is_paypal = ($payment_method === 'paypal');
 
-// Only Stripe, Square, and PayPal (with the coming-soon notice) reach this page.
-// free_key, manual, or unknown payment methods can't switch cycles — the AJAX
-// endpoint rejects them, so don't render a confirm UI that would inevitably fail.
+// Only Stripe, Square, and PayPal reach this page. free_key, manual, or
+// unknown payment methods can't switch cycles — redirect rather than
+// render a confirm UI that would inevitably fail.
 if (!in_array($payment_method, ['stripe', 'square', 'paypal'], true)) {
     $redirect_with_error('Cycle switching is not available for this subscription type. Please contact support.');
+}
+
+// PayPal-specific eligibility: must have at least one completed sale to
+// refund against (otherwise PayPal hasn't billed yet — the user just
+// subscribed seconds ago and the webhook hasn't arrived). Block here
+// rather than later in the flow.
+if ($is_paypal) {
+    require_once __DIR__ . '/../../webhooks/paypal-helper.php';
+    $paypal_recent_sale = getMostRecentPayPalSale($premium_subscription['subscription_id']);
+    if (!$paypal_recent_sale) {
+        $redirect_with_error('Your subscription is still being activated by PayPal. Please wait a few minutes after subscribing before changing cycles.');
+    }
 }
 
 $pricing_config = get_pricing_config();
@@ -56,11 +68,25 @@ $yearly_base = $pricing_config['premium_yearly_price'];
 $old_cycle = $premium_subscription['billing_cycle'];
 $new_cycle = ($old_cycle === 'monthly') ? 'yearly' : 'monthly';
 
-// Compute proration server-side. Even though the page is read-only, we recompute
-// on the AJAX endpoint to prevent any client tampering with displayed values.
-$proration = $is_paypal
-    ? null
-    : calculate_cycle_switch_proration($premium_subscription, $new_cycle, $pricing_config);
+// Compute proration server-side. Even though the page is read-only, the
+// AJAX endpoint (Stripe/Square) and process-subscription.php (PayPal)
+// recompute to prevent any client tampering with displayed values.
+$proration = calculate_cycle_switch_proration($premium_subscription, $new_cycle, $pricing_config);
+
+// PayPal-only refund estimate (same math used by checkout disclosure banner)
+$paypal_refund_estimate = 0.0;
+if ($is_paypal && ($proration['direction'] ?? '') !== 'noop') {
+    $paypal_refund_estimate = round(
+        (float) $proration['prorated_credit']
+        + (float) ($premium_subscription['credit_balance'] ?? 0),
+        2
+    );
+    // Cap at the most recent sale's amount (PayPal won't refund more
+    // than the original sale).
+    if ($paypal_recent_sale && $paypal_refund_estimate > (float) $paypal_recent_sale['amount']) {
+        $paypal_refund_estimate = (float) $paypal_recent_sale['amount'];
+    }
+}
 
 // Stripe publishable key for 3DS handling (only loaded when needed)
 $is_production = ($_ENV['APP_ENV'] ?? 'development') === 'production';
@@ -182,29 +208,84 @@ $is_upgrade = ($new_cycle === 'yearly');
                 <?= svg_icon('refresh', 48) ?>
             </div>
 
-            <?php if ($is_paypal): ?>
+            <?php if ($is_paypal):
+                // PayPal flow: show the breakdown with refund-style copy,
+                // then send the user to checkout where they'll approve a
+                // new PayPal subscription with the new plan_id.
+                $new_billed_base = ($new_cycle === 'yearly') ? $yearly_base : $monthly_base;
+                $new_billed_fee = function_exists('calculate_processing_fee') ? calculate_processing_fee($new_billed_base) : 0.0;
+                $new_billed_total = round($new_billed_base + $new_billed_fee, 2);
+                $existing_credit_used = (float) ($premium_subscription['credit_balance'] ?? 0);
+                $next_billing_date = date('F j, Y', strtotime(($new_cycle === 'yearly') ? '+1 year' : '+1 month'));
+            ?>
 
-                <h1>Cycle Switching for PayPal — Coming Soon</h1>
+                <h1>Switch to <?= htmlspecialchars(ucfirst($new_cycle)) ?> Billing?</h1>
 
                 <p class="confirm-description">
-                    Switching billing cycles for PayPal subscriptions is not yet available.
-                    To change your billing cycle, you can cancel your current subscription
-                    and resubscribe via the new cycle.
+                    You'll be redirected to PayPal to approve a new <?= htmlspecialchars($new_cycle) ?>
+                    subscription. PayPal will bill the new amount on activation, and the prorated
+                    value of your unused <?= htmlspecialchars($old_cycle) ?> period
+                    <?php if ($existing_credit_used > 0): ?>(plus your existing account credit) <?php endif; ?>will
+                    be refunded to your PayPal account within 5–10 business days.
                 </p>
 
-                <div class="info-box warning-box">
-                    <h3>Note</h3>
-                    <ul>
-                        <li>Cancelling your subscription will forfeit any account credit balance.</li>
-                        <li>Premium access continues until the end of your current billing period.</li>
-                        <li>If this affects you, please contact support before cancelling.</li>
-                    </ul>
+                <div class="proration-breakdown">
+                    <h3>Charge & Refund Breakdown</h3>
+
+                    <div class="proration-line">
+                        <span class="label">New <?= htmlspecialchars($new_cycle) ?> subscription</span>
+                        <span class="value">$<?= number_format($new_billed_base, 2) ?> CAD</span>
+                    </div>
+
+                    <?php if ($new_billed_fee > 0): ?>
+                    <div class="proration-line">
+                        <span class="label">Processing fee</span>
+                        <span class="value">$<?= number_format($new_billed_fee, 2) ?> CAD</span>
+                    </div>
+                    <?php endif; ?>
+
+                    <div class="proration-divider"></div>
+
+                    <div class="proration-total">
+                        <span>Charged today by PayPal</span>
+                        <span>$<?= number_format($new_billed_total, 2) ?> CAD</span>
+                    </div>
+
+                    <?php if ($paypal_refund_estimate > 0): ?>
+                        <div class="proration-divider"></div>
+
+                        <div class="proration-line discount">
+                            <span class="label">Prorated refund (5–10 business days)</span>
+                            <span class="value">-$<?= number_format($paypal_refund_estimate, 2) ?> CAD</span>
+                        </div>
+
+                        <?php if ($proration['prorated_credit'] > 0): ?>
+                        <div class="proration-line" style="font-size:13px; color:var(--gray-600); padding-left:12px;">
+                            <span class="label">— Unused <?= htmlspecialchars($old_cycle) ?> period</span>
+                            <span class="value">$<?= number_format($proration['prorated_credit'], 2) ?> CAD</span>
+                        </div>
+                        <?php endif; ?>
+
+                        <?php if ($existing_credit_used > 0): ?>
+                        <div class="proration-line" style="font-size:13px; color:var(--gray-600); padding-left:12px;">
+                            <span class="label">— Existing account credit</span>
+                            <span class="value">$<?= number_format($existing_credit_used, 2) ?> CAD</span>
+                        </div>
+                        <?php endif; ?>
+                    <?php endif; ?>
+
+                    <div class="proration-divider"></div>
+
+                    <div class="proration-footer-line">
+                        <span>Next billing date</span>
+                        <span><?= htmlspecialchars($next_billing_date) ?></span>
+                    </div>
                 </div>
 
                 <div class="confirm-actions">
-                    <a href="cancel-subscription.php" class="btn btn-outline-red">Cancel Subscription</a>
-                    <a href="../../contact-us/" class="btn btn-outline">Contact Support</a>
-                    <a href="subscription.php" class="btn btn-outline">Go Back</a>
+                    <a href="../../pricing/premium/checkout/?method=paypal&billing=<?= urlencode($new_cycle) ?>&change_method=1&cycle_switch=1"
+                       class="btn btn-purple">Continue with PayPal →</a>
+                    <a href="subscription.php" class="btn btn-outline">Cancel</a>
                 </div>
 
             <?php else:

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -363,6 +363,27 @@ try {
     logMessage("Error marking expired subscriptions: " . $e->getMessage(), 'ERROR');
 }
 
+// Cleanup: clear stale previous_paypal_subscription_id values from PayPal
+// cycle switches that happened more than 7 days ago. The column exists only
+// to let the cancel webhook recognize an expected cancel event for the
+// pre-switch subscription; once that event has had a week to arrive, we no
+// longer need the back-reference.
+try {
+    $stmt = $pdo->prepare("
+        UPDATE premium_subscriptions
+        SET previous_paypal_subscription_id = NULL
+        WHERE previous_paypal_subscription_id IS NOT NULL
+          AND updated_at < NOW() - INTERVAL 7 DAY
+    ");
+    $stmt->execute();
+    $cleared = $stmt->rowCount();
+    if ($cleared > 0) {
+        logMessage("Cleared previous_paypal_subscription_id on $cleared row(s)");
+    }
+} catch (PDOException $e) {
+    logMessage("Error clearing previous_paypal_subscription_id: " . $e->getMessage(), 'ERROR');
+}
+
 /**
  * Process Stripe renewal payment
  */

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -368,12 +368,17 @@ try {
 // to let the cancel webhook recognize an expected cancel event for the
 // pre-switch subscription; once that event has had a week to arrive, we no
 // longer need the back-reference.
+//
+// Cutoff is keyed on last_cycle_change_at, NOT updated_at — updated_at gets
+// auto-bumped by every renewal/admin edit (ON UPDATE CURRENT_TIMESTAMP), so
+// for monthly subs it would never reach the 7-day threshold.
 try {
     $stmt = $pdo->prepare("
         UPDATE premium_subscriptions
         SET previous_paypal_subscription_id = NULL
         WHERE previous_paypal_subscription_id IS NOT NULL
-          AND updated_at < NOW() - INTERVAL 7 DAY
+          AND last_cycle_change_at IS NOT NULL
+          AND last_cycle_change_at < NOW() - INTERVAL 7 DAY
     ");
     $stmt->execute();
     $cleared = $stmt->rowCount();

--- a/email_sender.php
+++ b/email_sender.php
@@ -917,6 +917,8 @@ function send_premium_subscription_reactivated_email($email, $subscriptionId, $e
  * @param string $newEndDate           New end_date (Y-m-d H:i:s)
  * @param float  $creditBalanceAfter   Remaining credit_balance after the switch
  * @param float  $monthlyBase          Monthly base price (for "covers N months" hint)
+ * @param float  $refundAmount         PayPal-only: prorated refund issued to the user's PayPal account (0 for Stripe/Square)
+ * @param string|null $refundProvider  PayPal-only: name of the refund provider rendered in the breakdown row (e.g. 'PayPal')
  * @return bool  Success status
  */
 function send_premium_subscription_cycle_changed_email(

--- a/email_sender.php
+++ b/email_sender.php
@@ -929,7 +929,9 @@ function send_premium_subscription_cycle_changed_email(
     $immediateCharge,
     $newEndDate,
     $creditBalanceAfter,
-    $monthlyBase
+    $monthlyBase,
+    $refundAmount = 0.0,
+    $refundProvider = null
 ) {
     $site_url        = site_url();
     $oldCycleLabel   = ucfirst($oldCycle);
@@ -967,6 +969,14 @@ function send_premium_subscription_cycle_changed_email(
             : '';
         $rows .= '<tr><td class="label">Remaining credit balance</td>'
               . '<td class="value">$' . number_format($creditBalanceAfter, 2) . ' CAD' . $monthsHint . '</td></tr>';
+    }
+
+    // PayPal-only: prorated refund line. Refund processes asynchronously
+    // and shows up in the user's PayPal account within 5–10 business days.
+    if ($refundAmount > 0) {
+        $providerLabel = $refundProvider ? ' via ' . htmlspecialchars($refundProvider) : '';
+        $rows .= '<tr><td class="label">Prorated refund (5–10 business days)</td>'
+              . '<td class="value">$' . number_format($refundAmount, 2) . ' CAD' . $providerLabel . '</td></tr>';
     }
 
     $rows .= '<tr><td class="label">Next billing date</td>'

--- a/legal/refund.php
+++ b/legal/refund.php
@@ -86,7 +86,7 @@
                 <li><strong>Upgrade (monthly to yearly)</strong>: You are charged the yearly amount immediately, less the prorated value of your current unused monthly period and any existing account credit. The new yearly billing period begins on the date of upgrade.</li>
                 <li><strong>Downgrade (yearly to monthly)</strong>: The prorated value of your unused yearly subscription is applied to reduce or fully cover the first new monthly charge. If the prorated value exceeds one month, the leftover remains as account credit and is automatically applied to future monthly renewals until depleted. No cash refund is issued.</li>
                 <li><strong>Account credit</strong>: Account credit is non-refundable, has no cash value, and cannot be transferred. It is forfeited if you cancel your subscription. Account credit is consumed automatically by future renewal charges and does not expire while your subscription remains active.</li>
-                <li><strong>Plan changes for PayPal subscribers</strong>: At this time, plan changes are available for subscriptions paid via Stripe and Square only. PayPal subscribers who wish to change plans should contact support.</li>
+                <li><strong>Plan changes for PayPal subscribers</strong>: The new subscription is billed by PayPal on activation, and the prorated value of your unused old period (plus any account credit) is refunded to your PayPal account within 5&ndash;10 business days.</li>
             </ul>
 
             <h2>How to Request a Refund</h2>

--- a/legal/terms.php
+++ b/legal/terms.php
@@ -136,7 +136,7 @@
                 <li><strong>Plan Changes (Upgrade)</strong>: When upgrading from monthly to yearly billing, you will be charged the yearly amount immediately, less the prorated value of your current unused billing period and any existing account credit. The new yearly billing period begins on the date of upgrade.</li>
                 <li><strong>Plan Changes (Downgrade)</strong>: When downgrading from yearly to monthly billing, the prorated value of your unused yearly subscription is applied to reduce or fully cover the first new monthly charge. Any leftover value remains as account credit and is automatically applied to future monthly renewals until depleted.</li>
                 <li><strong>Account Credit</strong>: Account credit is non-refundable, has no cash value, and is forfeited upon cancellation. Credit is consumed automatically by future renewal charges and does not expire while your subscription remains active.</li>
-                <li><strong>Payment Methods</strong>: We accept payments via Stripe, PayPal, and Square. Plan changes are currently available for subscriptions paid via Stripe and Square; PayPal subscribers should contact support to change billing cycles.</li>
+                <li><strong>Payment Methods</strong>: We accept payments via Stripe, PayPal, and Square. PayPal plan changes are refunded to your PayPal account; Stripe and Square plan changes apply credits or partial charges directly.</li>
                 <li><strong>Usage Limits</strong>: AI Receipt Scanning is limited to 500 scans per month.</li>
             </ul>
             <p>We reserve the right to modify subscription pricing with 30 days notice to existing subscribers.</p>

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -297,6 +297,7 @@ CREATE TABLE IF NOT EXISTS premium_subscriptions (
     stripe_customer_id VARCHAR(255) COMMENT 'Stripe customer ID for recurring billing',
     auto_renew TINYINT(1) DEFAULT 1 COMMENT 'Whether to auto-renew the subscription',
     paypal_subscription_id VARCHAR(100) COMMENT 'PayPal subscription ID for recurring billing',
+    previous_paypal_subscription_id VARCHAR(100) DEFAULT NULL COMMENT 'Old PayPal sub-id during in-flight cycle switch; cancel webhook for this ID is ignored',
     discount_applied TINYINT(1) DEFAULT 0,
     credit_balance DECIMAL(10,2) DEFAULT 0 COMMENT 'Remaining credit balance from premium discount',
     original_credit DECIMAL(10,2) DEFAULT 0 COMMENT 'Original credit amount (to track if credit was used)',

--- a/pricing/premium/checkout/index.php
+++ b/pricing/premium/checkout/index.php
@@ -27,6 +27,7 @@
     // Check if user already has an active subscription
     $existing_subscription = get_user_premium_subscription($user_id);
     $is_changing_method = isset($_GET['change_method']) && $_GET['change_method'] === '1';
+    $is_cycle_switch = isset($_GET['cycle_switch']) && $_GET['cycle_switch'] === '1';
 
     if ($existing_subscription && in_array($existing_subscription['status'], ['active', 'cancelled', 'payment_failed'])) {
         // User already has a subscription
@@ -95,6 +96,23 @@
     $renewalBase = ($billing === 'yearly') ? $yearlyPrice : $monthlyPrice;
     $renewalFee = calculate_processing_fee($renewalBase);
     $renewalTotal = $renewalBase + $renewalFee;
+
+    // Cycle-switch refund estimate for the disclosure banner
+    $cycleSwitchRefundEstimate = 0.0;
+    $cycleSwitchOldCycle = '';
+    if ($is_cycle_switch && $existing_subscription
+        && strtolower($existing_subscription['payment_method'] ?? '') === 'paypal') {
+        require_once __DIR__ . '/../../../community/users/user_functions.php';
+        $cycleSwitchOldCycle = $existing_subscription['billing_cycle'] ?? '';
+        $cycleSwitchProration = calculate_cycle_switch_proration($existing_subscription, $billing, $pricing);
+        if (($cycleSwitchProration['direction'] ?? '') !== 'noop') {
+            $cycleSwitchRefundEstimate = round(
+                (float) $cycleSwitchProration['prorated_credit']
+                + (float) ($existing_subscription['credit_balance'] ?? 0),
+                2
+            );
+        }
+    }
     ?>
 
     <!-- Payment processor keys -->
@@ -123,7 +141,8 @@
             totalCharge: <?php echo $totalToday; ?>,
             userId: <?php echo $user_id; ?>,
             userEmail: <?php echo json_encode($user_email, $je); ?>,
-            isUpdatingPaymentMethod: <?php echo $is_changing_method ? 'true' : 'false'; ?>
+            isUpdatingPaymentMethod: <?php echo $is_changing_method ? 'true' : 'false'; ?>,
+            isCycleSwitch: <?php echo $is_cycle_switch ? 'true' : 'false'; ?>
         };
     </script>
 
@@ -149,6 +168,29 @@
 
         <div class="checkout-form">
             <h2>Payment Details</h2>
+
+            <?php if ($is_cycle_switch && $cycleSwitchOldCycle && $cycleSwitchOldCycle !== $billing): ?>
+                <div class="cycle-switch-banner">
+                    <strong>Switching from <?php echo htmlspecialchars(ucfirst($cycleSwitchOldCycle)); ?> to <?php echo htmlspecialchars(ucfirst($billing)); ?>.</strong>
+                    PayPal will bill the new <?php echo htmlspecialchars($billing); ?> amount on activation.
+                    <?php if ($cycleSwitchRefundEstimate > 0): ?>
+                        Your prorated refund of about <strong>$<?php echo number_format($cycleSwitchRefundEstimate, 2); ?> CAD</strong> will appear in your PayPal account within 5–10 business days.
+                    <?php endif; ?>
+                </div>
+                <style>
+                .cycle-switch-banner {
+                    background: var(--purple-50, #faf5ff);
+                    border: 1px solid var(--purple-200, #e9d5ff);
+                    border-left: 4px solid var(--purple-500, #8b5cf6);
+                    border-radius: 10px;
+                    padding: 14px 18px;
+                    margin-bottom: 20px;
+                    font-size: 14px;
+                    line-height: 1.5;
+                    color: var(--gray-800, #1f2937);
+                }
+                </style>
+            <?php endif; ?>
 
             <div class="order-summary ai-order-summary">
                 <h3>Order Summary</h3>

--- a/pricing/premium/checkout/main.js
+++ b/pricing/premium/checkout/main.js
@@ -133,11 +133,21 @@ document.addEventListener("DOMContentLoaded", function () {
               user_id: subscription.userId,
               is_paypal_subscription: true,
               update_payment_method: subscription.isUpdatingPaymentMethod || false,
+              cycle_switch: subscription.isCycleSwitch || false,
             }),
           })
             .then((response) => response.json())
             .then((result) => {
               if (result.success) {
+                // Cycle switch: surface any warnings, then return to
+                // subscription page (not the thank-you/welcome page).
+                if (subscription.isCycleSwitch) {
+                  if (Array.isArray(result.warnings) && result.warnings.length > 0) {
+                    alert(result.message + "\n\n" + result.warnings.join("\n\n"));
+                  }
+                  window.location.href = "../../../community/users/subscription.php";
+                  return;
+                }
                 window.location.href =
                   "../thank-you/?subscription_id=" +
                   result.subscription_id +

--- a/pricing/premium/checkout/process-subscription.php
+++ b/pricing/premium/checkout/process-subscription.php
@@ -552,12 +552,15 @@ try {
                 }
             }
 
-            // 2. Issue the prorated refund (skip if no sale to refund against)
+            // 2. Issue the prorated refund (skip if no sale to refund against).
+            //    Pass the original sale's currency so PayPal validates it
+            //    against the sale.
             if ($sw['refund_amount'] > 0 && !empty($sw['sale']['transaction_id'])) {
                 $refundResult = refundPayPalSale(
                     $sw['sale']['transaction_id'],
                     $sw['refund_amount'],
-                    'Cycle switch proration'
+                    'Cycle switch proration',
+                    $sw['sale']['currency'] ?? 'CAD'
                 );
                 if (!$refundResult['success']) {
                     error_log("CRITICAL: cycle switch refund failed. user_id=$userId, subscription_id=$subscriptionId, sale_id={$sw['sale']['transaction_id']}, refund_amount={$sw['refund_amount']}, error=" . ($refundResult['error'] ?? 'unknown'));

--- a/pricing/premium/checkout/process-subscription.php
+++ b/pricing/premium/checkout/process-subscription.php
@@ -85,6 +85,12 @@ try {
 
 // Check if user is updating payment method for existing subscription
 $isUpdatingPaymentMethod = $input['update_payment_method'] ?? false;
+$cycleSwitch = !empty($input['cycle_switch']) && (
+    $input['cycle_switch'] === true
+    || $input['cycle_switch'] === 'true'
+    || $input['cycle_switch'] === 1
+    || $input['cycle_switch'] === '1'
+);
 $existingSubscription = null;
 $subscriptionStillValid = false;
 
@@ -369,58 +375,240 @@ try {
                 : date('Y-m-d H:i:s', strtotime('+1 month'));
         }
 
-        $stmt = $pdo->prepare("
-            UPDATE premium_subscriptions
-            SET payment_method = ?,
-                payment_token = ?,
-                stripe_customer_id = ?,
-                transaction_id = ?,
-                billing_cycle = ?,
-                amount = ?,
-                end_date = ?,
-                status = 'active',
-                auto_renew = 1,
-                cancelled_at = NULL,
-                updated_at = NOW()
-            WHERE subscription_id = ?
-        ");
-        $stmt->execute([
-            $paymentMethod,
-            $paymentToken,
-            $stripeCustomerId,
-            $transactionId,
-            $billing,
-            $newAmount,
-            $newEndDate,
-            $subscriptionId
-        ]);
+        // PayPal cycle-switch path: pre-compute proration + refund details.
+        // PayPal billing engine handles its own first-cycle charge on
+        // activation, so override end_date to today + new cycle. The cancel
+        // and refund happen post-commit (see below). We MUST proceed even
+        // if some prereqs fail — by this point the new PayPal sub already
+        // exists on PayPal's side; rolling back here would orphan it.
+        $isPayPalCycleSwitch = (
+            $cycleSwitch
+            && $paymentMethod === 'paypal'
+            && !empty($paypalSubscriptionId)
+        );
+        $paypalCycleSwitchData = null;
+        if ($isPayPalCycleSwitch) {
+            require_once __DIR__ . '/../../../webhooks/paypal-helper.php';
+            require_once __DIR__ . '/../../../community/users/user_functions.php';
 
-        // Update with PayPal subscription ID if applicable
-        if ($paypalSubscriptionId) {
+            $oldPaypalSubId = $existingSubscription['paypal_subscription_id'] ?? '';
+
+            // Anti-replay: new sub id MUST differ from existing row's id.
+            // PayPal generates a new id on each approval, so this should
+            // always hold; failure means a replay attack or a bug.
+            if ($oldPaypalSubId === $paypalSubscriptionId) {
+                $pdo->rollBack();
+                echo json_encode(['success' => false, 'error' => 'Replay rejected: same PayPal subscription id']);
+                exit();
+            }
+
+            $proration = calculate_cycle_switch_proration($existingSubscription, $billing, $pricingConfig);
+            if (($proration['direction'] ?? '') === 'noop') {
+                $pdo->rollBack();
+                echo json_encode(['success' => false, 'error' => 'Already on the requested billing cycle']);
+                exit();
+            }
+
+            // Override end_date — PayPal bills the new sub on activation
+            $newEndDate = ($billing === 'yearly')
+                ? date('Y-m-d H:i:s', strtotime('+1 year'))
+                : date('Y-m-d H:i:s', strtotime('+1 month'));
+
+            // Look up the most recent PayPal sale to refund against. If
+            // none (rare — confirm page guards this), we'll skip the
+            // refund step and warn the user.
+            $sale = getMostRecentPayPalSale($subscriptionId);
+            $existingCreditBalance = (float) ($existingSubscription['credit_balance'] ?? 0);
+            $refundAmount = 0.0;
+            if ($sale) {
+                $refundAmount = min(
+                    (float) $proration['prorated_credit'] + $existingCreditBalance,
+                    (float) $sale['amount']
+                );
+            }
+
+            $paypalCycleSwitchData = [
+                'old_paypal_sub_id' => $oldPaypalSubId,
+                'sale'              => $sale,
+                'refund_amount'     => round($refundAmount, 2),
+                'proration'         => $proration,
+                'existing_credit'   => $existingCreditBalance,
+            ];
+        }
+
+        if ($isPayPalCycleSwitch) {
+            // PayPal cycle-switch UPDATE: also writes
+            // previous_paypal_subscription_id (race fix for the cancel
+            // webhook), zeros credit_balance (consumed in refund),
+            // stamps last_cycle_change_at.
+            $stmt = $pdo->prepare("
+                UPDATE premium_subscriptions
+                SET payment_method = ?,
+                    payment_token = ?,
+                    stripe_customer_id = ?,
+                    transaction_id = ?,
+                    billing_cycle = ?,
+                    amount = ?,
+                    end_date = ?,
+                    paypal_subscription_id = ?,
+                    previous_paypal_subscription_id = ?,
+                    credit_balance = 0,
+                    last_cycle_change_at = NOW(),
+                    status = 'active',
+                    auto_renew = 1,
+                    cancelled_at = NULL,
+                    updated_at = NOW()
+                WHERE subscription_id = ?
+            ");
+            $stmt->execute([
+                $paymentMethod,
+                $paymentToken,
+                $stripeCustomerId,
+                $transactionId,
+                $billing,
+                $newAmount,
+                $newEndDate,
+                $paypalSubscriptionId,
+                $paypalCycleSwitchData['old_paypal_sub_id'],
+                $subscriptionId
+            ]);
+
+            // Audit row in payment history. The real $0 sale row gets
+            // written by the PAYMENT.SALE.COMPLETED webhook when PayPal
+            // bills the new sub.
             try {
-                $stmt = $pdo->prepare("UPDATE premium_subscriptions SET paypal_subscription_id = ? WHERE subscription_id = ?");
-                $stmt->execute([$paypalSubscriptionId, $subscriptionId]);
+                $stmt = $pdo->prepare("
+                    INSERT INTO premium_subscription_payments (
+                        subscription_id, amount, currency, payment_method,
+                        transaction_id, status, payment_type, created_at
+                    ) VALUES (?, 0, 'CAD', 'paypal', ?, 'completed', 'cycle_change', NOW())
+                ");
+                $stmt->execute([$subscriptionId, $paypalSubscriptionId]);
             } catch (PDOException $e) {
-                error_log("Could not set paypal_subscription_id: " . $e->getMessage());
+                error_log("Could not write cycle_change audit row: " . $e->getMessage());
+            }
+        } else {
+            // Original UPDATE for non-cycle-switch payment-method updates
+            $stmt = $pdo->prepare("
+                UPDATE premium_subscriptions
+                SET payment_method = ?,
+                    payment_token = ?,
+                    stripe_customer_id = ?,
+                    transaction_id = ?,
+                    billing_cycle = ?,
+                    amount = ?,
+                    end_date = ?,
+                    status = 'active',
+                    auto_renew = 1,
+                    cancelled_at = NULL,
+                    updated_at = NOW()
+                WHERE subscription_id = ?
+            ");
+            $stmt->execute([
+                $paymentMethod,
+                $paymentToken,
+                $stripeCustomerId,
+                $transactionId,
+                $billing,
+                $newAmount,
+                $newEndDate,
+                $subscriptionId
+            ]);
+
+            // Update with PayPal subscription ID if applicable
+            if ($paypalSubscriptionId) {
+                try {
+                    $stmt = $pdo->prepare("UPDATE premium_subscriptions SET paypal_subscription_id = ? WHERE subscription_id = ?");
+                    $stmt->execute([$paypalSubscriptionId, $subscriptionId]);
+                } catch (PDOException $e) {
+                    error_log("Could not set paypal_subscription_id: " . $e->getMessage());
+                }
             }
         }
 
         $pdo->commit();
 
+        // PayPal cycle-switch post-commit: cancel the OLD PayPal sub,
+        // then issue the prorated refund, then send email. Order matters:
+        //   - Cancel AFTER commit so the cancel webhook (which we deliberately
+        //     trigger) finds previous_paypal_subscription_id already set and
+        //     ignores itself via the race fix.
+        //   - Refund LAST so a refund failure doesn't undo a successful switch.
+        //   - Each step's failure is logged critical and surfaced as a warning
+        //     to the user, but never rolls back the cycle switch.
+        $switchWarnings = [];
+        if ($isPayPalCycleSwitch && $paypalCycleSwitchData) {
+            $sw = $paypalCycleSwitchData;
+
+            // 1. Cancel the old PayPal subscription
+            if (!empty($sw['old_paypal_sub_id'])) {
+                $cancelOk = cancelPayPalSubscription(
+                    $sw['old_paypal_sub_id'],
+                    "Cycle switch to {$billing}"
+                );
+                if (!$cancelOk) {
+                    error_log("CRITICAL: cycle switch cancel-old failed. user_id=$userId, subscription_id=$subscriptionId, old_paypal_sub_id={$sw['old_paypal_sub_id']}, new_paypal_sub_id=$paypalSubscriptionId");
+                    $switchWarnings[] = "We couldn't automatically cancel your old PayPal subscription. Please cancel it manually from your PayPal account or contact support.";
+                }
+            }
+
+            // 2. Issue the prorated refund (skip if no sale to refund against)
+            if ($sw['refund_amount'] > 0 && !empty($sw['sale']['transaction_id'])) {
+                $refundResult = refundPayPalSale(
+                    $sw['sale']['transaction_id'],
+                    $sw['refund_amount'],
+                    'Cycle switch proration'
+                );
+                if (!$refundResult['success']) {
+                    error_log("CRITICAL: cycle switch refund failed. user_id=$userId, subscription_id=$subscriptionId, sale_id={$sw['sale']['transaction_id']}, refund_amount={$sw['refund_amount']}, error=" . ($refundResult['error'] ?? 'unknown'));
+                    $switchWarnings[] = "Your prorated refund of $" . number_format($sw['refund_amount'], 2) . " is processing. If you don't see it within 10 business days, please contact support.";
+                }
+            } elseif ($sw['refund_amount'] > 0) {
+                error_log("WARN: cycle switch refund skipped — no completed PayPal sale found. user_id=$userId, subscription_id=$subscriptionId, refund_amount={$sw['refund_amount']}");
+                $switchWarnings[] = "We couldn't issue your prorated refund automatically because no recent PayPal payment was found. Please contact support if you expected a refund.";
+            }
+
+            // 3. Send the cycle-changed email with refund details
+            try {
+                send_premium_subscription_cycle_changed_email(
+                    $existingSubscription['email'] ?? $email,
+                    $subscriptionId,
+                    $sw['proration']['old_cycle'],
+                    $sw['proration']['new_cycle'],
+                    (float) $sw['proration']['prorated_credit'],
+                    (float) $sw['existing_credit'],
+                    (float) $newAmount,
+                    $newEndDate,
+                    0.0,
+                    (float) $pricingConfig['premium_monthly_price'],
+                    (float) $sw['refund_amount'],
+                    'PayPal'
+                );
+            } catch (Exception $e) {
+                error_log("Failed to send cycle change email: " . $e->getMessage());
+            }
+        }
+
         // Build appropriate success message
         $formattedEndDate = date('F j, Y', strtotime($newEndDate));
-        if ($skipPaymentProcessing) {
+        if ($isPayPalCycleSwitch) {
+            $chargeMessage = "Subscription switched to $billing. PayPal will bill the new amount today; your prorated refund (if any) will appear in 5–10 business days.";
+        } elseif ($skipPaymentProcessing) {
             $chargeMessage = "Your subscription has been updated. You will not be charged until $formattedEndDate.";
         } else {
             $chargeMessage = "Payment successful! Your subscription is now active until $formattedEndDate.";
         }
 
-        echo json_encode([
+        $responseData = [
             'success' => true,
             'subscription_id' => $subscriptionId,
             'message' => $chargeMessage,
-            'next_billing_date' => $newEndDate
-        ]);
+            'next_billing_date' => $newEndDate,
+        ];
+        if (!empty($switchWarnings)) {
+            $responseData['warnings'] = $switchWarnings;
+        }
+        echo json_encode($responseData);
 
     } else {
         // Create new subscription

--- a/webhooks/paypal-helper.php
+++ b/webhooks/paypal-helper.php
@@ -245,12 +245,13 @@ function activatePayPalSubscription($subscriptionId, $reason = 'Reactivated by u
  * unused billing period (and any pre-existing account credit) to the
  * user's PayPal account when they switch monthly <-> yearly.
  *
- * @param string $saleId  PayPal sale ID (from premium_subscription_payments.transaction_id)
- * @param float  $amount  Refund amount in CAD
- * @param string $reason  Internal reason for logs / PayPal display
+ * @param string $saleId       PayPal sale ID (from premium_subscription_payments.transaction_id)
+ * @param float  $amount       Refund amount
+ * @param string $description  Buyer-facing description (PayPal v1 sale-refund field name)
+ * @param string $currency     ISO currency code; defaults to CAD but should match the original sale's currency
  * @return array { success: bool, refund_id?: string|null, http_code?: int, error?: string }
  */
-function refundPayPalSale($saleId, $amount, $reason = 'Cycle switch proration') {
+function refundPayPalSale($saleId, $amount, $description = 'Cycle switch proration', $currency = 'CAD') {
     if (!isValidPayPalResourceId($saleId)) {
         return ['success' => false, 'error' => 'Invalid sale id format'];
     }
@@ -266,12 +267,14 @@ function refundPayPalSale($saleId, $amount, $reason = 'Cycle switch proration') 
     $baseUrl = getPayPalApiBaseUrl();
     $url = "$baseUrl/v1/payments/sale/" . urlencode($saleId) . "/refund";
 
+    // PayPal v1 sale-refund field is `description`, not `reason`. The
+    // cancel-subscription endpoint uses `reason`; sale refund does not.
     $body = json_encode([
         'amount' => [
             'total'    => number_format((float) $amount, 2, '.', ''),
-            'currency' => 'CAD',
+            'currency' => strtoupper($currency),
         ],
-        'reason' => $reason,
+        'description' => $description,
     ]);
 
     // PayPal-Request-Id: deterministic per (sale, day) so an accidental

--- a/webhooks/paypal-helper.php
+++ b/webhooks/paypal-helper.php
@@ -239,6 +239,107 @@ function activatePayPalSubscription($subscriptionId, $reason = 'Reactivated by u
 }
 
 /**
+ * Issue a refund against a PayPal v1 sale.
+ *
+ * Used by the cycle-switch flow to return the prorated value of an
+ * unused billing period (and any pre-existing account credit) to the
+ * user's PayPal account when they switch monthly <-> yearly.
+ *
+ * @param string $saleId  PayPal sale ID (from premium_subscription_payments.transaction_id)
+ * @param float  $amount  Refund amount in CAD
+ * @param string $reason  Internal reason for logs / PayPal display
+ * @return array { success: bool, refund_id?: string|null, http_code?: int, error?: string }
+ */
+function refundPayPalSale($saleId, $amount, $reason = 'Cycle switch proration') {
+    if (!isValidPayPalResourceId($saleId)) {
+        return ['success' => false, 'error' => 'Invalid sale id format'];
+    }
+    if (!is_numeric($amount) || $amount <= 0) {
+        return ['success' => false, 'error' => 'Refund amount must be positive'];
+    }
+
+    $accessToken = getPayPalAccessToken();
+    if (!$accessToken) {
+        return ['success' => false, 'error' => 'Failed to obtain PayPal access token'];
+    }
+
+    $baseUrl = getPayPalApiBaseUrl();
+    $url = "$baseUrl/v1/payments/sale/" . urlencode($saleId) . "/refund";
+
+    $body = json_encode([
+        'amount' => [
+            'total'    => number_format((float) $amount, 2, '.', ''),
+            'currency' => 'CAD',
+        ],
+        'reason' => $reason,
+    ]);
+
+    // PayPal-Request-Id: deterministic per (sale, day) so an accidental
+    // retry inside a 24h window reuses the key and PayPal dedups.
+    $requestId = hash('sha256', 'refund_' . $saleId . '_' . date('Y-m-d'));
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST           => true,
+        CURLOPT_POSTFIELDS     => $body,
+        CURLOPT_HTTPHEADER     => [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $accessToken,
+            'PayPal-Request-Id: ' . $requestId,
+        ],
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
+        CURLOPT_TIMEOUT        => 30,
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode !== 201) {
+        error_log("PayPal refund failed for sale $saleId: HTTP $httpCode response=$response");
+        return [
+            'success'   => false,
+            'http_code' => $httpCode,
+            'error'     => 'Refund API returned HTTP ' . $httpCode,
+        ];
+    }
+
+    $decoded = json_decode($response, true);
+    return [
+        'success'   => true,
+        'refund_id' => $decoded['id'] ?? null,
+        'http_code' => $httpCode,
+    ];
+}
+
+/**
+ * Find the most recent successful PayPal sale for a subscription.
+ * Returns the row from premium_subscription_payments suitable for
+ * refundPayPalSale, or null if no completed sale exists yet (block
+ * the cycle switch in that case).
+ *
+ * @param string $subscriptionId Argo subscription_id
+ * @return array|null { transaction_id, amount, currency, created_at }
+ */
+function getMostRecentPayPalSale($subscriptionId) {
+    global $pdo;
+    $stmt = $pdo->prepare("
+        SELECT transaction_id, amount, currency, created_at
+        FROM premium_subscription_payments
+        WHERE subscription_id = ?
+          AND payment_method = 'paypal'
+          AND status = 'completed'
+          AND payment_type IN ('initial', 'renewal')
+        ORDER BY created_at DESC
+        LIMIT 1
+    ");
+    $stmt->execute([$subscriptionId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+}
+
+/**
  * Log webhook event for debugging
  *
  * @param string $eventType The event type

--- a/webhooks/paypal-subscription.php
+++ b/webhooks/paypal-subscription.php
@@ -380,6 +380,15 @@ function handlePaymentCompleted($resource) {
 
     $paymentType = $paymentCount > 0 ? 'renewal' : 'initial';
 
+    // Detect "first bill after a cycle switch": process-subscription.php
+    // already set end_date and sent the cycle-changed email when the user
+    // approved the new PayPal sub. This webhook arrives seconds-to-minutes
+    // later when PayPal first bills the new sub. Without this guard, the
+    // renewal handler below would extend end_date a SECOND time (giving
+    // the user a free year/month of service) and send a duplicate email.
+    $cycleSwitchedRecently = !empty($subscription['last_cycle_change_at'])
+        && (time() - strtotime($subscription['last_cycle_change_at'])) < 600; // 10 min
+
     // Log the payment
     $stmt = $pdo->prepare("
         INSERT INTO premium_subscription_payments (
@@ -395,8 +404,12 @@ function handlePaymentCompleted($resource) {
         $paymentType
     ]);
 
-    // Update subscription end date if this is a renewal
-    if ($paymentType === 'renewal') {
+    if ($cycleSwitchedRecently) {
+        // First bill after a cycle switch — record the sale (above), but
+        // don't extend end_date and don't send a renewal email. Both were
+        // already handled when the user confirmed the switch.
+        logPayPalWebhookEvent('PAYMENT.SALE.COMPLETED', $resource, 'cycle_switch_first_bill_recorded');
+    } elseif ($paymentType === 'renewal') {
         $billing = $subscription['billing_cycle'];
         $newEndDate = calculateNewEndDate($subscription['end_date'], $billing);
 

--- a/webhooks/paypal-subscription.php
+++ b/webhooks/paypal-subscription.php
@@ -180,6 +180,29 @@ function handleSubscriptionCancelled($resource) {
         throw new Exception("Missing subscription ID in cancelled event");
     }
 
+    // Race fix for cycle-switch flow: when a user switches PayPal billing
+    // cycles, we cancel the old subscription server-side AFTER committing
+    // the new one to the DB. The cancel triggers a BILLING.SUBSCRIPTION.
+    // CANCELLED webhook for the OLD id. Without this guard, the handler
+    // below would mark the row (now pointing at the NEW sub) as cancelled
+    // and zero out credit_balance. The previous_paypal_subscription_id
+    // column is set in the same transaction as paypal_subscription_id, so
+    // this lookup is deterministic and survives webhook delivery delays.
+    $stmt = $pdo->prepare("
+        SELECT subscription_id FROM premium_subscriptions
+        WHERE previous_paypal_subscription_id = ?
+        LIMIT 1
+    ");
+    $stmt->execute([$paypalSubscriptionId]);
+    if ($stmt->fetch()) {
+        logPayPalWebhookEvent(
+            'BILLING.SUBSCRIPTION.CANCELLED',
+            $resource,
+            'cycle_switch_old_sub_cancel_ignored'
+        );
+        return;
+    }
+
     // Find subscription in our database
     $stmt = $pdo->prepare("SELECT * FROM premium_subscriptions WHERE paypal_subscription_id = ?");
     $stmt->execute([$paypalSubscriptionId]);


### PR DESCRIPTION
## Summary
- Wires up real PayPal cycle switching to replace the "coming soon" notice from Phase 1.
- Cancel old PayPal sub + approve new sub via PayPal redirect + refund prorated unused-period value (plus any pre-existing `credit_balance`) via PayPal Refunds API v1.
- Race fix for the inevitable `BILLING.SUBSCRIPTION.CANCELLED` webhook for the old sub: `previous_paypal_subscription_id` column lets the handler recognize and skip expected cancel events. Daily cron clears stale values after 7 days.
- Failure handling: cancel-old or refund failures are logged critical and surfaced as `warnings[]` in the JSON response, but never roll back a successful cycle switch (rolling back is worse — user ends up with two subs charging or a missing refund, both ops-fixable).
- "No completed sale yet" guard on confirm page (PayPal hasn't billed yet, no sale to refund against) — blocks with a friendly "still being activated" error.

## Schema (run on dev + prod manually)

```sql
ALTER TABLE premium_subscriptions
    ADD COLUMN previous_paypal_subscription_id VARCHAR(100) DEFAULT NULL
        COMMENT 'Old PayPal sub-id during in-flight cycle switch; cancel webhook for this ID is ignored'
        AFTER paypal_subscription_id;
```

## Critical ordering preserved
1. Recompute proration server-side, anti-replay check (new sub id ≠ existing row's id)
2. Look up most recent sale + cap refund at sale amount
3. UPDATE row inside transaction (writes new + previous PayPal sub ids atomically, zeros credit, end_date = today + new cycle)
4. INSERT \$0 audit row with `payment_type='cycle_change'`
5. **Commit**
6. Cancel old PayPal sub (failure → log + warning, no rollback)
7. Refund old sale (failure → log + warning, no rollback)
8. Send email with refund details

## Legal
[legal/terms.php](legal/terms.php) and [legal/refund.php](legal/refund.php) carve-outs for PayPal removed; replaced with refund-style language describing the 5–10 business day timeline.

## Test plan (PayPal sandbox)
- [ ] Run schema ALTER on dev DB before any of the below
- [ ] PayPal monthly → yearly mid-month: small refund (~\$5) visible in sandbox dashboard, end_date = +1 yr, `cycle_change` audit row written, email mentions refund
- [ ] PayPal yearly → monthly with 6 months remaining: larger refund (~\$50)
- [ ] Subscription with `credit_balance = $20`: refund includes both prorated value AND the \$20 credit, `credit_balance` = 0 after
- [ ] Brand-new PayPal subscriber clicks Switch immediately (before initial PAYMENT.SALE.COMPLETED webhook fires) → confirm page shows "still being activated" error
- [ ] Trigger `BILLING.SUBSCRIPTION.CANCELLED` webhook for old sub id post-switch → handler logs `cycle_switch_old_sub_cancel_ignored`, no state change
- [ ] Simulate cancel API failure → user sees "couldn't automatically cancel old PayPal sub" warning, both subs remain in PayPal
- [ ] Simulate refund API failure → user sees "refund processing — contact support if not received in 10 business days" warning
- [ ] Direct POST to `process-subscription.php` reusing the same `paypal_subscription_id` that's already on the row → rejected as replay
- [ ] After several test switches, run `cron/subscription_renewal.php` and verify it nulls `previous_paypal_subscription_id` on rows untouched 7+ days
- [ ] `/legal/terms.php` and `/legal/refund.php` render the new PayPal copy