### PR TITLE
Email: marketing preferences + admin-triggered review/feedback emails

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -97,6 +97,9 @@ $base_path = $in_subdir ? '../' : '';
                     <a href="<?php echo $base_path; ?>outreach/" class="header-link <?php echo $current_dir === 'outreach' ? 'active' : ''; ?>">
                         Outreach
                     </a>
+                    <a href="<?php echo $base_path; ?>reviews/" class="header-link <?php echo $current_dir === 'reviews' ? 'active' : ''; ?>">
+                        Reviews
+                    </a>
                     <a href="<?php echo $base_path; ?>settings/" class="header-link <?php echo $current_dir === 'settings' ? 'active' : ''; ?>">
                         2FA
                     </a>
@@ -140,6 +143,7 @@ $base_path = $in_subdir ? '../' : '';
                     <li><a href="<?php echo $base_path; ?>users/" class="<?php echo $current_dir === 'users' ? 'active' : ''; ?>">Users</a></li>
                     <li><a href="<?php echo $base_path; ?>reports/" class="<?php echo $current_dir === 'reports' ? 'active' : ''; ?>">Reports</a></li>
                     <li><a href="<?php echo $base_path; ?>outreach/" class="<?php echo $current_dir === 'outreach' ? 'active' : ''; ?>">Outreach</a></li>
+                    <li><a href="<?php echo $base_path; ?>reviews/" class="<?php echo $current_dir === 'reviews' ? 'active' : ''; ?>">Reviews</a></li>
                     <li><a href="<?php echo $base_path; ?>settings/" class="<?php echo $current_dir === 'settings' ? 'active' : ''; ?>">2FA</a></li>
                     <li><a href="<?php echo $base_path; ?>logout.php" class="logout-link">Logout</a></li>
                 </ul>

--- a/admin/reviews/index.php
+++ b/admin/reviews/index.php
@@ -102,18 +102,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $email = $row['email'];
                     $variant = is_active_user($row['last_active_at']) ? 'active' : 'inactive';
 
+                    // Atomic claim: only proceed if no other request beat us to this row.
+                    // The IS NULL guard makes the operation idempotent under concurrent
+                    // admin sessions and protects against double-emailing the customer.
+                    $claim = $pdo->prepare("UPDATE license_keys
+                                            SET review_email_sent_at = NOW(),
+                                                review_email_variant = ?
+                                            WHERE id = ? AND review_email_sent_at IS NULL");
+                    $claim->execute([$variant, $licenseId]);
+                    if ($claim->rowCount() === 0) {
+                        // Already claimed by another request — skip silently.
+                        continue;
+                    }
+
                     $ok = ($variant === 'active')
                         ? send_review_request_email($licenseId, $email)
                         : send_feedback_request_email($licenseId, $email);
 
                     if ($ok) {
-                        $stmt = $pdo->prepare("UPDATE license_keys
-                                               SET review_email_sent_at = NOW(),
-                                                   review_email_variant = ?
-                                               WHERE id = ?");
-                        $stmt->execute([$variant, $licenseId]);
                         $sent++;
                     } else {
+                        // Best-effort revert so the admin can retry. Scoped by variant
+                        // so we only un-claim the row WE just claimed.
+                        $revert = $pdo->prepare("UPDATE license_keys
+                                                 SET review_email_sent_at = NULL,
+                                                     review_email_variant = NULL
+                                                 WHERE id = ? AND review_email_variant = ?");
+                        $revert->execute([$licenseId, $variant]);
                         $failed++;
                     }
                 }

--- a/admin/reviews/index.php
+++ b/admin/reviews/index.php
@@ -1,0 +1,276 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/../../email_marketing.php';
+
+// Auth: admin session only (matches admin/outreach/index.php pattern)
+if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== true) {
+    header('Location: ../login.php');
+    exit;
+}
+
+// CSRF token
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$page_title = "Review Emails";
+$page_description = "Send review or feedback emails to license-key customers (purchased 30+ days ago).";
+
+$flash = null;
+$flash_type = null;
+
+/**
+ * Eligibility query — license keys we can send to.
+ * Re-used both for rendering and for the POST handler (defence in depth).
+ */
+function fetch_eligible_licenses(PDO $pdo, ?array $idFilter = null): array
+{
+    $sql = "
+        SELECT
+          lk.id, lk.email, lk.license_key,
+          lk.created_at AS purchased_at,
+          GREATEST(
+            COALESCE((SELECT MAX(updated_at) FROM receipt_scan_usage WHERE license_key = lk.license_key), '1970-01-01'),
+            COALESCE((SELECT MAX(updated_at) FROM invoice_send_usage  WHERE license_key = lk.license_key), '1970-01-01')
+          ) AS last_active_at
+        FROM license_keys lk
+        WHERE lk.activated = 1
+          AND lk.created_at <= NOW() - INTERVAL 30 DAY
+          AND lk.review_email_sent_at IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM email_suppressions s
+            WHERE s.email = lk.email AND s.context IN ('reviews','all_marketing')
+          )
+    ";
+
+    $params = [];
+    if ($idFilter !== null && count($idFilter) > 0) {
+        $placeholders = implode(',', array_fill(0, count($idFilter), '?'));
+        $sql .= " AND lk.id IN ($placeholders)";
+        $params = array_values(array_map('intval', $idFilter));
+    }
+
+    $sql .= " ORDER BY lk.created_at ASC LIMIT 500";
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    return $stmt->fetchAll();
+}
+
+/**
+ * "Active" = used the desktop app in the last 14 days.
+ */
+function is_active_user(string $lastActiveAt): bool
+{
+    $threshold = strtotime('-14 days');
+    return strtotime($lastActiveAt) >= $threshold;
+}
+
+// POST handler
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $postedToken = $_POST['csrf_token'] ?? '';
+    if (!$postedToken || !hash_equals($_SESSION['csrf_token'], $postedToken)) {
+        $flash = 'Session expired or invalid request token. Please try again.';
+        $flash_type = 'error';
+    } else {
+        $action = $_POST['action'] ?? 'send';
+
+        if ($action === 'skip') {
+            $skipId = (int) ($_POST['license_id'] ?? 0);
+            if ($skipId > 0) {
+                $stmt = $pdo->prepare("UPDATE license_keys
+                                       SET review_email_sent_at = NOW(),
+                                           review_email_variant = 'manually_skipped'
+                                       WHERE id = ? AND review_email_sent_at IS NULL");
+                $stmt->execute([$skipId]);
+                $flash = 'License skipped. It will no longer appear in this list.';
+                $flash_type = 'success';
+            }
+        } elseif ($action === 'send') {
+            $selected = $_POST['license_ids'] ?? [];
+            if (!is_array($selected) || count($selected) === 0) {
+                $flash = 'No licenses selected.';
+                $flash_type = 'error';
+            } else {
+                $eligible = fetch_eligible_licenses($pdo, $selected);
+                $sent = 0;
+                $failed = 0;
+
+                foreach ($eligible as $row) {
+                    $licenseId = (int) $row['id'];
+                    $email = $row['email'];
+                    $variant = is_active_user($row['last_active_at']) ? 'active' : 'inactive';
+
+                    $ok = ($variant === 'active')
+                        ? send_review_request_email($licenseId, $email)
+                        : send_feedback_request_email($licenseId, $email);
+
+                    if ($ok) {
+                        $stmt = $pdo->prepare("UPDATE license_keys
+                                               SET review_email_sent_at = NOW(),
+                                                   review_email_variant = ?
+                                               WHERE id = ?");
+                        $stmt->execute([$variant, $licenseId]);
+                        $sent++;
+                    } else {
+                        $failed++;
+                    }
+                }
+
+                $flash = "Sent {$sent} email(s)." . ($failed > 0 ? " {$failed} failed — check error logs." : '');
+                $flash_type = $failed > 0 ? 'error' : 'success';
+            }
+        }
+    }
+}
+
+// Render
+$eligible = fetch_eligible_licenses($pdo);
+$active = [];
+$inactive = [];
+foreach ($eligible as $row) {
+    if (is_active_user($row['last_active_at'])) {
+        $active[] = $row;
+    } else {
+        $inactive[] = $row;
+    }
+}
+
+include __DIR__ . '/../admin_header.php';
+?>
+
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="../../resources/styles/checkbox.css">
+
+<?php if ($flash): ?>
+    <div class="alert alert-<?= htmlspecialchars($flash_type) ?>"><?= htmlspecialchars($flash) ?></div>
+<?php endif; ?>
+
+<div class="reviews-intro">
+    <p>
+        These are license-key customers who purchased 30+ days ago and haven't been emailed yet. Active customers (used the app in the last 14 days) get a review request linking to Capterra. Inactive customers get a feedback request asking them to reply with what's getting in the way. Each customer is asked at most once.
+    </p>
+    <p>
+        Use <strong>Skip</strong> to permanently exclude someone (for example, customers who already left a review or who you've already spoken to in person).
+    </p>
+</div>
+
+<form method="post" id="reviews-form">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
+    <input type="hidden" name="action" value="send">
+
+    <?php
+    /**
+     * @param array $rows
+     * @param string $variantLabel
+     */
+    $renderSection = function (array $rows, string $sectionTitle, string $sectionDescription, string $variantClass) {
+        ?>
+        <div class="review-section <?= $variantClass ?>">
+            <h2><?= htmlspecialchars($sectionTitle) ?> <span class="count">(<?= count($rows) ?>)</span></h2>
+            <p class="section-description"><?= htmlspecialchars($sectionDescription) ?></p>
+
+            <?php if (count($rows) === 0): ?>
+                <p class="empty-state">No eligible customers in this group.</p>
+            <?php else: ?>
+                <table class="reviews-table">
+                    <thead>
+                        <tr>
+                            <th><input type="checkbox" class="select-all" data-section="<?= $variantClass ?>" checked></th>
+                            <th>Email</th>
+                            <th>License key</th>
+                            <th>Purchased</th>
+                            <th>Last active</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($rows as $row):
+                            $purchased = date('Y-m-d', strtotime($row['purchased_at']));
+                            $lastActive = strtotime($row['last_active_at']);
+                            $lastActiveDisplay = ($lastActive > strtotime('1970-01-02')) ? date('Y-m-d', $lastActive) : 'Never';
+                            $licenseShort = substr($row['license_key'], 0, 12) . '…';
+                        ?>
+                            <tr>
+                                <td>
+                                    <input type="checkbox" class="row-check <?= $variantClass ?>-row"
+                                           name="license_ids[]" value="<?= (int) $row['id'] ?>" checked>
+                                </td>
+                                <td><?= htmlspecialchars($row['email']) ?></td>
+                                <td><code title="<?= htmlspecialchars($row['license_key']) ?>"><?= htmlspecialchars($licenseShort) ?></code></td>
+                                <td><?= htmlspecialchars($purchased) ?></td>
+                                <td><?= htmlspecialchars($lastActiveDisplay) ?></td>
+                                <td>
+                                    <button type="button" class="btn btn-small btn-gray skip-btn"
+                                            data-license-id="<?= (int) $row['id'] ?>">Skip</button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+        </div>
+        <?php
+    };
+
+    $renderSection(
+        $active,
+        'Active customers (review request)',
+        'These customers used the app in the last 14 days. They will receive a Capterra review ask.',
+        'active'
+    );
+
+    $renderSection(
+        $inactive,
+        'Inactive customers (feedback request)',
+        'These customers have not used the app in the last 14 days. They will receive a "what got in the way?" email asking them to reply.',
+        'inactive'
+    );
+    ?>
+
+    <?php if (count($eligible) > 0): ?>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-blue">Send to selected</button>
+        </div>
+    <?php endif; ?>
+</form>
+
+<form method="post" id="skip-form" style="display:none;">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
+    <input type="hidden" name="action" value="skip">
+    <input type="hidden" name="license_id" id="skip-license-id" value="">
+</form>
+
+<script>
+    document.querySelectorAll('.select-all').forEach(function (master) {
+        master.addEventListener('change', function () {
+            var section = master.dataset.section;
+            document.querySelectorAll('.row-check.' + section + '-row').forEach(function (cb) {
+                cb.checked = master.checked;
+            });
+        });
+    });
+
+    document.querySelectorAll('.skip-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            if (!confirm('Skip this customer permanently? They will no longer appear in this list, even if they remain eligible.')) {
+                return;
+            }
+            document.getElementById('skip-license-id').value = btn.dataset.licenseId;
+            document.getElementById('skip-form').submit();
+        });
+    });
+
+    document.getElementById('reviews-form').addEventListener('submit', function (e) {
+        var checked = document.querySelectorAll('.row-check:checked').length;
+        if (checked === 0) {
+            e.preventDefault();
+            alert('No customers selected.');
+            return;
+        }
+        if (!confirm('Send emails to ' + checked + ' customer(s)?')) {
+            e.preventDefault();
+        }
+    });
+</script>

--- a/admin/reviews/style.css
+++ b/admin/reviews/style.css
@@ -1,0 +1,147 @@
+.reviews-intro {
+    background: var(--blue-50, #eff6ff);
+    border-left: 3px solid var(--primary-blue);
+    padding: 14px 18px;
+    border-radius: 4px;
+    margin-bottom: 24px;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.reviews-intro p {
+    margin: 0 0 8px 0;
+}
+
+.reviews-intro p:last-child {
+    margin-bottom: 0;
+}
+
+.review-section {
+    background: var(--white);
+    border-radius: 8px;
+    box-shadow: 0 1px 3px var(--shadow-default);
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.review-section h2 {
+    font-size: 18px;
+    margin: 0 0 4px 0;
+    color: var(--blue-900);
+}
+
+.review-section h2 .count {
+    color: var(--gray-600, #6b7280);
+    font-weight: 400;
+    font-size: 14px;
+}
+
+.review-section.active h2 {
+    color: var(--emerald-800, #065f46);
+}
+
+.review-section.inactive h2 {
+    color: var(--amber-700, #b45309);
+}
+
+.section-description {
+    font-size: 13px;
+    color: var(--gray-600, #6b7280);
+    margin: 0 0 14px 0;
+}
+
+.empty-state {
+    color: var(--gray-500, #9ca3af);
+    font-style: italic;
+    margin: 0;
+}
+
+.reviews-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.reviews-table th,
+.reviews-table td {
+    padding: 8px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--gray-100, #f3f4f6);
+}
+
+.reviews-table th {
+    font-weight: 600;
+    background: var(--gray-50, #f9fafb);
+    color: var(--gray-700, #374151);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.reviews-table tr:last-child td {
+    border-bottom: none;
+}
+
+.reviews-table code {
+    background: var(--gray-100, #f3f4f6);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 20px;
+}
+
+.btn-small {
+    padding: 4px 10px;
+    font-size: 12px;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] .reviews-intro {
+    background: var(--blue-alpha-15);
+    border-left-color: var(--blue-400);
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .review-section {
+    background: var(--gray-800);
+    box-shadow: 0 1px 3px var(--overlay-light);
+}
+
+[data-theme="dark"] .review-section h2 {
+    color: var(--blue-300);
+}
+
+[data-theme="dark"] .review-section.active h2 {
+    color: var(--emerald-300, #6ee7b7);
+}
+
+[data-theme="dark"] .review-section.inactive h2 {
+    color: var(--amber-300, #fcd34d);
+}
+
+[data-theme="dark"] .review-section h2 .count,
+[data-theme="dark"] .section-description,
+[data-theme="dark"] .empty-state {
+    color: var(--gray-400);
+}
+
+[data-theme="dark"] .reviews-table th,
+[data-theme="dark"] .reviews-table td {
+    border-bottom-color: var(--gray-700);
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .reviews-table th {
+    background: var(--gray-700);
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .reviews-table code {
+    background: var(--gray-700);
+    color: var(--gray-200);
+}

--- a/community/users/email_preferences-style.css
+++ b/community/users/email_preferences-style.css
@@ -1,0 +1,135 @@
+.wrapper {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0;
+}
+
+.prefs-container {
+  max-width: 700px;
+  width: 100%;
+  background: var(--white);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px var(--shadow-default);
+  padding: 30px;
+}
+
+.prefs-header {
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.prefs-header h1 {
+  font-size: 24px;
+  color: var(--blue-900);
+}
+
+.prefs-header .subtitle {
+  font-size: 14px;
+  color: var(--gray-600, #6b7280);
+  margin-top: 6px;
+}
+
+.prefs-form {
+  margin-top: 20px;
+}
+
+.prefs-section {
+  margin-bottom: 30px;
+}
+
+.prefs-section h2 {
+  font-size: 18px;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--gray-border);
+  color: var(--blue-900);
+}
+
+.checkbox {
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+}
+
+.setting-description {
+  margin-left: 28px;
+  font-size: 14px;
+  color: var(--gray-600, #6b7280);
+}
+
+.transactional-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px 0;
+}
+
+.transactional-list li {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--gray-100, #f3f4f6);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.transactional-list li:last-child {
+  border-bottom: none;
+}
+
+.transactional-list .label {
+  font-weight: 500;
+}
+
+.always-on-tag {
+  background: var(--emerald-100);
+  color: var(--emerald-800);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.info-note {
+  background: var(--blue-50, #eff6ff);
+  border-left: 3px solid var(--primary-blue);
+  padding: 12px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-top: 12px;
+  color: var(--blue-900);
+}
+
+.review-note {
+  background: var(--amber-50, #fffbeb);
+  border-left: 3px solid var(--amber-500, #f59e0b);
+  padding: 12px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-top: 12px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30px;
+}
+
+.success-message {
+  background-color: var(--emerald-100);
+  color: var(--emerald-800);
+  padding: 15px;
+  border-radius: 6px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.error-message {
+  background-color: var(--red-100);
+  color: var(--red-700);
+  padding: 15px;
+  border-radius: 6px;
+  margin-bottom: 20px;
+  text-align: center;
+}

--- a/community/users/email_preferences.php
+++ b/community/users/email_preferences.php
@@ -1,9 +1,14 @@
 <?php
 session_start();
 require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/../../email_marketing.php';
 require_once __DIR__ . '/user_functions.php';
 
 require_login();
+
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 
 $user_id = (int) $_SESSION['user_id'];
 $success_message = '';
@@ -29,32 +34,58 @@ $is_license_holder = (bool) $stmt->fetchColumn();
 
 // Process form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $product_updates  = isset($_POST['email_pref_product_updates']) ? 1 : 0;
-    $tips_onboarding  = isset($_POST['email_pref_tips_onboarding']) ? 1 : 0;
-    $reviews          = isset($_POST['email_pref_reviews']) ? 1 : 0;
-    $promotions       = isset($_POST['email_pref_promotions']) ? 1 : 0;
-    $community_digest = isset($_POST['email_pref_community_digest']) ? 1 : 0;
+    if (!isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $error_message = 'Invalid request. Please try again.';
+    } else {
+        $product_updates  = isset($_POST['email_pref_product_updates']) ? 1 : 0;
+        $tips_onboarding  = isset($_POST['email_pref_tips_onboarding']) ? 1 : 0;
+        $reviews          = isset($_POST['email_pref_reviews']) ? 1 : 0;
+        $promotions       = isset($_POST['email_pref_promotions']) ? 1 : 0;
+        $community_digest = isset($_POST['email_pref_community_digest']) ? 1 : 0;
 
-    try {
-        $stmt = $pdo->prepare('UPDATE community_users
-                               SET email_pref_product_updates = ?,
-                                   email_pref_tips_onboarding = ?,
-                                   email_pref_reviews = ?,
-                                   email_pref_promotions = ?,
-                                   email_pref_community_digest = ?
-                               WHERE id = ?');
-        $stmt->execute([$product_updates, $tips_onboarding, $reviews, $promotions, $community_digest, $user_id]);
+        try {
+            $stmt = $pdo->prepare('UPDATE community_users
+                                   SET email_pref_product_updates = ?,
+                                       email_pref_tips_onboarding = ?,
+                                       email_pref_reviews = ?,
+                                       email_pref_promotions = ?,
+                                       email_pref_community_digest = ?
+                                   WHERE id = ?');
+            $stmt->execute([$product_updates, $tips_onboarding, $reviews, $promotions, $community_digest, $user_id]);
 
-        $prefs['email_pref_product_updates']  = $product_updates;
-        $prefs['email_pref_tips_onboarding']  = $tips_onboarding;
-        $prefs['email_pref_reviews']          = $reviews;
-        $prefs['email_pref_promotions']       = $promotions;
-        $prefs['email_pref_community_digest'] = $community_digest;
+            // Sync suppressions: a previous one-click unsubscribe leaves a row in
+            // email_suppressions, and the send-time gate checks that table FIRST.
+            // When the user opts in here, those rows must be cleared or the
+            // pref column flip would have no effect.
+            $opted_in_contexts = [];
+            if ($product_updates)  $opted_in_contexts[] = 'product_updates';
+            if ($tips_onboarding)  $opted_in_contexts[] = 'tips_onboarding';
+            if ($reviews)          $opted_in_contexts[] = 'reviews';
+            if ($promotions)       $opted_in_contexts[] = 'promotions';
+            if ($community_digest) $opted_in_contexts[] = 'community_digest';
 
-        $success_message = 'Email preferences updated successfully.';
-    } catch (PDOException $e) {
-        error_log('email_preferences update failed: ' . $e->getMessage());
-        $error_message = 'Failed to update email preferences. Please try again.';
+            $email_lc = strtolower(trim($prefs['email']));
+            if (count($opted_in_contexts) > 0) {
+                // If any category is opted-in, the blanket suppression must go.
+                $del = $pdo->prepare("DELETE FROM email_suppressions WHERE email = ? AND context = 'all_marketing'");
+                $del->execute([$email_lc]);
+
+                $placeholders = implode(',', array_fill(0, count($opted_in_contexts), '?'));
+                $del = $pdo->prepare("DELETE FROM email_suppressions WHERE email = ? AND context IN ($placeholders)");
+                $del->execute(array_merge([$email_lc], $opted_in_contexts));
+            }
+
+            $prefs['email_pref_product_updates']  = $product_updates;
+            $prefs['email_pref_tips_onboarding']  = $tips_onboarding;
+            $prefs['email_pref_reviews']          = $reviews;
+            $prefs['email_pref_promotions']       = $promotions;
+            $prefs['email_pref_community_digest'] = $community_digest;
+
+            $success_message = 'Email preferences updated successfully.';
+        } catch (PDOException $e) {
+            error_log('email_preferences update failed: ' . $e->getMessage());
+            $error_message = 'Failed to update email preferences. Please try again.';
+        }
     }
 }
 ?>
@@ -101,6 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php endif; ?>
 
             <form method="post" class="prefs-form">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                 <div class="prefs-section">
                     <h2>Account &amp; transactional emails</h2>
                     <ul class="transactional-list">

--- a/community/users/email_preferences.php
+++ b/community/users/email_preferences.php
@@ -1,0 +1,177 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/user_functions.php';
+
+require_login();
+
+$user_id = (int) $_SESSION['user_id'];
+$success_message = '';
+$error_message = '';
+
+// Load current prefs
+$stmt = $pdo->prepare('SELECT email, email_pref_product_updates, email_pref_tips_onboarding,
+                              email_pref_reviews, email_pref_promotions, email_pref_community_digest
+                       FROM community_users WHERE id = ?');
+$stmt->execute([$user_id]);
+$prefs = $stmt->fetch();
+
+if (!$prefs) {
+    // Logged in but no row — shouldn't happen, but bail safely
+    header('Location: login.php');
+    exit;
+}
+
+// Check whether this user is also a license-key holder (drives the "reviews" notice)
+$stmt = $pdo->prepare('SELECT 1 FROM license_keys WHERE email = ? LIMIT 1');
+$stmt->execute([$prefs['email']]);
+$is_license_holder = (bool) $stmt->fetchColumn();
+
+// Process form submission
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $product_updates  = isset($_POST['email_pref_product_updates']) ? 1 : 0;
+    $tips_onboarding  = isset($_POST['email_pref_tips_onboarding']) ? 1 : 0;
+    $reviews          = isset($_POST['email_pref_reviews']) ? 1 : 0;
+    $promotions       = isset($_POST['email_pref_promotions']) ? 1 : 0;
+    $community_digest = isset($_POST['email_pref_community_digest']) ? 1 : 0;
+
+    try {
+        $stmt = $pdo->prepare('UPDATE community_users
+                               SET email_pref_product_updates = ?,
+                                   email_pref_tips_onboarding = ?,
+                                   email_pref_reviews = ?,
+                                   email_pref_promotions = ?,
+                                   email_pref_community_digest = ?
+                               WHERE id = ?');
+        $stmt->execute([$product_updates, $tips_onboarding, $reviews, $promotions, $community_digest, $user_id]);
+
+        $prefs['email_pref_product_updates']  = $product_updates;
+        $prefs['email_pref_tips_onboarding']  = $tips_onboarding;
+        $prefs['email_pref_reviews']          = $reviews;
+        $prefs['email_pref_promotions']       = $promotions;
+        $prefs['email_pref_community_digest'] = $community_digest;
+
+        $success_message = 'Email preferences updated successfully.';
+    } catch (PDOException $e) {
+        error_log('email_preferences update failed: ' . $e->getMessage());
+        $error_message = 'Failed to update email preferences. Please try again.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" type="image/x-icon" href="../../resources/images/argo-logo/argo-icon.ico">
+    <title>Email Preferences - Argo Community</title>
+
+    <script src="../../resources/scripts/jquery-3.6.0.js"></script>
+    <script src="../../resources/scripts/main.js"></script>
+
+    <link rel="stylesheet" href="auth.css">
+    <link rel="stylesheet" href="email_preferences-style.css">
+    <link rel="stylesheet" href="../../resources/styles/custom-colors.css">
+    <link rel="stylesheet" href="../../resources/styles/checkbox.css">
+    <link rel="stylesheet" href="../../resources/styles/button.css">
+    <link rel="stylesheet" href="../../resources/header/style.css">
+    <link rel="stylesheet" href="../../resources/footer/style.css">
+    <link rel="stylesheet" href="../../resources/header/dark.css">
+</head>
+
+<body>
+    <header>
+        <div id="includeHeader"></div>
+    </header>
+
+    <div class="wrapper">
+        <div class="prefs-container">
+            <div class="prefs-header">
+                <h1>Email Preferences</h1>
+                <p class="subtitle">Choose which emails you'd like to receive from Argo Books.</p>
+            </div>
+
+            <?php if ($success_message): ?>
+                <div class="success-message"><?php echo htmlspecialchars($success_message); ?></div>
+            <?php endif; ?>
+
+            <?php if ($error_message): ?>
+                <div class="error-message"><?php echo htmlspecialchars($error_message); ?></div>
+            <?php endif; ?>
+
+            <form method="post" class="prefs-form">
+                <div class="prefs-section">
+                    <h2>Account &amp; transactional emails</h2>
+                    <ul class="transactional-list">
+                        <li><span class="always-on-tag">Always on</span><span class="label">Email verification</span></li>
+                        <li><span class="always-on-tag">Always on</span><span class="label">Password reset</span></li>
+                        <li><span class="always-on-tag">Always on</span><span class="label">Payment receipts</span></li>
+                        <li><span class="always-on-tag">Always on</span><span class="label">License key delivery</span></li>
+                        <li><span class="always-on-tag">Always on</span><span class="label">Subscription renewal &amp; payment-failed notices</span></li>
+                        <li><span class="always-on-tag">Always on</span><span class="label">Account deletion warnings</span></li>
+                    </ul>
+                    <div class="info-note">
+                        These keep your account, payments, and recovery working &mdash; turning them off would break things like password resets and receipt delivery.
+                    </div>
+                </div>
+
+                <div class="prefs-section">
+                    <h2>Marketing emails</h2>
+
+                    <div class="checkbox">
+                        <input type="checkbox" id="email_pref_product_updates" name="email_pref_product_updates"
+                               <?php echo $prefs['email_pref_product_updates'] ? 'checked' : ''; ?>>
+                        <label for="email_pref_product_updates">Product updates</label>
+                    </div>
+                    <p class="setting-description">New features, release notes, and what's new in Argo Books.</p>
+
+                    <div class="checkbox">
+                        <input type="checkbox" id="email_pref_tips_onboarding" name="email_pref_tips_onboarding"
+                               <?php echo $prefs['email_pref_tips_onboarding'] ? 'checked' : ''; ?>>
+                        <label for="email_pref_tips_onboarding">Tips &amp; onboarding</label>
+                    </div>
+                    <p class="setting-description">How-to guides and getting-started nudges, mostly useful when you're new.</p>
+
+                    <div class="checkbox">
+                        <input type="checkbox" id="email_pref_reviews" name="email_pref_reviews"
+                               <?php echo $prefs['email_pref_reviews'] ? 'checked' : ''; ?>>
+                        <label for="email_pref_reviews">Review requests</label>
+                    </div>
+                    <p class="setting-description">An occasional ask to leave a review on Capterra or share feedback directly.</p>
+
+                    <?php if ($is_license_holder): ?>
+                        <div class="review-note">
+                            <strong>Heads up:</strong> if you've purchased Argo Books, we may still ask you once for a review even with this off, since you're a paying customer. You can unsubscribe from that email itself when you receive it.
+                        </div>
+                    <?php endif; ?>
+
+                    <div class="checkbox">
+                        <input type="checkbox" id="email_pref_promotions" name="email_pref_promotions"
+                               <?php echo $prefs['email_pref_promotions'] ? 'checked' : ''; ?>>
+                        <label for="email_pref_promotions">Promotions &amp; offers</label>
+                    </div>
+                    <p class="setting-description">Discount codes and Premium upsells. Sent rarely.</p>
+
+                    <div class="checkbox">
+                        <input type="checkbox" id="email_pref_community_digest" name="email_pref_community_digest"
+                               <?php echo $prefs['email_pref_community_digest'] ? 'checked' : ''; ?>>
+                        <label for="email_pref_community_digest">Community digest</label>
+                    </div>
+                    <p class="setting-description">Replies to your community posts and comments, plus interesting activity.</p>
+                </div>
+
+                <div class="form-actions">
+                    <a href="profile.php" class="btn btn-black">Back to Profile</a>
+                    <button type="submit" class="btn btn-blue">Save Preferences</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <div id="includeFooter"></div>
+    </footer>
+</body>
+
+</html>

--- a/community/users/profile.php
+++ b/community/users/profile.php
@@ -595,6 +595,10 @@ if ($user) {
                                     <?= svg_icon('edit', 20, '', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
                                     Edit Account
                                 </a>
+                                <a href="email_preferences.php" class="btn btn-blue">
+                                    <?= svg_icon('mail', 20, '', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
+                                    Email Preferences
+                                </a>
                                 <a href="logout.php" class="btn btn-gray">Log Out</a>
                             <?php endif; ?>
                         </div>

--- a/community/users/register.css
+++ b/community/users/register.css
@@ -74,3 +74,17 @@ input {
 .form-group.invalid .validation-feedback {
   display: block;
 }
+
+/* Keep the checkbox box square and vertically centered against its label,
+   even when the label wraps on narrow viewports. */
+.auth-form .checkbox {
+  align-items: center;
+}
+
+.auth-form .checkbox input[type="checkbox"] {
+  flex-shrink: 0;
+}
+
+.auth-form .checkbox + .checkbox {
+  margin-top: 10px;
+}

--- a/community/users/register.php
+++ b/community/users/register.php
@@ -25,6 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = isset($_POST['password']) ? $_POST['password'] : '';
     $password_confirm = isset($_POST['password_confirm']) ? $_POST['password_confirm'] : '';
     $terms_agreed = isset($_POST['terms']);
+    $email_marketing_consent = isset($_POST['email_marketing']);
 
     // Define restricted terms for usernames
     $restricted_terms = ['argo', 'admin', 'moderator', 'mod', 'staff', 'support', 'system'];
@@ -64,7 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'You must agree to the terms and conditions';
     } else {
         // Attempt to register user
-        $result = register_user($username, $email, $password);
+        $result = register_user($username, $email, $password, $email_marketing_consent);
 
         if ($result['success']) {
             // Store user_id temporarily for verification
@@ -163,7 +164,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 <div class="checkbox">
                     <input type="checkbox" id="terms" name="terms" <?php echo isset($_POST['terms']) ? 'checked' : ''; ?> required>
-                    <label for="terms">I agree to the <a href="../../legal/terms.php" target="_blank" class="link-no-underline">terms and conditions</a></label>
+                    <label for="terms">I agree to the <a href="../../legal/terms.php" target="_blank" class="link-no-underline">terms of service</a></label>
+                </div>
+
+                <div class="checkbox">
+                    <input type="checkbox" id="email_marketing" name="email_marketing" <?php echo isset($_POST['email_marketing']) ? 'checked' : ''; ?>>
+                    <label for="email_marketing">Send me marketing emails (change anytime)</label>
                 </div>
 
                 <div class="form-actions">

--- a/community/users/register.php
+++ b/community/users/register.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($password !== $password_confirm) {
         $error = 'Passwords do not match';
     } elseif (!$terms_agreed) {
-        $error = 'You must agree to the terms and conditions';
+        $error = 'You must agree to the terms of service';
     } else {
         // Attempt to register user
         $result = register_user($username, $email, $password, $email_marketing_consent);

--- a/community/users/user_functions.php
+++ b/community/users/user_functions.php
@@ -10,6 +10,9 @@ namespace {
      * @param string $username Username
      * @param string $email Email address
      * @param string $password Plain text password
+     * @param bool $email_marketing_consent When true, opts the user in to all 5
+     *                                      email_pref_* marketing categories at
+     *                                      insert time. Defaults to false (off).
      * @return array Result with success, message, and user_id
      */
     function register_user($username, $email, $password, $email_marketing_consent = false)

--- a/community/users/user_functions.php
+++ b/community/users/user_functions.php
@@ -12,7 +12,7 @@ namespace {
      * @param string $password Plain text password
      * @return array Result with success, message, and user_id
      */
-    function register_user($username, $email, $password)
+    function register_user($username, $email, $password, $email_marketing_consent = false)
     {
         global $pdo;
 
@@ -36,11 +36,19 @@ namespace {
 
         $verification_code = generate_verification_code();
         $password_hash = password_hash($password, PASSWORD_DEFAULT);
+        $marketing = $email_marketing_consent ? 1 : 0;
 
-        // Insert new user
-        $stmt = $pdo->prepare('INSERT INTO community_users (username, email, password_hash, verification_code, email_verified)
-                         VALUES (?, ?, ?, ?, 0)');
-        $success = $stmt->execute([$username, $email, $password_hash, $verification_code]);
+        // Insert new user. Marketing prefs default to 0 in the schema; if the
+        // user ticked the signup checkbox, opt them in to all 5 categories.
+        $stmt = $pdo->prepare('INSERT INTO community_users
+                         (username, email, password_hash, verification_code, email_verified,
+                          email_pref_product_updates, email_pref_tips_onboarding,
+                          email_pref_reviews, email_pref_promotions, email_pref_community_digest)
+                         VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?)');
+        $success = $stmt->execute([
+            $username, $email, $password_hash, $verification_code,
+            $marketing, $marketing, $marketing, $marketing, $marketing
+        ]);
 
         if ($success) {
             $user_id = $pdo->lastInsertId();

--- a/email_marketing.php
+++ b/email_marketing.php
@@ -1,0 +1,231 @@
+<?php
+
+require_once __DIR__ . '/db_connect.php';
+require_once __DIR__ . '/email_sender.php';
+require_once __DIR__ . '/env_helper.php';
+
+/**
+ * Marketing email contexts that users can independently subscribe to.
+ * Maps context -> community_users.email_pref_<column>.
+ */
+function marketing_contexts(): array
+{
+    return [
+        'product_updates'   => 'email_pref_product_updates',
+        'tips_onboarding'   => 'email_pref_tips_onboarding',
+        'reviews'           => 'email_pref_reviews',
+        'promotions'        => 'email_pref_promotions',
+        'community_digest'  => 'email_pref_community_digest',
+    ];
+}
+
+/**
+ * Decide whether a marketing email may be sent to $email for $context.
+ *
+ * Rules (see plan: Send-time gate):
+ * - 'all_marketing' suppression always blocks.
+ * - For 'reviews' to a license-key holder: allow unless explicitly suppressed
+ *   for 'reviews' or 'all_marketing'. Community-user prefs are NOT consulted —
+ *   purchase establishes an existing business relationship for one ask.
+ * - For all other community-driven contexts (and reviews to non-license
+ *   holders): require an opted-in community_users row.
+ */
+function should_send_marketing_email(string $email, string $context): bool
+{
+    global $pdo;
+
+    $email = strtolower(trim($email));
+    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        return false;
+    }
+
+    $contexts = marketing_contexts();
+    if (!isset($contexts[$context])) {
+        return false;
+    }
+
+    // Hard block: blanket suppression
+    $stmt = $pdo->prepare("SELECT 1 FROM email_suppressions WHERE email = ? AND context = 'all_marketing' LIMIT 1");
+    $stmt->execute([$email]);
+    if ($stmt->fetchColumn()) {
+        return false;
+    }
+
+    // Per-context suppression
+    $stmt = $pdo->prepare('SELECT 1 FROM email_suppressions WHERE email = ? AND context = ? LIMIT 1');
+    $stmt->execute([$email, $context]);
+    if ($stmt->fetchColumn()) {
+        return false;
+    }
+
+    // Reviews path: license-key holder gets the ask by default
+    if ($context === 'reviews') {
+        $stmt = $pdo->prepare('SELECT 1 FROM license_keys WHERE email = ? LIMIT 1');
+        $stmt->execute([$email]);
+        if ($stmt->fetchColumn()) {
+            return true;
+        }
+    }
+
+    // Community-driven path: must have opted in via community account
+    $column = $contexts[$context];
+    $stmt = $pdo->prepare("SELECT $column FROM community_users WHERE email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $optedIn = $stmt->fetchColumn();
+
+    return $optedIn === 1 || $optedIn === '1';
+}
+
+/**
+ * Record that a marketing email was sent. Informational only — used for
+ * debugging "did this email get sent?" later.
+ */
+function mark_marketing_sent(string $email, string $context, ?int $relatedId = null): void
+{
+    global $pdo;
+    $stmt = $pdo->prepare('INSERT INTO email_marketing_log (email, context, related_id) VALUES (?, ?, ?)');
+    $stmt->execute([strtolower(trim($email)), $context, $relatedId]);
+}
+
+/**
+ * Lazily generate and persist a community-user unsubscribe token. Reused
+ * across all marketing emails to that user so unsubscribe links remain stable.
+ */
+function ensure_unsubscribe_token(int $userId): ?string
+{
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT email_pref_unsubscribe_token FROM community_users WHERE id = ?');
+    $stmt->execute([$userId]);
+    $existing = $stmt->fetchColumn();
+    if ($existing) {
+        return $existing;
+    }
+
+    $token = bin2hex(random_bytes(24));
+    $stmt = $pdo->prepare('UPDATE community_users SET email_pref_unsubscribe_token = ? WHERE id = ?');
+    $stmt->execute([$token, $userId]);
+    return $token;
+}
+
+/**
+ * Build the unsubscribe URL for a community-user-scoped marketing email.
+ */
+function community_user_unsubscribe_url(int $userId, string $context): ?string
+{
+    $token = ensure_unsubscribe_token($userId);
+    if (!$token) {
+        return null;
+    }
+    return site_url('/unsubscribe/marketing.php?u=' . urlencode($token) . '&c=' . urlencode($context));
+}
+
+/**
+ * Build the unsubscribe URL for a license-only marketing email (review/feedback).
+ * Generates and persists a per-license token if none exists yet.
+ */
+function license_unsubscribe_url(int $licenseId): ?string
+{
+    global $pdo;
+
+    $stmt = $pdo->prepare('SELECT review_email_token FROM license_keys WHERE id = ?');
+    $stmt->execute([$licenseId]);
+    $token = $stmt->fetchColumn();
+
+    if (!$token) {
+        $token = bin2hex(random_bytes(24));
+        $stmt = $pdo->prepare('UPDATE license_keys SET review_email_token = ? WHERE id = ?');
+        $stmt->execute([$token, $licenseId]);
+    }
+
+    return site_url('/unsubscribe/marketing.php?l=' . urlencode($token));
+}
+
+/**
+ * Send a review-request email to an active license-key holder.
+ * Returns true on success. Caller is responsible for marking the license row.
+ */
+function send_review_request_email(int $licenseId, string $email): bool
+{
+    if (!should_send_marketing_email($email, 'reviews')) {
+        return false;
+    }
+
+    $unsubscribe_url = license_unsubscribe_url($licenseId);
+    $review_url = site_url('/review/');
+    $unsubscribe_safe = htmlspecialchars($unsubscribe_url ?? '', ENT_QUOTES, 'UTF-8');
+    $review_safe = htmlspecialchars($review_url, ENT_QUOTES, 'UTF-8');
+
+    $body = <<<HTML
+        <h2>How is Argo Books working for you?</h2>
+        <p>Hey,</p>
+        <p>Thanks for being an Argo Books customer. If the app has helped your bookkeeping, I'd really appreciate a short review on Capterra — it's the single biggest thing that helps other small businesses find Argo.</p>
+        <p style="margin: 24px 0;">
+            <a href="{$review_safe}" class="btn-primary" style="background:#2563eb;color:#fff;padding:12px 20px;border-radius:6px;text-decoration:none;display:inline-block;">Leave a review</a>
+        </p>
+        <p>If something's getting in the way or you have feedback, just hit reply — I read every email.</p>
+        <p>&mdash; Evan, Argo Books</p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+        <p style="font-size:12px;color:#6b7280;">
+            You're receiving this because you purchased an Argo Books license.
+            <a href="{$unsubscribe_safe}">Unsubscribe</a>.
+        </p>
+        HTML;
+
+    $sent = send_styled_email(
+        $email,
+        'How is Argo Books working for you?',
+        $body,
+        'blue',
+        'noreply@argorobots.com',
+        'Evan at Argo Books',
+        'contact@argorobots.com'
+    );
+
+    if ($sent) {
+        mark_marketing_sent($email, 'reviews', $licenseId);
+    }
+    return $sent;
+}
+
+/**
+ * Send a feedback-request email to an inactive license-key holder.
+ * Asks them to reply with what's getting in the way.
+ */
+function send_feedback_request_email(int $licenseId, string $email): bool
+{
+    if (!should_send_marketing_email($email, 'reviews')) {
+        return false;
+    }
+
+    $unsubscribe_url = license_unsubscribe_url($licenseId);
+    $unsubscribe_safe = htmlspecialchars($unsubscribe_url ?? '', ENT_QUOTES, 'UTF-8');
+
+    $body = <<<HTML
+        <h2>Quick check-in on Argo Books</h2>
+        <p>Hey,</p>
+        <p>I noticed it's been a little while since you used Argo Books. I wanted to check in — was there something that didn't work for you, or that's missing?</p>
+        <p>Just reply to this email and let me know. Anything you tell me goes straight to me, and it genuinely helps me decide what to build next.</p>
+        <p>You can also email me directly at <a href="mailto:contact@argorobots.com">contact@argorobots.com</a>.</p>
+        <p>&mdash; Evan, Argo Books</p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+        <p style="font-size:12px;color:#6b7280;">
+            You're receiving this because you purchased an Argo Books license.
+            <a href="{$unsubscribe_safe}">Unsubscribe</a>.
+        </p>
+        HTML;
+
+    $sent = send_styled_email(
+        $email,
+        'Quick check-in on Argo Books',
+        $body,
+        'blue',
+        'noreply@argorobots.com',
+        'Evan at Argo Books',
+        'contact@argorobots.com'
+    );
+
+    if ($sent) {
+        mark_marketing_sent($email, 'reviews', $licenseId);
+    }
+    return $sent;
+}

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -12,7 +12,11 @@ CREATE TABLE IF NOT EXISTS license_keys (
     order_id VARCHAR(100),
     payment_method VARCHAR(50),
     payment_intent VARCHAR(100),
-    INDEX idx_license_keys_user_id (user_id)
+    review_email_sent_at DATETIME DEFAULT NULL,
+    review_email_variant VARCHAR(20) DEFAULT NULL COMMENT 'active, inactive, or manually_skipped',
+    review_email_token CHAR(48) DEFAULT NULL,
+    INDEX idx_license_keys_user_id (user_id),
+    UNIQUE KEY uk_review_email_token (review_email_token)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin users table
@@ -48,7 +52,14 @@ CREATE TABLE IF NOT EXISTS community_users (
     last_login DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deletion_scheduled_at DATETIME DEFAULT NULL
+    deletion_scheduled_at DATETIME DEFAULT NULL,
+    email_pref_product_updates BOOLEAN NOT NULL DEFAULT 0,
+    email_pref_tips_onboarding BOOLEAN NOT NULL DEFAULT 0,
+    email_pref_reviews BOOLEAN NOT NULL DEFAULT 0,
+    email_pref_promotions BOOLEAN NOT NULL DEFAULT 0,
+    email_pref_community_digest BOOLEAN NOT NULL DEFAULT 0,
+    email_pref_unsubscribe_token CHAR(48) DEFAULT NULL,
+    UNIQUE KEY uk_email_pref_unsubscribe_token (email_pref_unsubscribe_token)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Create posts table
@@ -602,6 +613,14 @@ CREATE TABLE IF NOT EXISTS outreach_leads (
 --     MODIFY COLUMN status ENUM('new','draft_generated','awaiting_approval','approved','contacted','replied','interested','not_interested','onboarded','email_bounced') DEFAULT 'new';
 
 -- Email suppression list (unsubscribes, opt-outs across all email contexts)
+-- Known context values:
+--   'outreach'           - cold outreach campaign
+--   'reviews'            - review-request emails to license-key holders
+--   'product_updates'    - release notes / feature announcements
+--   'tips_onboarding'    - how-to / getting-started nudges
+--   'promotions'         - discount codes / upsells
+--   'community_digest'   - replies / activity digest
+--   'all_marketing'      - blanket suppression of all marketing contexts
 CREATE TABLE IF NOT EXISTS email_suppressions (
     id INT PRIMARY KEY AUTO_INCREMENT,
     email VARCHAR(255) NOT NULL,
@@ -611,6 +630,17 @@ CREATE TABLE IF NOT EXISTS email_suppressions (
     suppressed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY unique_email_context (email, context),
     INDEX idx_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Log of marketing emails actually sent (for debugging and de-duplication)
+CREATE TABLE IF NOT EXISTS email_marketing_log (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    email VARCHAR(255) NOT NULL,
+    context VARCHAR(50) NOT NULL,
+    sent_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    related_id INT DEFAULT NULL COMMENT 'license_keys.id for review emails, etc.',
+    INDEX idx_email_context (email, context),
+    INDEX idx_sent_at (sent_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Activity log for outreach leads

--- a/unsubscribe/marketing.php
+++ b/unsubscribe/marketing.php
@@ -1,0 +1,228 @@
+<?php
+require_once __DIR__ . '/../resources/icons.php';
+require_once __DIR__ . '/../db_connect.php';
+require_once __DIR__ . '/../email_marketing.php';
+
+$state = 'invalid';
+$displayName = '';
+$resubscribeUrl = '';
+$category_label = '';
+
+$tokenUser = isset($_GET['u']) ? trim($_GET['u']) : '';
+$tokenLicense = isset($_GET['l']) ? trim($_GET['l']) : '';
+$rawContext = isset($_GET['c']) ? trim($_GET['c']) : 'all';
+$isUndo = isset($_GET['undo']) && $_GET['undo'] === '1';
+
+$context_labels = [
+    'product_updates'  => 'product updates',
+    'tips_onboarding'  => 'tips & onboarding',
+    'reviews'          => 'review requests',
+    'promotions'       => 'promotions & offers',
+    'community_digest' => 'community digest',
+    'all'              => 'all marketing emails',
+];
+$contexts = marketing_contexts();
+
+try {
+    if ($tokenUser !== '' && preg_match('/^[a-f0-9]{24,128}$/', $tokenUser)) {
+        // Community-user-scoped flow
+        $context = isset($context_labels[$rawContext]) ? $rawContext : 'all';
+        $category_label = $context_labels[$context];
+
+        $stmt = $pdo->prepare('SELECT id, username, email FROM community_users WHERE email_pref_unsubscribe_token = ? LIMIT 1');
+        $stmt->execute([$tokenUser]);
+        $user = $stmt->fetch();
+
+        if ($user) {
+            $displayName = $user['username'];
+            $email = strtolower(trim($user['email']));
+            $resubscribeUrl = '/unsubscribe/marketing.php?u=' . urlencode($tokenUser) . '&c=' . urlencode($context);
+
+            // Build the list of pref columns we'll touch.
+            $columns = ($context === 'all') ? array_values($contexts) : [$contexts[$context]];
+
+            if ($isUndo) {
+                // Re-subscribe: flip prefs back on, drop suppressions
+                $assignments = implode(', ', array_map(fn($c) => "$c = 1", $columns));
+                $stmt = $pdo->prepare("UPDATE community_users SET $assignments WHERE id = ?");
+                $stmt->execute([$user['id']]);
+
+                $deleteContexts = ($context === 'all')
+                    ? array_merge(array_keys($contexts), ['all_marketing'])
+                    : [$context, 'all_marketing'];
+                $placeholders = implode(',', array_fill(0, count($deleteContexts), '?'));
+                $stmt = $pdo->prepare("DELETE FROM email_suppressions WHERE email = ? AND context IN ($placeholders)");
+                $stmt->execute(array_merge([$email], $deleteContexts));
+
+                $state = 'resubscribed';
+            } else {
+                // Unsubscribe
+                $assignments = implode(', ', array_map(fn($c) => "$c = 0", $columns));
+                $stmt = $pdo->prepare("UPDATE community_users SET $assignments WHERE id = ?");
+                $stmt->execute([$user['id']]);
+
+                $insertContexts = ($context === 'all') ? ['all_marketing'] : [$context];
+                $alreadySuppressed = true;
+                foreach ($insertContexts as $ctx) {
+                    $check = $pdo->prepare('SELECT 1 FROM email_suppressions WHERE email = ? AND context = ? LIMIT 1');
+                    $check->execute([$email, $ctx]);
+                    if (!$check->fetchColumn()) {
+                        $alreadySuppressed = false;
+                        $ins = $pdo->prepare('INSERT INTO email_suppressions (email, context, reason, source_id) VALUES (?, ?, ?, ?)');
+                        $ins->execute([$email, $ctx, 'one-click unsubscribe (community user)', $user['id']]);
+                    }
+                }
+
+                $state = $alreadySuppressed ? 'already_unsubscribed' : 'unsubscribed';
+            }
+        }
+    } elseif ($tokenLicense !== '' && preg_match('/^[a-f0-9]{24,128}$/', $tokenLicense)) {
+        // License-only flow (review/feedback emails)
+        $category_label = 'all marketing emails';
+
+        $stmt = $pdo->prepare('SELECT id, email FROM license_keys WHERE review_email_token = ? LIMIT 1');
+        $stmt->execute([$tokenLicense]);
+        $license = $stmt->fetch();
+
+        if ($license) {
+            $email = strtolower(trim($license['email']));
+            $resubscribeUrl = '/unsubscribe/marketing.php?l=' . urlencode($tokenLicense);
+
+            if ($isUndo) {
+                $stmt = $pdo->prepare("DELETE FROM email_suppressions WHERE email = ? AND context IN ('reviews','all_marketing')");
+                $stmt->execute([$email]);
+                $state = 'resubscribed';
+            } else {
+                $alreadySuppressed = true;
+                foreach (['reviews', 'all_marketing'] as $ctx) {
+                    $check = $pdo->prepare('SELECT 1 FROM email_suppressions WHERE email = ? AND context = ? LIMIT 1');
+                    $check->execute([$email, $ctx]);
+                    if (!$check->fetchColumn()) {
+                        $alreadySuppressed = false;
+                        $ins = $pdo->prepare('INSERT INTO email_suppressions (email, context, reason, source_id) VALUES (?, ?, ?, ?)');
+                        $ins->execute([$email, $ctx, 'one-click unsubscribe (license holder)', $license['id']]);
+                    }
+                }
+                $state = $alreadySuppressed ? 'already_unsubscribed' : 'unsubscribed';
+            }
+        }
+    }
+} catch (Exception $e) {
+    error_log('Marketing unsubscribe error: ' . $e->getMessage());
+    $state = 'invalid';
+}
+
+$titles = [
+    'unsubscribed'         => "You've been unsubscribed",
+    'already_unsubscribed' => 'Already unsubscribed',
+    'resubscribed'         => 'Welcome back',
+    'invalid'              => 'Link expired',
+];
+$title = $titles[$state];
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Manage your Argo Books email preferences.">
+  <meta name="author" content="Argo">
+  <meta name="robots" content="noindex, nofollow">
+
+  <link rel="shortcut icon" type="image/x-icon" href="../resources/images/argo-logo/argo-icon.ico">
+  <title>Argo Books - <?= htmlspecialchars($title) ?></title>
+
+  <script src="../resources/scripts/jquery-3.6.0.js"></script>
+  <script src="../resources/scripts/main.js"></script>
+
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../resources/styles/custom-colors.css">
+  <link rel="stylesheet" href="../resources/header/style.css">
+  <link rel="stylesheet" href="../resources/header/dark.css">
+  <link rel="stylesheet" href="../resources/footer/style.css">
+</head>
+
+<body>
+  <header>
+    <div id="includeHeader"></div>
+  </header>
+  <main>
+    <section class="first">
+      <div class="success-container state-<?= htmlspecialchars($state) ?>">
+        <div class="success-icon">
+          <?php if ($state === 'unsubscribed' || $state === 'already_unsubscribed'): ?>
+            <?= svg_icon('circle-check', null, '', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
+          <?php elseif ($state === 'resubscribed'): ?>
+            <?= svg_icon('refresh', null, '', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
+          <?php else: ?>
+            <?= svg_icon('x', null, '', null, 'stroke-linecap="round" stroke-linejoin="round"') ?>
+          <?php endif; ?>
+        </div>
+
+        <div class="success-content">
+          <h1><?= htmlspecialchars($title) ?></h1>
+
+          <?php if ($state === 'unsubscribed'): ?>
+            <p class="success-message">
+              <?php if ($displayName): ?>
+                <strong><?= htmlspecialchars($displayName) ?></strong>, you won't receive <?= htmlspecialchars($category_label) ?> from Argo Books.
+              <?php else: ?>
+                You won't receive <?= htmlspecialchars($category_label) ?> from Argo Books.
+              <?php endif; ?>
+              We'll still send transactional emails (receipts, password resets, etc.) since those are required for your account.
+            </p>
+
+            <div class="action-buttons">
+              <a href="/" class="btn primary-btn">Visit Argo Books</a>
+            </div>
+
+            <p class="undo-line">
+              Clicked by mistake? <a href="<?= htmlspecialchars($resubscribeUrl) ?>&amp;undo=1">Re-subscribe</a>
+            </p>
+
+          <?php elseif ($state === 'already_unsubscribed'): ?>
+            <p class="success-message">
+              You're already unsubscribed from <?= htmlspecialchars($category_label) ?>.
+            </p>
+
+            <div class="action-buttons">
+              <a href="/" class="btn primary-btn">Visit Argo Books</a>
+            </div>
+
+            <p class="undo-line">
+              Changed your mind? <a href="<?= htmlspecialchars($resubscribeUrl) ?>&amp;undo=1">Re-subscribe</a>
+            </p>
+
+          <?php elseif ($state === 'resubscribed'): ?>
+            <p class="success-message">
+              Welcome back. We'll start sending <?= htmlspecialchars($category_label) ?> again. You can change this anytime in your email preferences.
+            </p>
+
+            <div class="action-buttons">
+              <a href="/" class="btn primary-btn">Visit Argo Books</a>
+              <a href="<?= htmlspecialchars($resubscribeUrl) ?>" class="btn secondary-btn">Unsubscribe again</a>
+            </div>
+
+          <?php else: ?>
+            <p class="success-message">
+              This unsubscribe link is invalid or has expired. If you'd like to manage your email preferences, log in to your community account and visit the email preferences page, or reply to any email from us and we'll handle it.
+            </p>
+
+            <div class="action-buttons">
+              <a href="/" class="btn primary-btn">Visit Argo Books</a>
+              <a href="/contact-us" class="btn secondary-btn">Contact Support</a>
+            </div>
+          <?php endif; ?>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div id="includeFooter"></div>
+  </footer>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

- Self-service email preferences page for community users + unchecked signup checkbox
- Admin **Reviews** tab that batches license-key customers (30+ days post-purchase) into active vs inactive and sends a Capterra review ask or a "what's getting in the way?" feedback ask, with per-row Skip and token-based unsubscribe
- New `should_send_marketing_email()` gate in `email_marketing.php` that all future marketing senders must route through

## Design notes

- Transactional email (verification, receipts, password resets, license delivery, renewal/payment-failed, deletion warnings) stays always-on, explained on the prefs page
- License-customer review emails are **decoupled** from community-account marketing prefs, so an unchecked-by-default signup doesn't silently block review asks. Suppression for those is governed by `email_suppressions`; per-user marketing prefs cover product_updates / tips_onboarding / promotions / community_digest, plus reviews for non-license-holders
- All marketing categories share unsubscribe infrastructure even though only the review/feedback senders are wired up in this PR — schema, prefs UI, and gate are ready for the others

## Schema (run as ALTER on existing DBs)

```sql
ALTER TABLE community_users
  ADD COLUMN email_pref_product_updates    BOOLEAN NOT NULL DEFAULT 0,
  ADD COLUMN email_pref_tips_onboarding    BOOLEAN NOT NULL DEFAULT 0,
  ADD COLUMN email_pref_reviews            BOOLEAN NOT NULL DEFAULT 0,
  ADD COLUMN email_pref_promotions         BOOLEAN NOT NULL DEFAULT 0,
  ADD COLUMN email_pref_community_digest   BOOLEAN NOT NULL DEFAULT 0,
  ADD COLUMN email_pref_unsubscribe_token  CHAR(48) DEFAULT NULL,
  ADD UNIQUE KEY uk_email_pref_unsubscribe_token (email_pref_unsubscribe_token);

ALTER TABLE license_keys
  ADD COLUMN review_email_sent_at  DATETIME DEFAULT NULL,
  ADD COLUMN review_email_variant  VARCHAR(20) DEFAULT NULL,
  ADD COLUMN review_email_token    CHAR(48) DEFAULT NULL,
  ADD UNIQUE KEY uk_review_email_token (review_email_token);

CREATE TABLE IF NOT EXISTS email_marketing_log (
    id INT PRIMARY KEY AUTO_INCREMENT,
    email VARCHAR(255) NOT NULL,
    context VARCHAR(50) NOT NULL,
    sent_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    related_id INT DEFAULT NULL,
    INDEX idx_email_context (email, context),
    INDEX idx_sent_at (sent_at)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

## Test plan

- [x] Run the ALTER/CREATE statements above against the dev DB
- [ ] Register a new account without ticking the marketing checkbox — confirm all 5 \`email_pref_*\` columns are 0
- [ ] Register another with the box ticked — all 5 should be 1
- [ ] Open \`/community/users/email_preferences.php\` while logged in — toggle and save a couple of boxes, reload, verify DB matches
- [ ] Seed two license keys (\`created_at\` 35+ days ago: one with a recent \`receipt_scan_usage\` row, one without) — open \`/admin/reviews/\`, confirm split is correct, send to both, verify MailHog receives the right templates
- [ ] Click the unsubscribe link in a test review email — verify \`email_suppressions\` rows for \`reviews\` + \`all_marketing\` get inserted; resubscribe link removes them
- [ ] Confirm a license that's already been emailed no longer appears in the admin list
- [x] Verify dark theme on the admin Reviews page