### PR TITLE
Add PHPUnit test suite for licensing, payments, crypto, renewals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ reset_admin_password.php
 /api/invoice/logs/*.log
 /api/invoice/logs/*.json
 /resources/rate_limits/
+.phpunit.cache/
+.phpunit.result.cache
+/tests/coverage/

--- a/_email_helpers.php
+++ b/_email_helpers.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Strip CR/LF and the rest of the ASCII control range from any value that
+ * ends up in an email header. PHPMailer sanitizes its own header inputs,
+ * but the mail() fallback path in send_styled_email() concatenates these
+ * into the headers string verbatim — a stray newline would let an attacker
+ * inject Bcc/Cc/etc. via user-controlled fields (subject lines from
+ * community posts, contact-form reply-to, etc.).
+ *
+ * Returns null for null input so callers can pass through optional fields.
+ */
+function sanitize_header_value(?string $value): ?string
+{
+    if ($value === null) {
+        return null;
+    }
+    return preg_replace('/[\r\n\x00-\x1f]+/', ' ', $value);
+}

--- a/api/portal/webhooks/_square_helpers.php
+++ b/api/portal/webhooks/_square_helpers.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Verify a Square webhook HMAC-SHA256 signature.
+ *
+ * Square signs the concatenation of the notification URL and the raw request
+ * body using the configured signature key. The signature header is the
+ * base64-encoded HMAC-SHA256 of that string.
+ *
+ * Returns false (rather than throwing) for missing/empty key or signature so
+ * the caller can decide on the appropriate HTTP response code.
+ */
+function verify_square_webhook_signature(
+    string $notificationUrl,
+    string $payload,
+    string $signatureKey,
+    string $providedSignature
+): bool {
+    if ($signatureKey === '' || $providedSignature === '') {
+        return false;
+    }
+    $stringToSign = $notificationUrl . $payload;
+    $expectedSignature = base64_encode(hash_hmac('sha256', $stringToSign, $signatureKey, true));
+    return hash_equals($expectedSignature, $providedSignature);
+}

--- a/api/portal/webhooks/_stripe_refund_db.php
+++ b/api/portal/webhooks/_stripe_refund_db.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Apply a Stripe refund to the portal payments / invoices tables.
+ *
+ * Extracted from api/portal/webhooks/stripe.php so the DB-only side of the
+ * refund flow can be exercised without standing up a Stripe webhook test
+ * harness. The caller (the webhook handler) still owns extraction of the
+ * refund amount from the SDK Charge object — currency-divisor logic stays
+ * out of this function.
+ *
+ * Steps:
+ *   1. Find the original completed payment row by provider_payment_id.
+ *   2. Insert a negative payment row marked status=refunded
+ *      (uses provider_payment_id 'refund_' . $providerPaymentId so the
+ *       INSERT ... ON DUPLICATE KEY UPDATE in record_portal_payment() makes
+ *       repeated refund webhooks idempotent).
+ *   3. Flip the original payment row to status=refunded.
+ *   4. Bump invoice.balance_due by the refund amount, capped at total_amount;
+ *      flip status back to 'sent' once fully refunded, else 'partial'.
+ *
+ * Returns false when no matching completed original payment exists; true
+ * after all four steps run.
+ */
+function apply_stripe_refund_to_db(
+    PDO $pdo,
+    string $providerPaymentId,
+    float $refundAmount,
+    string $chargeId,
+    bool $isProduction
+): bool {
+    $stmt = $pdo->prepare(
+        'SELECT id, company_id, invoice_id, customer_name, currency
+         FROM portal_payments
+         WHERE provider_payment_id = ? AND status = "completed"
+         LIMIT 1'
+    );
+    $stmt->execute([$providerPaymentId]);
+    $originalPayment = $stmt->fetch();
+
+    if (!$originalPayment) {
+        return false;
+    }
+
+    record_portal_payment([
+        'company_id' => $originalPayment['company_id'],
+        'invoice_id' => $originalPayment['invoice_id'],
+        'customer_name' => $originalPayment['customer_name'],
+        'amount' => -$refundAmount,
+        'currency' => $originalPayment['currency'],
+        'payment_method' => 'stripe',
+        'provider_payment_id' => 'refund_' . $providerPaymentId,
+        'provider_transaction_id' => $chargeId,
+        'reference_number' => generate_reference_number(),
+        'status' => 'refunded',
+        'payment_environment' => $isProduction ? 'production' : 'sandbox',
+    ]);
+
+    $stmt = $pdo->prepare(
+        'UPDATE portal_payments SET status = "refunded" WHERE id = ?'
+    );
+    $stmt->execute([$originalPayment['id']]);
+
+    $stmt = $pdo->prepare(
+        'UPDATE portal_invoices
+         SET balance_due = LEAST(total_amount, balance_due + ?),
+             status = CASE
+                 WHEN balance_due + ? >= total_amount THEN "sent"
+                 ELSE "partial"
+             END,
+             updated_at = NOW()
+         WHERE company_id = ? AND invoice_id = ?'
+    );
+    $stmt->execute([
+        $refundAmount, $refundAmount,
+        $originalPayment['company_id'], $originalPayment['invoice_id']
+    ]);
+
+    return true;
+}

--- a/api/portal/webhooks/_stripe_refund_db.php
+++ b/api/portal/webhooks/_stripe_refund_db.php
@@ -22,6 +22,14 @@ declare(strict_types=1);
  *
  * Returns false when no matching completed original payment exists; true
  * after all four steps run.
+ *
+ * NOTE on the $pdo parameter: $pdo is used for the SELECT/UPDATE statements
+ * inside this function, but the call to record_portal_payment() reaches for
+ * `global $pdo` independently. Callers MUST ensure $GLOBALS['pdo'] points
+ * at the same connection passed in (production code does this via
+ * db_connect.php; tests do it via tests/bootstrap.php). Passing a different
+ * PDO would cause the negative-payment INSERT to land on a different
+ * connection than the rest of this function — don't do that.
  */
 function apply_stripe_refund_to_db(
     PDO $pdo,

--- a/api/portal/webhooks/square.php
+++ b/api/portal/webhooks/square.php
@@ -9,6 +9,7 @@
  */
 
 require_once __DIR__ . '/../portal-helper.php';
+require_once __DIR__ . '/_square_helpers.php';
 
 // Only allow POST
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -35,10 +36,7 @@ if (empty($signature)) {
 }
 
 $notificationUrl = site_url('/api/portal/webhooks/square');
-$stringToSign = $notificationUrl . $payload;
-$expectedSignature = base64_encode(hash_hmac('sha256', $stringToSign, $webhookSignatureKey, true));
-
-if (!hash_equals($expectedSignature, $signature)) {
+if (!verify_square_webhook_signature($notificationUrl, $payload, $webhookSignatureKey, $signature)) {
     error_log('Portal Square webhook: Invalid signature');
     http_response_code(400);
     exit;

--- a/api/portal/webhooks/stripe.php
+++ b/api/portal/webhooks/stripe.php
@@ -12,6 +12,7 @@
 
 require_once __DIR__ . '/../portal-helper.php';
 require_once __DIR__ . '/../../../vendor/autoload.php';
+require_once __DIR__ . '/_stripe_refund_db.php';
 
 // Only allow POST
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -113,69 +114,29 @@ function handle_payment_succeeded(\Stripe\PaymentIntent $paymentIntent): void
  */
 function handle_refund(\Stripe\Charge $charge): void
 {
-    global $is_production;
+    global $is_production, $pdo;
     $providerPaymentId = $charge->payment_intent;
 
     if (empty($providerPaymentId)) {
         return;
     }
 
-    global $pdo;
-
-    // Find the original payment
+    // Currency divisor logic stays here because it depends on the SDK Charge.
+    // Use the original payment's currency (already stored in our DB) so refunds
+    // honour the exact currency used at capture time even if Stripe normalised.
     $stmt = $pdo->prepare(
-        'SELECT id, company_id, invoice_id, customer_name, currency
-         FROM portal_payments
-         WHERE provider_payment_id = ? AND status = "completed"
-         LIMIT 1'
+        'SELECT currency FROM portal_payments
+         WHERE provider_payment_id = ? AND status = "completed" LIMIT 1'
     );
     $stmt->execute([$providerPaymentId]);
-    $originalPayment = $stmt->fetch();
-
-    if (!$originalPayment) {
+    $row = $stmt->fetch();
+    if (!$row) {
         return;
     }
-
-    // Calculate refund amount
-    $refundCurrency = strtoupper($originalPayment['currency'] ?? 'USD');
+    $refundCurrency = strtoupper($row['currency'] ?? 'USD');
     $zeroDecimalCurrencies = ['BIF','CLP','DJF','GNF','JPY','KMF','KRW','MGA','PYG','RWF','UGX','VND','VUV','XAF','XOF','XPF'];
     $divisor = in_array($refundCurrency, $zeroDecimalCurrencies) ? 1 : 100;
     $refundAmount = $charge->amount_refunded / $divisor;
 
-    // Record the refund as a negative payment
-    record_portal_payment([
-        'company_id' => $originalPayment['company_id'],
-        'invoice_id' => $originalPayment['invoice_id'],
-        'customer_name' => $originalPayment['customer_name'],
-        'amount' => -$refundAmount,
-        'currency' => $originalPayment['currency'],
-        'payment_method' => 'stripe',
-        'provider_payment_id' => 'refund_' . $providerPaymentId,
-        'provider_transaction_id' => $charge->id,
-        'reference_number' => generate_reference_number(),
-        'status' => 'refunded',
-        'payment_environment' => $is_production ? 'production' : 'sandbox',
-    ]);
-
-    // Update the original payment status
-    $stmt = $pdo->prepare(
-        'UPDATE portal_payments SET status = "refunded" WHERE id = ?'
-    );
-    $stmt->execute([$originalPayment['id']]);
-
-    // Update invoice balance (add refund amount back)
-    $stmt = $pdo->prepare(
-        'UPDATE portal_invoices
-         SET balance_due = LEAST(total_amount, balance_due + ?),
-             status = CASE
-                 WHEN balance_due + ? >= total_amount THEN "sent"
-                 ELSE "partial"
-             END,
-             updated_at = NOW()
-         WHERE company_id = ? AND invoice_id = ?'
-    );
-    $stmt->execute([
-        $refundAmount, $refundAmount,
-        $originalPayment['company_id'], $originalPayment['invoice_id']
-    ]);
+    apply_stripe_refund_to_db($pdo, $providerPaymentId, $refundAmount, $charge->id, $is_production);
 }

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,11 @@
         "square/square": "^42.1",
         "vlucas/phpdotenv": "^5.6",
         "phpmailer/phpmailer": "^6.9"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "11"
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\": "tests/" }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "026bff7b35e21979ac4c498ae8fd774e",
+    "content-hash": "496b7ca15497a5758fa555fb80255530",
     "packages": [
         {
             "name": "apimatic/core",
@@ -1672,13 +1672,1733 @@
             "time": "2025-12-27T19:49:13+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "ece3536c22fc5113906a42e7e82de00baaef36d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ece3536c22fc5113906a42e7e82de00baaef36d0",
+                "reference": "ece3536c22fc5113906a42e7e82de00baaef36d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0",
+                "phpunit/php-file-iterator": "^5.0",
+                "phpunit/php-invoker": "^5.0",
+                "phpunit/php-text-template": "^4.0",
+                "phpunit/php-timer": "^7.0",
+                "sebastian/cli-parser": "^3.0",
+                "sebastian/code-unit": "^3.0",
+                "sebastian/comparator": "^6.0",
+                "sebastian/diff": "^6.0",
+                "sebastian/environment": "^7.0",
+                "sebastian/exporter": "^6.0",
+                "sebastian/global-state": "^7.0",
+                "sebastian/object-enumerator": "^6.0",
+                "sebastian/type": "^5.0",
+                "sebastian/version": "^5.0"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-02T06:12:57+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/cron/_renewal_helpers.php
+++ b/cron/_renewal_helpers.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pure helpers extracted from subscription_renewal.php so the renewal logic
+ * can be exercised without running the cron's top-level dispatch loop.
+ *
+ * - calculateNewEndDate: date math with a "stale end_date" guard
+ * - decide_renewal_charge: credit-balance decision tree returning the
+ *   billed amount including the processing fee
+ * - recently_renewed: 23-hour idempotency guard against double-charges
+ */
+
+require_once __DIR__ . '/../config/pricing.php';
+
+/**
+ * Calculate new subscription end date.
+ *
+ * Bases the new period on the LATER of the existing end_date or NOW(). When a
+ * cron run is delayed and end_date is already in the past, extending from the
+ * stale end_date can leave the new end_date still in the past — causing the
+ * subscription to be picked up again and re-charged on the next run.
+ */
+function calculateNewEndDate($currentEndDate, $billing) {
+    $endDateTime = new DateTime($currentEndDate);
+    $now = new DateTime('now');
+    if ($endDateTime < $now) {
+        $endDateTime = $now;
+    }
+
+    if ($billing === 'yearly') {
+        $endDateTime->add(new DateInterval('P1Y'));
+    } else {
+        $endDateTime->add(new DateInterval('P1M'));
+    }
+
+    return $endDateTime->format('Y-m-d H:i:s');
+}
+
+/**
+ * Decide how much to charge for a renewal given the customer's credit balance.
+ *
+ * Returns:
+ *   useCredit       — true only when credit fully covers the renewal
+ *   creditUsed      — amount of credit consumed (0 when no credit)
+ *   baseAmount      — pre-fee renewal price for the billing cycle
+ *   amountToCharge  — final amount to charge the card, INCLUDING the
+ *                     processing fee. 0 when fully credit-covered.
+ *
+ * The processing fee is intentionally added inside this helper so the call
+ * site reflects the same one-shot decision the cron already makes — the
+ * single source of truth for "what does the card see this cycle?".
+ */
+function decide_renewal_charge(float $creditBalance, string $billing, array $pricingConfig): array
+{
+    $baseAmount = ($billing === 'yearly')
+        ? (float) $pricingConfig['premium_yearly_price']
+        : (float) $pricingConfig['premium_monthly_price'];
+
+    $useCredit = false;
+    $creditUsed = 0.0;
+    $amountToCharge = $baseAmount;
+
+    if ($creditBalance > 0) {
+        if ($creditBalance >= $baseAmount) {
+            $useCredit = true;
+            $creditUsed = $baseAmount;
+            $amountToCharge = 0.0;
+        } else {
+            $creditUsed = $creditBalance;
+            $amountToCharge = $baseAmount - $creditBalance;
+        }
+    }
+
+    if ($amountToCharge > 0) {
+        $amountToCharge += calculate_processing_fee($amountToCharge);
+    }
+
+    return [
+        'useCredit' => $useCredit,
+        'creditUsed' => $creditUsed,
+        'baseAmount' => $baseAmount,
+        'amountToCharge' => $amountToCharge,
+    ];
+}
+
+/**
+ * Idempotency guard for the renewal cron: returns true if a successful
+ * renewal payment has already landed for this subscription within the last
+ * 23 hours. Protects against double-charges when the cron fires twice
+ * (overlapping runs, manual retries, accidental re-invokes).
+ */
+function recently_renewed(PDO $pdo, string $subscriptionId): bool
+{
+    $stmt = $pdo->prepare(
+        "SELECT 1 FROM premium_subscription_payments
+         WHERE subscription_id = ?
+           AND status = 'completed'
+           AND payment_type = 'renewal'
+           AND created_at > DATE_SUB(NOW(), INTERVAL 23 HOUR)
+         LIMIT 1"
+    );
+    $stmt->execute([$subscriptionId]);
+    return $stmt->fetch() !== false;
+}

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/../config/pricing.php';
 
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../email_sender.php';
+require_once __DIR__ . '/_renewal_helpers.php';
 
 // Configure logging
 function logMessage($message, $type = 'INFO') {
@@ -122,36 +123,19 @@ foreach ($subscriptions as $subscription) {
 
     logMessage("Processing renewal for subscription: $subscriptionId (User: $userId, Method: $paymentMethod, Credit: $$creditBalance)");
 
-    // Calculate renewal amount from centralized config
+    // Decide credit/charge split (and add processing fee). Single source of
+    // truth lives in cron/_renewal_helpers.php so it can be unit-tested.
     $pricingConfig = get_pricing_config();
-    $baseMonthly = $pricingConfig['premium_monthly_price'];
-    $baseYearly = $pricingConfig['premium_yearly_price'];
-    $amount = ($billing === 'yearly') ? $baseYearly : $baseMonthly;
+    $decision = decide_renewal_charge((float) $creditBalance, $billing, $pricingConfig);
+    $useCredit = $decision['useCredit'];
+    $creditUsed = $decision['creditUsed'];
+    $amount = $decision['baseAmount'];
+    $amountToCharge = $decision['amountToCharge'];
 
-    // Check if renewal can be covered by credit
-    $useCredit = false;
-    $creditUsed = 0;
-    $amountToCharge = $amount;
-
-    if ($creditBalance > 0) {
-        if ($creditBalance >= $amount) {
-            // Full renewal covered by credit - no charge needed
-            $useCredit = true;
-            $creditUsed = $amount;
-            $amountToCharge = 0;
-            logMessage("Renewal for $subscriptionId covered by credit balance ($$creditBalance)");
-        } else {
-            // Partial credit - charge the difference
-            $creditUsed = $creditBalance;
-            $amountToCharge = $amount - $creditBalance;
-            logMessage("Partial credit ($$creditBalance) applied for $subscriptionId, charging $$amountToCharge");
-        }
-    }
-
-    // Add processing fee on the amount actually charged to the card
-    if ($amountToCharge > 0) {
-        $processingFee = calculate_processing_fee($amountToCharge);
-        $amountToCharge += $processingFee;
+    if ($useCredit) {
+        logMessage("Renewal for $subscriptionId covered by credit balance ($$creditBalance)");
+    } elseif ($creditUsed > 0) {
+        logMessage("Partial credit ($$creditBalance) applied for $subscriptionId, charging $$amountToCharge");
     }
 
     // Skip payment processing if fully covered by credit
@@ -203,20 +187,9 @@ foreach ($subscriptions as $subscription) {
     $transactionId = null;
 
     try {
-        // Idempotency guard: if a successful renewal payment already exists for
-        // this subscription within the last 23 hours, skip — this prevents a
-        // double-charge if the cron is fired twice (overlapping runs, retry,
-        // accidental re-invoke).
-        $stmt = $pdo->prepare("
-            SELECT 1 FROM premium_subscription_payments
-            WHERE subscription_id = ?
-              AND status = 'completed'
-              AND payment_type = 'renewal'
-              AND created_at > DATE_SUB(NOW(), INTERVAL 23 HOUR)
-            LIMIT 1
-        ");
-        $stmt->execute([$subscriptionId]);
-        if ($stmt->fetch()) {
+        // Idempotency guard against double-charges (overlapping cron runs,
+        // manual retries). Single source of truth in _renewal_helpers.php.
+        if (recently_renewed($pdo, $subscriptionId)) {
             logMessage("Skipping $subscriptionId - already renewed within the last 23 hours", 'INFO');
             $skippedCount++;
             continue;
@@ -539,30 +512,6 @@ function processSquareRenewal($cardId, $amount, $subscriptionId, $email, $access
             'error' => $e->getMessage()
         ];
     }
-}
-
-/**
- * Calculate new subscription end date.
- *
- * Bases the new period on the LATER of the existing end_date or NOW(). When a
- * cron run is delayed and end_date is already in the past, extending from the
- * stale end_date can leave the new end_date still in the past — causing the
- * subscription to be picked up again and re-charged on the next run.
- */
-function calculateNewEndDate($currentEndDate, $billing) {
-    $endDateTime = new DateTime($currentEndDate);
-    $now = new DateTime('now');
-    if ($endDateTime < $now) {
-        $endDateTime = $now;
-    }
-
-    if ($billing === 'yearly') {
-        $endDateTime->add(new DateInterval('P1Y'));
-    } else {
-        $endDateTime->add(new DateInterval('P1M'));
-    }
-
-    return $endDateTime->format('Y-m-d H:i:s');
 }
 
 /**

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -135,7 +135,10 @@ foreach ($subscriptions as $subscription) {
     if ($useCredit) {
         logMessage("Renewal for $subscriptionId covered by credit balance ($$creditBalance)");
     } elseif ($creditUsed > 0) {
-        logMessage("Partial credit ($$creditBalance) applied for $subscriptionId, charging $$amountToCharge");
+        // Log the pre-fee partial charge to match the original cron's wording
+        // (the post-fee value is also visible in subsequent payment logs).
+        $preFeeCharge = $amount - $creditUsed;
+        logMessage("Partial credit ($$creditBalance) applied for $subscriptionId, charging $$preFeeCharge");
     }
 
     // Skip payment processing if fully covered by credit

--- a/email_sender.php
+++ b/email_sender.php
@@ -151,8 +151,7 @@ function send_styled_email($to_email, $subject, $body_content, $header_style = '
     // headers (In-Reply-To, References) only work when SMTP is configured.
     if (!empty($extra_headers) && is_array($extra_headers)) {
         foreach ($extra_headers as $name => $value) {
-            $sanitized = preg_replace('/[\r\n\x00-\x1f]+/', ' ', (string) $value);
-            $headers[] = $name . ': ' . $sanitized;
+            $headers[] = $name . ': ' . sanitize_header_value((string) $value);
         }
     }
 

--- a/email_sender.php
+++ b/email_sender.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/smtp_mailer.php';
 require_once __DIR__ . '/config/pricing.php';
+require_once __DIR__ . '/_email_helpers.php';
 
 // Note: send_post_reply_email() and send_mention_email() defined below
 // call into helpers from email_marketing.php (should_send_marketing_email,
@@ -43,22 +44,14 @@ function _premium_feature_list_items($prefix = '')
  */
 function send_styled_email($to_email, $subject, $body_content, $header_style = '', $from_email = null, $from_name = null, $reply_to = null, $extra_headers = [], $preheader = null, $format = 'html', &$message_id = null)
 {
-    // Strip CR/LF and the rest of the ASCII control range from any value that
-    // ends up in an email header. PHPMailer sanitizes its own header inputs,
-    // but the mail() fallback path below concatenates these into the headers
-    // string verbatim — a stray newline would let an attacker inject Bcc/Cc/
-    // etc. via user-controlled fields (subject lines from community posts,
-    // contact-form reply-to, etc.). Matches the policy used by
-    // api/invoice/invoice_email_sender.php for consistency.
-    $headerSafe = static function ($value) {
-        if ($value === null) return null;
-        return preg_replace('/[\r\n\x00-\x1f]+/', ' ', (string) $value);
-    };
-    $to_email = $headerSafe($to_email);
-    $subject = (string) $headerSafe($subject);
-    $from_email = $headerSafe($from_email);
-    $from_name = $headerSafe($from_name);
-    $reply_to = $headerSafe($reply_to);
+    // sanitize_header_value() (in _email_helpers.php) strips CR/LF and ASCII
+    // control chars so user-controlled fields can't inject Bcc/Cc/etc into
+    // the mail() fallback's concatenated header string.
+    $to_email = sanitize_header_value($to_email);
+    $subject = (string) sanitize_header_value($subject);
+    $from_email = sanitize_header_value($from_email);
+    $from_name = sanitize_header_value($from_name);
+    $reply_to = sanitize_header_value($reply_to);
 
     $isPlain = ($format === 'plain');
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="Unit"><directory>tests/Unit</directory></testsuite>
+        <testsuite name="Integration"><directory>tests/Integration</directory></testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Helpers/DatabaseTestCase.php
+++ b/tests/Helpers/DatabaseTestCase.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+abstract class DatabaseTestCase extends TestCase
+{
+    protected PDO $pdo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pdo = $GLOBALS['pdo'];
+        $this->pdo->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->pdo->inTransaction()) {
+            $this->pdo->rollBack();
+        }
+        parent::tearDown();
+    }
+
+    protected function seedPremiumKey(int $durationMonths = 1, ?string $email = null): string
+    {
+        $key = 'PREM-TEST-' . bin2hex(random_bytes(4));
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO premium_subscription_keys
+             (subscription_key, email, duration_months, created_at)
+             VALUES (?, ?, ?, NOW())'
+        );
+        $stmt->execute([$key, $email, $durationMonths]);
+        return $key;
+    }
+
+    protected function seedRedeemedKey(string $deviceId, string $subscriptionId, int $durationMonths = 12): string
+    {
+        $key = $this->seedPremiumKey($durationMonths);
+        $stmt = $this->pdo->prepare(
+            'UPDATE premium_subscription_keys
+             SET redeemed_at = NOW(), device_id = ?, subscription_id = ?
+             WHERE subscription_key = ?'
+        );
+        $stmt->execute([$deviceId, $subscriptionId, $key]);
+        return $key;
+    }
+
+    protected function seedSubscription(
+        string $subscriptionId,
+        string $endDate,
+        string $status = 'active',
+        string $billingCycle = 'yearly'
+    ): void {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO premium_subscriptions
+             (subscription_id, billing_cycle, amount, currency, start_date, end_date,
+              status, payment_method, transaction_id, auto_renew, environment, created_at)
+             VALUES (?, ?, 0.00, 'CAD', NOW(), ?, ?, 'free_key', ?, 0, 'sandbox', NOW())"
+        );
+        $stmt->execute([$subscriptionId, $billingCycle, $endDate, $status, $subscriptionId]);
+    }
+
+    /** @return int New portal_companies.id */
+    protected function seedPortalCompany(string $companyName = 'Test Co'): int
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO portal_companies (company_name, environment, is_active, created_at)
+             VALUES (?, 'sandbox', 1, NOW())"
+        );
+        $stmt->execute([$companyName]);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    protected function seedPortalInvoice(
+        int $companyId,
+        string $invoiceId,
+        float $totalAmount,
+        ?float $balanceDue = null,
+        string $currency = 'USD',
+        string $status = 'sent'
+    ): void {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO portal_invoices
+             (company_id, invoice_id, invoice_token, customer_token, customer_name,
+              status, total_amount, balance_due, currency, environment, created_at)
+             VALUES (?, ?, ?, ?, 'Test Customer', ?, ?, ?, ?, 'sandbox', NOW())"
+        );
+        $stmt->execute([
+            $companyId,
+            $invoiceId,
+            bin2hex(random_bytes(24)),
+            bin2hex(random_bytes(24)),
+            $status,
+            $totalAmount,
+            $balanceDue ?? $totalAmount,
+            $currency,
+        ]);
+    }
+}

--- a/tests/Helpers/IntegrationTestCase.php
+++ b/tests/Helpers/IntegrationTestCase.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for integration tests against functions that manage their own
+ * transactions (e.g. redeem_premium_key, _recreate_subscription_for_key).
+ *
+ * MySQL doesn't nest transactions, so wrapping the test in beginTransaction()
+ * would conflict with the function's own commit/rollback. Instead we track
+ * fixture rows and clean them up in tearDown().
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    protected PDO $pdo;
+
+    /** @var string[] */
+    private array $seededKeys = [];
+    /** @var string[] */
+    private array $seededSubscriptions = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pdo = $GLOBALS['pdo'];
+    }
+
+    protected function tearDown(): void
+    {
+        if (!empty($this->seededKeys)) {
+            $placeholders = implode(',', array_fill(0, count($this->seededKeys), '?'));
+            $this->pdo->prepare(
+                "DELETE FROM premium_subscription_keys WHERE subscription_key IN ($placeholders)"
+            )->execute($this->seededKeys);
+        }
+        if (!empty($this->seededSubscriptions)) {
+            $placeholders = implode(',', array_fill(0, count($this->seededSubscriptions), '?'));
+            $this->pdo->prepare(
+                "DELETE FROM premium_subscriptions WHERE subscription_id IN ($placeholders)"
+            )->execute($this->seededSubscriptions);
+        }
+        // Catch-all for subscriptions created by the function under test
+        // (transaction_id holds the original key for free-key redemptions).
+        if (!empty($this->seededKeys)) {
+            $placeholders = implode(',', array_fill(0, count($this->seededKeys), '?'));
+            $this->pdo->prepare(
+                "DELETE FROM premium_subscriptions WHERE transaction_id IN ($placeholders)"
+            )->execute($this->seededKeys);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Register a subscription_id (created by the function under test, not by
+     * the seed helpers) so it'll be cleaned up in tearDown().
+     */
+    protected function trackSubscription(string $subscriptionId): void
+    {
+        $this->seededSubscriptions[] = $subscriptionId;
+    }
+
+    protected function seedPremiumKey(int $durationMonths = 1, ?string $email = null): string
+    {
+        $key = 'PREM-TEST-' . bin2hex(random_bytes(4));
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO premium_subscription_keys
+             (subscription_key, email, duration_months, created_at)
+             VALUES (?, ?, ?, NOW())'
+        );
+        $stmt->execute([$key, $email, $durationMonths]);
+        $this->seededKeys[] = $key;
+        return $key;
+    }
+
+    protected function seedRedeemedKey(string $deviceId, string $subscriptionId, int $durationMonths = 12): string
+    {
+        $key = $this->seedPremiumKey($durationMonths);
+        $stmt = $this->pdo->prepare(
+            'UPDATE premium_subscription_keys
+             SET redeemed_at = NOW(), device_id = ?, subscription_id = ?
+             WHERE subscription_key = ?'
+        );
+        $stmt->execute([$deviceId, $subscriptionId, $key]);
+        $this->seededSubscriptions[] = $subscriptionId;
+        return $key;
+    }
+
+    protected function seedSubscription(
+        string $subscriptionId,
+        string $endDate,
+        string $status = 'active',
+        string $billingCycle = 'yearly',
+        ?string $transactionId = null
+    ): void {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO premium_subscriptions
+             (subscription_id, billing_cycle, amount, currency, start_date, end_date,
+              status, payment_method, transaction_id, auto_renew, environment, created_at)
+             VALUES (?, ?, 0.00, 'CAD', NOW(), ?, ?, 'free_key', ?, 0, 'sandbox', NOW())"
+        );
+        $stmt->execute([$subscriptionId, $billingCycle, $endDate, $status, $transactionId ?? $subscriptionId]);
+        $this->seededSubscriptions[] = $subscriptionId;
+    }
+}

--- a/tests/Integration/License/RedeemPremiumKeyTest.php
+++ b/tests/Integration/License/RedeemPremiumKeyTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\License;
+
+use Tests\Helpers\IntegrationTestCase;
+
+/**
+ * redeem_premium_key() and _recreate_subscription_for_key() each call
+ * $pdo->beginTransaction() internally, so these tests can't use the
+ * transaction-rolled DatabaseTestCase. They use IntegrationTestCase, which
+ * tracks fixture rows and deletes them in tearDown().
+ */
+final class RedeemPremiumKeyTest extends IntegrationTestCase
+{
+    private const DEVICE = 'device-hash-redeem-001';
+
+    public function test_first_redemption_creates_subscription_and_marks_key_redeemed(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 6);
+
+        $result = redeem_premium_key($key, self::DEVICE);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('active', $result['status']);
+        $this->assertNotEmpty($result['subscription_id']);
+
+        // Track for cleanup
+        $this->trackSubscription($result['subscription_id']);
+
+        // Verify subscription row was inserted
+        $stmt = $this->pdo->prepare('SELECT * FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$result['subscription_id']]);
+        $sub = $stmt->fetch();
+        $this->assertNotFalse($sub);
+        $this->assertSame('active', $sub['status']);
+        $this->assertSame('monthly', $sub['billing_cycle']);
+
+        // Verify key marked redeemed
+        $stmt = $this->pdo->prepare('SELECT redeemed_at, device_id FROM premium_subscription_keys WHERE subscription_key = ?');
+        $stmt->execute([$key]);
+        $row = $stmt->fetch();
+        $this->assertNotNull($row['redeemed_at']);
+        $this->assertSame(self::DEVICE, $row['device_id']);
+    }
+
+    public function test_first_redemption_uses_yearly_billing_for_12_month_duration(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 12);
+        $result = redeem_premium_key($key, self::DEVICE);
+        $this->trackSubscription($result['subscription_id']);
+
+        $stmt = $this->pdo->prepare('SELECT billing_cycle FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$result['subscription_id']]);
+        $this->assertSame('yearly', $stmt->fetch()['billing_cycle']);
+    }
+
+    public function test_first_redemption_with_zero_duration_creates_lifetime_subscription(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 0);
+        $result = redeem_premium_key($key, self::DEVICE);
+        $this->trackSubscription($result['subscription_id']);
+
+        $stmt = $this->pdo->prepare('SELECT end_date FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$result['subscription_id']]);
+        $endDate = $stmt->fetch()['end_date'];
+
+        // 100 years out (give or take) — assert at least 99 years from now
+        $minExpected = (new \DateTime('+99 years'))->format('Y-m-d');
+        $this->assertGreaterThanOrEqual($minExpected, substr($endDate, 0, 10));
+    }
+
+    public function test_re_redemption_active_subscription_transfers_device_id(): void
+    {
+        $subId = 'PREM-RERED-EMPT-AAAA-BBBB';
+        $this->seedSubscription($subId, (new \DateTime('+30 days'))->format('Y-m-d H:i:s'));
+        $key = $this->seedRedeemedKey('original-device', $subId);
+
+        $result = redeem_premium_key($key, 'new-device-after-transfer');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('active', $result['status']);
+        $this->assertSame($subId, $result['subscription_id']);
+
+        // Verify device_id transferred on the key
+        $stmt = $this->pdo->prepare('SELECT device_id FROM premium_subscription_keys WHERE subscription_key = ?');
+        $stmt->execute([$key]);
+        $this->assertSame('new-device-after-transfer', $stmt->fetch()['device_id']);
+    }
+
+    public function test_re_redemption_expired_subscription_returns_expired(): void
+    {
+        $subId = 'PREM-EXPIR-EDDD-AAAA-CCCC';
+        $this->seedSubscription($subId, (new \DateTime('-5 days'))->format('Y-m-d H:i:s'), status: 'active');
+        $key = $this->seedRedeemedKey('original-device', $subId);
+
+        $result = redeem_premium_key($key, 'new-device');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('expired', $result['status']);
+
+        // Side effect: subscription marked expired in DB
+        $stmt = $this->pdo->prepare('SELECT status FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$subId]);
+        $this->assertSame('expired', $stmt->fetch()['status']);
+    }
+
+    public function test_re_redemption_missing_subscription_recreates_it(): void
+    {
+        // Key marked redeemed but pointing at a subscription_id that doesn't exist
+        $key = $this->seedRedeemedKey('original-device', 'PREM-NOSUCH-SUBS-RIPT-IONA', durationMonths: 6);
+
+        $result = redeem_premium_key($key, 'new-device');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('active', $result['status']);
+        $this->assertNotSame('PREM-NOSUCH-SUBS-RIPT-IONA', $result['subscription_id']);
+
+        $this->trackSubscription($result['subscription_id']);
+
+        // New subscription row exists
+        $stmt = $this->pdo->prepare('SELECT status FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$result['subscription_id']]);
+        $this->assertSame('active', $stmt->fetch()['status']);
+    }
+}

--- a/tests/Integration/License/ValidateLicenseTest.php
+++ b/tests/Integration/License/ValidateLicenseTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\License;
+
+use Tests\Helpers\DatabaseTestCase;
+
+final class ValidateLicenseTest extends DatabaseTestCase
+{
+    private const DEVICE = 'device-hash-test-001';
+
+    public function test_returns_invalid_key_for_unredeemed_key(): void
+    {
+        $key = $this->seedPremiumKey();
+        $result = validate_license($key, self::DEVICE);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_key', $result['status']);
+    }
+
+    public function test_returns_wrong_device_when_device_id_mismatches(): void
+    {
+        $subId = 'PREM-TEST-SUB1-AAAA-BBBB';
+        $this->seedSubscription($subId, (new \DateTime('+30 days'))->format('Y-m-d H:i:s'));
+        $key = $this->seedRedeemedKey(self::DEVICE, $subId);
+
+        $result = validate_license($key, 'different-device-hash');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('wrong_device', $result['status']);
+    }
+
+    public function test_returns_expired_when_subscription_end_date_in_past(): void
+    {
+        $subId = 'PREM-TEST-SUB2-CCCC-DDDD';
+        $pastDate = (new \DateTime('-5 days'))->format('Y-m-d H:i:s');
+        $this->seedSubscription($subId, $pastDate, status: 'active');
+        $key = $this->seedRedeemedKey(self::DEVICE, $subId);
+
+        $result = validate_license($key, self::DEVICE);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('expired', $result['status']);
+
+        // Verify the side effect: subscription row flipped to 'expired'.
+        $stmt = $this->pdo->prepare('SELECT status FROM premium_subscriptions WHERE subscription_id = ?');
+        $stmt->execute([$subId]);
+        $this->assertSame('expired', $stmt->fetch()['status']);
+    }
+
+    public function test_returns_valid_when_redeemed_active_matching_device(): void
+    {
+        $subId = 'PREM-TEST-SUB3-EEEE-FFFF';
+        $this->seedSubscription($subId, (new \DateTime('+90 days'))->format('Y-m-d H:i:s'));
+        $key = $this->seedRedeemedKey(self::DEVICE, $subId);
+
+        $result = validate_license($key, self::DEVICE);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('valid', $result['status']);
+    }
+
+    public function test_returns_invalid_when_subscription_row_missing(): void
+    {
+        // Redeemed key pointing at a non-existent subscription_id
+        $key = $this->seedRedeemedKey(self::DEVICE, 'PREM-NOSUCH-SUBS-RIPT-IONX');
+
+        $result = validate_license($key, self::DEVICE);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_key', $result['status']);
+    }
+}

--- a/tests/Integration/License/ValidatePremiumKeyTest.php
+++ b/tests/Integration/License/ValidatePremiumKeyTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\License;
+
+use Tests\Helpers\DatabaseTestCase;
+
+final class ValidatePremiumKeyTest extends DatabaseTestCase
+{
+    public function test_returns_invalid_for_unknown_key(): void
+    {
+        $result = validate_premium_key('PREM-DOES-NOTE-XIST-AAAA');
+        $this->assertFalse($result['success']);
+        $this->assertSame('Invalid premium key.', $result['message']);
+    }
+
+    public function test_returns_valid_status_for_unredeemed_key(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 12);
+        $result = validate_premium_key($key);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('valid', $result['status']);
+        $this->assertSame($key, $result['key']);
+    }
+
+    public function test_returns_redeemed_status_for_already_redeemed_key(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 12);
+        $this->pdo->prepare(
+            "UPDATE premium_subscription_keys
+             SET redeemed_at = NOW(), device_id = ?, subscription_id = ?
+             WHERE subscription_key = ?"
+        )->execute(['device-hash-abc', 'PREM-FAKE-SUB1-AAAA-BBBB', $key]);
+
+        $result = validate_premium_key($key);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('redeemed', $result['status']);
+        $this->assertSame('PREM-FAKE-SUB1-AAAA-BBBB', $result['subscription_id']);
+    }
+
+    public function test_response_includes_duration_months(): void
+    {
+        $key = $this->seedPremiumKey(durationMonths: 6);
+        $result = validate_premium_key($key);
+        $this->assertSame(6, (int) $result['duration_months']);
+    }
+}

--- a/tests/Integration/Portal/RecordPortalPaymentTest.php
+++ b/tests/Integration/Portal/RecordPortalPaymentTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\Portal;
+
+use Tests\Helpers\DatabaseTestCase;
+
+final class RecordPortalPaymentTest extends DatabaseTestCase
+{
+    public function test_records_payment_and_marks_invoice_paid_for_full_amount(): void
+    {
+        $companyId = $this->seedPortalCompany();
+        $this->seedPortalInvoice($companyId, 'INV-FULL-001', 100.00, currency: 'USD');
+
+        $result = record_portal_payment([
+            'company_id' => $companyId,
+            'invoice_id' => 'INV-FULL-001',
+            'customer_name' => 'Test Customer',
+            'amount' => 100.00,
+            'currency' => 'USD',
+            'payment_method' => 'stripe',
+            'provider_payment_id' => 'pi_test_full_' . bin2hex(random_bytes(4)),
+            'status' => 'completed',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertNotEmpty($result['reference_number']);
+
+        $stmt = $this->pdo->prepare('SELECT status, balance_due FROM portal_invoices WHERE company_id = ? AND invoice_id = ?');
+        $stmt->execute([$companyId, 'INV-FULL-001']);
+        $invoice = $stmt->fetch();
+        $this->assertSame('paid', $invoice['status']);
+        $this->assertSame(0.00, (float) $invoice['balance_due']);
+    }
+
+    public function test_partial_payment_marks_invoice_partial(): void
+    {
+        $companyId = $this->seedPortalCompany();
+        $this->seedPortalInvoice($companyId, 'INV-PART-001', 100.00);
+
+        record_portal_payment([
+            'company_id' => $companyId,
+            'invoice_id' => 'INV-PART-001',
+            'customer_name' => 'Test Customer',
+            'amount' => 40.00,
+            'currency' => 'USD',
+            'payment_method' => 'stripe',
+            'provider_payment_id' => 'pi_test_partial_' . bin2hex(random_bytes(4)),
+            'status' => 'completed',
+        ]);
+
+        $stmt = $this->pdo->prepare('SELECT status, balance_due FROM portal_invoices WHERE company_id = ? AND invoice_id = ?');
+        $stmt->execute([$companyId, 'INV-PART-001']);
+        $invoice = $stmt->fetch();
+        $this->assertSame('partial', $invoice['status']);
+        $this->assertSame(60.00, (float) $invoice['balance_due']);
+    }
+
+    public function test_duplicate_provider_payment_id_returns_existing_reference_without_double_charging(): void
+    {
+        $companyId = $this->seedPortalCompany();
+        $this->seedPortalInvoice($companyId, 'INV-DUP-001', 100.00);
+
+        $providerPaymentId = 'pi_test_dup_' . bin2hex(random_bytes(4));
+
+        $first = record_portal_payment([
+            'company_id' => $companyId,
+            'invoice_id' => 'INV-DUP-001',
+            'customer_name' => 'Test Customer',
+            'amount' => 100.00,
+            'currency' => 'USD',
+            'payment_method' => 'stripe',
+            'provider_payment_id' => $providerPaymentId,
+            'status' => 'completed',
+        ]);
+
+        $second = record_portal_payment([
+            'company_id' => $companyId,
+            'invoice_id' => 'INV-DUP-001',
+            'customer_name' => 'Test Customer',
+            'amount' => 100.00,
+            'currency' => 'USD',
+            'payment_method' => 'stripe',
+            'provider_payment_id' => $providerPaymentId,
+            'status' => 'completed',
+        ]);
+
+        $this->assertTrue($first['success']);
+        $this->assertTrue($second['success']);
+        $this->assertSame($first['reference_number'], $second['reference_number']);
+
+        // Only one payment row should exist for the duplicate provider_payment_id
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) AS cnt FROM portal_payments WHERE provider_payment_id = ?');
+        $stmt->execute([$providerPaymentId]);
+        $this->assertSame(1, (int) $stmt->fetch()['cnt']);
+
+        // Invoice should be paid exactly once (balance_due = 0, not -100)
+        $stmt = $this->pdo->prepare('SELECT balance_due FROM portal_invoices WHERE company_id = ? AND invoice_id = ?');
+        $stmt->execute([$companyId, 'INV-DUP-001']);
+        $this->assertSame(0.00, (float) $stmt->fetch()['balance_due']);
+    }
+}

--- a/tests/Integration/Portal/StripeRefundTest.php
+++ b/tests/Integration/Portal/StripeRefundTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\Portal;
+
+use Tests\Helpers\DatabaseTestCase;
+
+final class StripeRefundTest extends DatabaseTestCase
+{
+    public function test_inserts_negative_payment_and_flips_original_to_refunded(): void
+    {
+        $companyId = $this->seedPortalCompany();
+        $this->seedPortalInvoice($companyId, 'INV-REF-001', 200.00, balanceDue: 0.00, status: 'paid');
+
+        $providerPaymentId = 'pi_test_refund_' . bin2hex(random_bytes(4));
+
+        // Seed a completed original payment row
+        $this->pdo->prepare(
+            "INSERT INTO portal_payments
+             (company_id, invoice_id, customer_name, amount, processing_fee,
+              currency, payment_method, provider_payment_id, provider_transaction_id,
+              reference_number, status, payment_environment, created_at)
+             VALUES (?, 'INV-REF-001', 'Test Customer', 200.00, 0.00,
+                     'USD', 'stripe', ?, 'ch_orig', ?, 'completed', 'sandbox', NOW())"
+        )->execute([$companyId, $providerPaymentId, 'PAY-' . date('Ymd') . '-AAAAAA']);
+
+        $ok = apply_stripe_refund_to_db($this->pdo, $providerPaymentId, 200.00, 'ch_refund_xyz', false);
+        $this->assertTrue($ok);
+
+        // Negative refund payment row exists
+        $stmt = $this->pdo->prepare(
+            'SELECT amount, status FROM portal_payments WHERE provider_payment_id = ?'
+        );
+        $stmt->execute(['refund_' . $providerPaymentId]);
+        $refund = $stmt->fetch();
+        $this->assertNotFalse($refund);
+        $this->assertSame(-200.00, (float) $refund['amount']);
+        $this->assertSame('refunded', $refund['status']);
+
+        // Original payment row flipped to refunded
+        $stmt = $this->pdo->prepare(
+            'SELECT status FROM portal_payments WHERE provider_payment_id = ?'
+        );
+        $stmt->execute([$providerPaymentId]);
+        $this->assertSame('refunded', $stmt->fetch()['status']);
+    }
+
+    public function test_refund_increases_invoice_balance_due_capped_at_total(): void
+    {
+        $companyId = $this->seedPortalCompany();
+        $this->seedPortalInvoice($companyId, 'INV-REF-002', 100.00, balanceDue: 0.00, status: 'paid');
+
+        $providerPaymentId = 'pi_test_cap_' . bin2hex(random_bytes(4));
+        $this->pdo->prepare(
+            "INSERT INTO portal_payments
+             (company_id, invoice_id, customer_name, amount, processing_fee,
+              currency, payment_method, provider_payment_id, provider_transaction_id,
+              reference_number, status, payment_environment, created_at)
+             VALUES (?, 'INV-REF-002', 'Test Customer', 100.00, 0.00,
+                     'USD', 'stripe', ?, 'ch_orig2', ?, 'completed', 'sandbox', NOW())"
+        )->execute([$companyId, $providerPaymentId, 'PAY-' . date('Ymd') . '-BBBBBB']);
+
+        // Refund larger than total — should cap balance_due at total_amount
+        apply_stripe_refund_to_db($this->pdo, $providerPaymentId, 500.00, 'ch_refund_cap', false);
+
+        $stmt = $this->pdo->prepare(
+            'SELECT balance_due, status FROM portal_invoices WHERE company_id = ? AND invoice_id = ?'
+        );
+        $stmt->execute([$companyId, 'INV-REF-002']);
+        $invoice = $stmt->fetch();
+        $this->assertSame(100.00, (float) $invoice['balance_due']);
+        $this->assertSame('sent', $invoice['status']);
+    }
+
+    public function test_returns_false_when_no_matching_completed_payment(): void
+    {
+        $ok = apply_stripe_refund_to_db($this->pdo, 'pi_does_not_exist', 50.00, 'ch_x', false);
+        $this->assertFalse($ok);
+    }
+}

--- a/tests/Integration/Renewal/IdempotencyGuardTest.php
+++ b/tests/Integration/Renewal/IdempotencyGuardTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\Renewal;
+
+use Tests\Helpers\DatabaseTestCase;
+
+final class IdempotencyGuardTest extends DatabaseTestCase
+{
+    private const SUB_ID = 'PREM-IDEM-POTE-NCYY-TEST';
+
+    public function test_returns_true_when_completed_renewal_within_23h(): void
+    {
+        $this->insertRenewalPayment(2, 'completed', 'renewal');
+        $this->assertTrue(recently_renewed($this->pdo, self::SUB_ID));
+    }
+
+    public function test_returns_false_when_last_renewal_was_24h_ago(): void
+    {
+        $this->insertRenewalPayment(25, 'completed', 'renewal');
+        $this->assertFalse(recently_renewed($this->pdo, self::SUB_ID));
+    }
+
+    public function test_returns_false_when_only_failed_renewal_exists(): void
+    {
+        $this->insertRenewalPayment(1, 'failed', 'renewal');
+        $this->assertFalse(recently_renewed($this->pdo, self::SUB_ID));
+    }
+
+    public function test_returns_false_for_initial_payment_within_window(): void
+    {
+        // payment_type=initial shouldn't satisfy the renewal idempotency guard.
+        $this->insertRenewalPayment(1, 'completed', 'initial');
+        $this->assertFalse(recently_renewed($this->pdo, self::SUB_ID));
+    }
+
+    /**
+     * Use MySQL's NOW() - INTERVAL N HOUR for the timestamp so the test is
+     * timezone-agnostic (PHP and MySQL clocks differ in default Laragon
+     * setups: PHP is UTC, MySQL uses system local time).
+     */
+    private function insertRenewalPayment(int $hoursAgo, string $status, string $type): void
+    {
+        $this->pdo->prepare(
+            "INSERT INTO premium_subscription_payments
+             (subscription_id, amount, currency, payment_method, transaction_id,
+              status, payment_type, environment, created_at)
+             VALUES (?, 10.00, 'CAD', 'stripe', ?, ?, ?, 'sandbox',
+                     DATE_SUB(NOW(), INTERVAL ? HOUR))"
+        )->execute([self::SUB_ID, 'TXN_' . bin2hex(random_bytes(4)), $status, $type, $hoursAgo]);
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,52 @@
+# Argo Books Tests
+
+PHPUnit-based test suite covering high-stakes pure logic and the financial / licensing flows.
+
+## One-time setup
+
+1. **Add PHP to your system PATH.** The `vendor/bin/phpunit` shim is a `.bat` file that invokes `php`, so PHP must be resolvable from any shell. Laragon doesn't add its bundled PHP to PATH by default.
+
+   - Win+R → `sysdm.cpl` → Advanced → Environment Variables
+   - Under **User variables** (or **System variables**), edit **Path** and add the full path to your active PHP install — e.g. `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64`
+   - Open a fresh shell and verify with `php --version` (should print 8.3+)
+
+   If you'd rather not touch global PATH, run tests from **Laragon's bundled terminal** (right-click the tray icon → Terminal) — it sets PATH up automatically.
+
+2. **Create the test database** in MySQL/HeidiSQL:
+   ```sql
+   CREATE DATABASE argo_books_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+   ```
+
+3. **Import the schema** (re-run any time `mysql_schema.sql` changes):
+   ```
+   mysql -u root argo_books_test < ../mysql_schema.sql
+   ```
+
+4. **Install dev dependencies**:
+   ```
+   composer install
+   ```
+
+5. **Verify `.env.testing` exists** at the project root with `DB_NAME=argo_books_test`. The bootstrap aborts if `DB_NAME` is anything else, so production data is safe.
+
+## Running tests
+
+```
+vendor/bin/phpunit                          # all tests
+vendor/bin/phpunit --testsuite=Unit         # fast, no DB
+vendor/bin/phpunit --testsuite=Integration  # DB-touching
+vendor/bin/phpunit --filter CalculateProcessingFee
+vendor/bin/phpunit --testdox                # readable output
+```
+
+## Layout
+
+- `tests/Unit/` — pure functions, no DB, no network. Should run in seconds.
+- `tests/Integration/` — touches `argo_books_test`. Each test wraps in a transaction and rolls back at teardown (via `DatabaseTestCase`), or does manual cleanup (via `IntegrationTestCase` for functions that open their own transactions).
+- `tests/Helpers/` — base classes and fixture helpers.
+
+## Adding tests
+
+- Extend `Tests\Helpers\DatabaseTestCase` for tests that don't call `beginTransaction()` themselves — fast isolation via auto-rollback.
+- Extend `Tests\Helpers\IntegrationTestCase` for tests against functions that manage their own transactions (e.g. `redeem_premium_key`). These do manual cleanup of seed rows in `tearDown()`.
+- Schema changes: re-import `mysql_schema.sql` into `argo_books_test`, then update fixture helpers in `tests/Helpers/` if column names changed.

--- a/tests/Unit/Crypto/PortalEncryptDecryptTest.php
+++ b/tests/Unit/Crypto/PortalEncryptDecryptTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Crypto;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class PortalEncryptDecryptTest extends TestCase
+{
+    private string $originalKey;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalKey = $_ENV['PORTAL_ENCRYPTION_KEY'] ?? '';
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['PORTAL_ENCRYPTION_KEY'] = $this->originalKey;
+        parent::tearDown();
+    }
+
+    public function test_roundtrip_returns_original_plaintext(): void
+    {
+        $plaintext = 'Sensitive customer data: 4242-4242-4242-4242';
+        $ciphertext = portal_encrypt($plaintext);
+        $this->assertNotSame($plaintext, $ciphertext);
+        $this->assertSame($plaintext, portal_decrypt($ciphertext));
+    }
+
+    public function test_each_encryption_uses_unique_iv(): void
+    {
+        $plaintext = 'same input';
+        $a = portal_encrypt($plaintext);
+        $b = portal_encrypt($plaintext);
+        $this->assertNotSame($a, $b, 'Two encryptions of identical plaintext must yield different ciphertexts (random IV)');
+        $this->assertSame($plaintext, portal_decrypt($a));
+        $this->assertSame($plaintext, portal_decrypt($b));
+    }
+
+    public function test_decrypt_throws_on_tampered_ciphertext(): void
+    {
+        $ciphertext = portal_encrypt('original');
+        // Flip a byte in the middle of the base64 payload — corrupts ciphertext
+        // (and tag), causing GCM verification to fail.
+        $tampered = substr_replace($ciphertext, 'X', strlen($ciphertext) - 4, 1);
+
+        $this->expectException(RuntimeException::class);
+        portal_decrypt($tampered);
+    }
+
+    public function test_throws_when_key_is_wrong_length(): void
+    {
+        $_ENV['PORTAL_ENCRYPTION_KEY'] = 'abc';
+        $this->expectException(RuntimeException::class);
+        portal_encrypt('anything');
+    }
+}

--- a/tests/Unit/Crypto/PortalEncryptDecryptTest.php
+++ b/tests/Unit/Crypto/PortalEncryptDecryptTest.php
@@ -8,17 +8,25 @@ use RuntimeException;
 
 final class PortalEncryptDecryptTest extends TestCase
 {
+    private bool $hadOriginalKey;
     private string $originalKey;
 
     protected function setUp(): void
     {
         parent::setUp();
+        $this->hadOriginalKey = isset($_ENV['PORTAL_ENCRYPTION_KEY']);
         $this->originalKey = $_ENV['PORTAL_ENCRYPTION_KEY'] ?? '';
     }
 
     protected function tearDown(): void
     {
-        $_ENV['PORTAL_ENCRYPTION_KEY'] = $this->originalKey;
+        // Restore the exact prior state — distinguish "set to empty string"
+        // from "unset" so later tests see the same env they would normally see.
+        if ($this->hadOriginalKey) {
+            $_ENV['PORTAL_ENCRYPTION_KEY'] = $this->originalKey;
+        } else {
+            unset($_ENV['PORTAL_ENCRYPTION_KEY']);
+        }
         parent::tearDown();
     }
 

--- a/tests/Unit/Db/CurrentEnvironmentTest.php
+++ b/tests/Unit/Db/CurrentEnvironmentTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Db;
+
+use PHPUnit\Framework\TestCase;
+
+final class CurrentEnvironmentTest extends TestCase
+{
+    private ?string $originalAppEnv;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalAppEnv = $_ENV['APP_ENV'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalAppEnv === null) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->originalAppEnv;
+        }
+        parent::tearDown();
+    }
+
+    public function test_returns_production_when_app_env_is_production(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $this->assertSame('production', current_environment());
+    }
+
+    public function test_returns_sandbox_when_app_env_is_development(): void
+    {
+        $_ENV['APP_ENV'] = 'development';
+        $this->assertSame('sandbox', current_environment());
+    }
+
+    public function test_returns_sandbox_when_app_env_is_unset(): void
+    {
+        unset($_ENV['APP_ENV']);
+        $this->assertSame('sandbox', current_environment());
+    }
+}

--- a/tests/Unit/Email/EmailHelpersTest.php
+++ b/tests/Unit/Email/EmailHelpersTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Email;
+
+use PHPUnit\Framework\TestCase;
+
+final class EmailHelpersTest extends TestCase
+{
+    public function test_sanitize_header_value_strips_crlf(): void
+    {
+        $injected = "user@example.com\r\nBcc: attacker@evil.com";
+        $sanitized = sanitize_header_value($injected);
+        $this->assertStringNotContainsString("\r", $sanitized);
+        $this->assertStringNotContainsString("\n", $sanitized);
+    }
+
+    public function test_sanitize_header_value_strips_control_chars(): void
+    {
+        $injected = "subject\x00with\x07\x1fcontrol\x08chars";
+        $sanitized = sanitize_header_value($injected);
+        // Replacement collapses runs of control chars to a single space.
+        $this->assertSame('subject with control chars', $sanitized);
+    }
+
+    public function test_sanitize_header_value_returns_null_for_null(): void
+    {
+        $this->assertNull(sanitize_header_value(null));
+    }
+
+    public function test_sanitize_header_value_passes_through_clean_input(): void
+    {
+        $this->assertSame('Hello World', sanitize_header_value('Hello World'));
+    }
+
+    public function test_community_excerpt_strips_html_and_truncates_with_ellipsis(): void
+    {
+        $input = '<p>This is a <strong>long</strong> post body that should be truncated to a short excerpt for the email notification.</p>';
+        $excerpt = _community_excerpt($input, 40);
+        $this->assertStringNotContainsString('<', $excerpt);
+        $this->assertStringNotContainsString('>', $excerpt);
+        $this->assertSame(40, mb_strlen($excerpt));
+        $this->assertStringEndsWith('…', $excerpt);
+    }
+
+    public function test_community_excerpt_collapses_whitespace(): void
+    {
+        $input = "line one\n\n\nline   two\t\ttabs";
+        $excerpt = _community_excerpt($input, 100);
+        $this->assertStringNotContainsString("\n", $excerpt);
+        $this->assertStringNotContainsString("\t", $excerpt);
+        $this->assertStringNotContainsString('  ', $excerpt);
+    }
+
+    public function test_community_excerpt_below_max_returns_unchanged(): void
+    {
+        $input = 'Short.';
+        $this->assertSame('Short.', _community_excerpt($input, 240));
+    }
+}

--- a/tests/Unit/License/GenerateLicenseKeyTest.php
+++ b/tests/Unit/License/GenerateLicenseKeyTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\License;
+
+use PHPUnit\Framework\TestCase;
+
+final class GenerateLicenseKeyTest extends TestCase
+{
+    public function test_format_matches_PREM_dashed_groups(): void
+    {
+        $key = generate_license_key();
+        $this->assertMatchesRegularExpression(
+            '/^PREM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/',
+            $key
+        );
+    }
+
+    public function test_total_length_is_24_characters(): void
+    {
+        $this->assertSame(24, strlen(generate_license_key()));
+    }
+
+    public function test_uniqueness_across_1000_invocations(): void
+    {
+        $keys = [];
+        for ($i = 0; $i < 1000; $i++) {
+            $keys[] = generate_license_key();
+        }
+        $this->assertCount(1000, array_unique($keys), 'All 1000 generated keys should be unique');
+    }
+}

--- a/tests/Unit/Portal/GenerateReferenceNumberTest.php
+++ b/tests/Unit/Portal/GenerateReferenceNumberTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Portal;
+
+use PHPUnit\Framework\TestCase;
+
+final class GenerateReferenceNumberTest extends TestCase
+{
+    public function test_format_PAY_yyyymmdd_six_hex(): void
+    {
+        $ref = generate_reference_number();
+        $this->assertMatchesRegularExpression('/^PAY-\d{8}-[0-9A-F]{6}$/', $ref);
+    }
+
+    public function test_date_segment_is_today(): void
+    {
+        $ref = generate_reference_number();
+        $this->assertSame(date('Ymd'), substr($ref, 4, 8));
+    }
+}

--- a/tests/Unit/Portal/GenerateReferenceNumberTest.php
+++ b/tests/Unit/Portal/GenerateReferenceNumberTest.php
@@ -15,7 +15,12 @@ final class GenerateReferenceNumberTest extends TestCase
 
     public function test_date_segment_is_today(): void
     {
+        // Capture the date before AND after generation. If the day rolls
+        // over between calls (microsecond-window flake), accept either.
+        $before = date('Ymd');
         $ref = generate_reference_number();
-        $this->assertSame(date('Ymd'), substr($ref, 4, 8));
+        $after = date('Ymd');
+
+        $this->assertContains(substr($ref, 4, 8), [$before, $after]);
     }
 }

--- a/tests/Unit/Pricing/CalculateProcessingFeeTest.php
+++ b/tests/Unit/Pricing/CalculateProcessingFeeTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Pricing;
+
+use PHPUnit\Framework\TestCase;
+
+final class CalculateProcessingFeeTest extends TestCase
+{
+    public function test_returns_zero_for_zero_subtotal(): void
+    {
+        $this->assertSame(0.00, calculate_processing_fee(0));
+    }
+
+    public function test_returns_zero_for_negative_subtotal(): void
+    {
+        $this->assertSame(0.00, calculate_processing_fee(-50));
+    }
+
+    public function test_calculates_290_percent_plus_fixed_for_positive_subtotal(): void
+    {
+        // .env.testing sets PROCESSING_FEE_PERCENT=2.90, PROCESSING_FEE_FIXED=0.30
+        // 100 * 0.029 + 0.30 = 3.20
+        $this->assertSame(3.20, calculate_processing_fee(100));
+    }
+
+    public function test_rounds_to_two_decimals(): void
+    {
+        // 33.33 * 0.029 + 0.30 = 1.26657 → rounds to 1.27
+        $this->assertSame(1.27, calculate_processing_fee(33.33));
+    }
+
+    public function test_handles_large_subtotal(): void
+    {
+        // 1000 * 0.029 + 0.30 = 29.30
+        $this->assertSame(29.30, calculate_processing_fee(1000));
+    }
+}

--- a/tests/Unit/Pricing/PricingParseEnvTest.php
+++ b/tests/Unit/Pricing/PricingParseEnvTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Pricing;
+
+use PHPUnit\Framework\TestCase;
+
+final class PricingParseEnvTest extends TestCase
+{
+    private const TEST_KEY = '__TEST_PRICING_PARSE__';
+
+    protected function tearDown(): void
+    {
+        unset($_ENV[self::TEST_KEY]);
+        parent::tearDown();
+    }
+
+    public function test_parse_env_returns_default_when_unset(): void
+    {
+        unset($_ENV[self::TEST_KEY]);
+        $this->assertSame(7.50, _pricing_parse_env(self::TEST_KEY, 7.50));
+    }
+
+    public function test_parse_env_returns_default_for_non_numeric(): void
+    {
+        $_ENV[self::TEST_KEY] = 'abc';
+        $this->assertSame(7.50, _pricing_parse_env(self::TEST_KEY, 7.50));
+    }
+
+    public function test_parse_env_returns_default_for_negative(): void
+    {
+        $_ENV[self::TEST_KEY] = '-5.00';
+        $this->assertSame(7.50, _pricing_parse_env(self::TEST_KEY, 7.50));
+    }
+
+    public function test_parse_env_rounds_to_two_decimals(): void
+    {
+        $_ENV[self::TEST_KEY] = '12.345';
+        $this->assertSame(12.35, _pricing_parse_env(self::TEST_KEY, 0));
+    }
+
+    public function test_parse_int_env_returns_default_for_zero(): void
+    {
+        $_ENV[self::TEST_KEY] = '0';
+        $this->assertSame(50, _pricing_parse_int_env(self::TEST_KEY, 50));
+    }
+
+    public function test_parse_int_env_floors_floats(): void
+    {
+        $_ENV[self::TEST_KEY] = '3.7';
+        $this->assertSame(3, _pricing_parse_int_env(self::TEST_KEY, 0));
+    }
+}

--- a/tests/Unit/Renewal/DecideRenewalChargeTest.php
+++ b/tests/Unit/Renewal/DecideRenewalChargeTest.php
@@ -33,24 +33,24 @@ final class DecideRenewalChargeTest extends TestCase
 
     public function test_partial_credit_charges_difference_plus_fee(): void
     {
-        // Credit $3 against monthly $10: charge $7 + fee.
-        // Fee = 7 * 0.029 + 0.30 = 0.503 → 0.50
+        // Credit $3 against monthly $10: charges (10 - 3) + fee on the
+        // remainder. Computing the expected total via calculate_processing_fee
+        // keeps this robust to fee-config changes in .env.testing.
         $decision = decide_renewal_charge(3.00, 'monthly', $this->config);
 
         $this->assertFalse($decision['useCredit']);
         $this->assertSame(3.00, $decision['creditUsed']);
-        $this->assertSame(7.50, $decision['amountToCharge']);
+        $this->assertSame(7.0 + calculate_processing_fee(7.0), $decision['amountToCharge']);
     }
 
     public function test_no_credit_charges_full_amount_plus_fee(): void
     {
-        // Yearly $100, no credit: charge $100 + fee.
-        // Fee = 100 * 0.029 + 0.30 = 3.20
+        // Yearly $100, no credit: charges full price + fee on the full price.
         $decision = decide_renewal_charge(0.00, 'yearly', $this->config);
 
         $this->assertFalse($decision['useCredit']);
         $this->assertSame(0.0, $decision['creditUsed']);
-        $this->assertSame(103.20, $decision['amountToCharge']);
+        $this->assertSame(100.0 + calculate_processing_fee(100.0), $decision['amountToCharge']);
     }
 
     public function test_exact_credit_match_counts_as_full_coverage(): void

--- a/tests/Unit/Renewal/DecideRenewalChargeTest.php
+++ b/tests/Unit/Renewal/DecideRenewalChargeTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Renewal;
+
+use PHPUnit\Framework\TestCase;
+
+final class DecideRenewalChargeTest extends TestCase
+{
+    private array $config;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Mirrors .env.testing values so the test is self-contained
+        // even if .env.testing later drifts. The processing-fee values are
+        // also set in .env.testing so calculate_processing_fee() agrees.
+        $this->config = [
+            'premium_monthly_price' => 10.00,
+            'premium_yearly_price'  => 100.00,
+        ];
+    }
+
+    public function test_full_credit_coverage_charges_zero(): void
+    {
+        // Credit > monthly price: full coverage, no charge.
+        $decision = decide_renewal_charge(15.00, 'monthly', $this->config);
+
+        $this->assertTrue($decision['useCredit']);
+        $this->assertSame(10.00, $decision['creditUsed']);
+        $this->assertSame(0.00, $decision['amountToCharge']);
+    }
+
+    public function test_partial_credit_charges_difference_plus_fee(): void
+    {
+        // Credit $3 against monthly $10: charge $7 + fee.
+        // Fee = 7 * 0.029 + 0.30 = 0.503 → 0.50
+        $decision = decide_renewal_charge(3.00, 'monthly', $this->config);
+
+        $this->assertFalse($decision['useCredit']);
+        $this->assertSame(3.00, $decision['creditUsed']);
+        $this->assertSame(7.50, $decision['amountToCharge']);
+    }
+
+    public function test_no_credit_charges_full_amount_plus_fee(): void
+    {
+        // Yearly $100, no credit: charge $100 + fee.
+        // Fee = 100 * 0.029 + 0.30 = 3.20
+        $decision = decide_renewal_charge(0.00, 'yearly', $this->config);
+
+        $this->assertFalse($decision['useCredit']);
+        $this->assertSame(0.0, $decision['creditUsed']);
+        $this->assertSame(103.20, $decision['amountToCharge']);
+    }
+
+    public function test_exact_credit_match_counts_as_full_coverage(): void
+    {
+        // Credit equals price exactly: still treated as full coverage.
+        $decision = decide_renewal_charge(10.00, 'monthly', $this->config);
+
+        $this->assertTrue($decision['useCredit']);
+        $this->assertSame(10.00, $decision['creditUsed']);
+        $this->assertSame(0.00, $decision['amountToCharge']);
+    }
+}

--- a/tests/Unit/Renewal/RenewalHelpersTest.php
+++ b/tests/Unit/Renewal/RenewalHelpersTest.php
@@ -4,24 +4,49 @@ declare(strict_types=1);
 namespace Tests\Unit\Renewal;
 
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * calculateNewEndDate() reads `now` internally, so multiple wall-clock reads
+ * in a single test (one for input, one for expectation, one inside the helper)
+ * could disagree across a midnight boundary. We capture a single immutable
+ * base in setUp() and derive everything from it; the helper is still free to
+ * read its own `now`, so we accept a small window via assertGreaterThan /
+ * assertLessThan rather than exact equality.
+ */
 final class RenewalHelpersTest extends TestCase
 {
+    private DateTimeImmutable $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = new DateTimeImmutable('now');
+    }
+
     public function test_yearly_adds_one_year_from_future_end_date(): void
     {
-        $futureEnd = (new DateTime('+30 days'))->format('Y-m-d H:i:s');
-        $expected = (new DateTime('+30 days'))->modify('+1 year')->format('Y-m-d');
-        $newEnd = calculateNewEndDate($futureEnd, 'yearly');
-        $this->assertSame($expected, substr($newEnd, 0, 10));
+        $futureEnd = $this->base->modify('+30 days')->format('Y-m-d H:i:s');
+        $minExpected = $this->base->modify('+1 year +29 days')->format('Y-m-d');
+        $maxExpected = $this->base->modify('+1 year +31 days')->format('Y-m-d');
+
+        $newEnd = substr(calculateNewEndDate($futureEnd, 'yearly'), 0, 10);
+
+        $this->assertGreaterThanOrEqual($minExpected, $newEnd);
+        $this->assertLessThanOrEqual($maxExpected, $newEnd);
     }
 
     public function test_monthly_adds_one_month_from_future_end_date(): void
     {
-        $futureEnd = (new DateTime('+10 days'))->format('Y-m-d H:i:s');
-        $expected = (new DateTime('+10 days'))->modify('+1 month')->format('Y-m-d');
-        $newEnd = calculateNewEndDate($futureEnd, 'monthly');
-        $this->assertSame($expected, substr($newEnd, 0, 10));
+        $futureEnd = $this->base->modify('+10 days')->format('Y-m-d H:i:s');
+        $minExpected = $this->base->modify('+1 month +9 days')->format('Y-m-d');
+        $maxExpected = $this->base->modify('+1 month +11 days')->format('Y-m-d');
+
+        $newEnd = substr(calculateNewEndDate($futureEnd, 'monthly'), 0, 10);
+
+        $this->assertGreaterThanOrEqual($minExpected, $newEnd);
+        $this->assertLessThanOrEqual($maxExpected, $newEnd);
     }
 
     public function test_extends_from_now_when_end_date_is_in_past(): void
@@ -29,27 +54,25 @@ final class RenewalHelpersTest extends TestCase
         // End date 30 days ago. Without the "stale end_date" guard, the new
         // end date would be 30 days ago + 1 month ≈ now, potentially still in
         // the past — risking another renewal pickup on the next cron run.
-        $pastEnd = (new DateTime('-30 days'))->format('Y-m-d H:i:s');
-        $expectedMin = (new DateTime('+27 days'))->format('Y-m-d');
-        $expectedMax = (new DateTime('+33 days'))->format('Y-m-d');
+        $pastEnd = $this->base->modify('-30 days')->format('Y-m-d H:i:s');
+        $expectedMin = $this->base->modify('+27 days')->format('Y-m-d');
+        $expectedMax = $this->base->modify('+33 days')->format('Y-m-d');
 
-        $newEnd = calculateNewEndDate($pastEnd, 'monthly');
-        $newEndDate = substr($newEnd, 0, 10);
+        $newEnd = substr(calculateNewEndDate($pastEnd, 'monthly'), 0, 10);
 
-        $this->assertGreaterThanOrEqual($expectedMin, $newEndDate);
-        $this->assertLessThanOrEqual($expectedMax, $newEndDate);
+        $this->assertGreaterThanOrEqual($expectedMin, $newEnd);
+        $this->assertLessThanOrEqual($expectedMax, $newEnd);
     }
 
     public function test_yearly_with_past_end_date_extends_from_now(): void
     {
-        $pastEnd = (new DateTime('-90 days'))->format('Y-m-d H:i:s');
-        $expectedMin = (new DateTime('+360 days'))->format('Y-m-d');
-        $expectedMax = (new DateTime('+370 days'))->format('Y-m-d');
+        $pastEnd = $this->base->modify('-90 days')->format('Y-m-d H:i:s');
+        $expectedMin = $this->base->modify('+360 days')->format('Y-m-d');
+        $expectedMax = $this->base->modify('+370 days')->format('Y-m-d');
 
-        $newEnd = calculateNewEndDate($pastEnd, 'yearly');
-        $newEndDate = substr($newEnd, 0, 10);
+        $newEnd = substr(calculateNewEndDate($pastEnd, 'yearly'), 0, 10);
 
-        $this->assertGreaterThanOrEqual($expectedMin, $newEndDate);
-        $this->assertLessThanOrEqual($expectedMax, $newEndDate);
+        $this->assertGreaterThanOrEqual($expectedMin, $newEnd);
+        $this->assertLessThanOrEqual($expectedMax, $newEnd);
     }
 }

--- a/tests/Unit/Renewal/RenewalHelpersTest.php
+++ b/tests/Unit/Renewal/RenewalHelpersTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Renewal;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+final class RenewalHelpersTest extends TestCase
+{
+    public function test_yearly_adds_one_year_from_future_end_date(): void
+    {
+        $futureEnd = (new DateTime('+30 days'))->format('Y-m-d H:i:s');
+        $expected = (new DateTime('+30 days'))->modify('+1 year')->format('Y-m-d');
+        $newEnd = calculateNewEndDate($futureEnd, 'yearly');
+        $this->assertSame($expected, substr($newEnd, 0, 10));
+    }
+
+    public function test_monthly_adds_one_month_from_future_end_date(): void
+    {
+        $futureEnd = (new DateTime('+10 days'))->format('Y-m-d H:i:s');
+        $expected = (new DateTime('+10 days'))->modify('+1 month')->format('Y-m-d');
+        $newEnd = calculateNewEndDate($futureEnd, 'monthly');
+        $this->assertSame($expected, substr($newEnd, 0, 10));
+    }
+
+    public function test_extends_from_now_when_end_date_is_in_past(): void
+    {
+        // End date 30 days ago. Without the "stale end_date" guard, the new
+        // end date would be 30 days ago + 1 month ≈ now, potentially still in
+        // the past — risking another renewal pickup on the next cron run.
+        $pastEnd = (new DateTime('-30 days'))->format('Y-m-d H:i:s');
+        $expectedMin = (new DateTime('+27 days'))->format('Y-m-d');
+        $expectedMax = (new DateTime('+33 days'))->format('Y-m-d');
+
+        $newEnd = calculateNewEndDate($pastEnd, 'monthly');
+        $newEndDate = substr($newEnd, 0, 10);
+
+        $this->assertGreaterThanOrEqual($expectedMin, $newEndDate);
+        $this->assertLessThanOrEqual($expectedMax, $newEndDate);
+    }
+
+    public function test_yearly_with_past_end_date_extends_from_now(): void
+    {
+        $pastEnd = (new DateTime('-90 days'))->format('Y-m-d H:i:s');
+        $expectedMin = (new DateTime('+360 days'))->format('Y-m-d');
+        $expectedMax = (new DateTime('+370 days'))->format('Y-m-d');
+
+        $newEnd = calculateNewEndDate($pastEnd, 'yearly');
+        $newEndDate = substr($newEnd, 0, 10);
+
+        $this->assertGreaterThanOrEqual($expectedMin, $newEndDate);
+        $this->assertLessThanOrEqual($expectedMax, $newEndDate);
+    }
+}

--- a/tests/Unit/Webhooks/SquareSignatureTest.php
+++ b/tests/Unit/Webhooks/SquareSignatureTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Webhooks;
+
+use PHPUnit\Framework\TestCase;
+
+final class SquareSignatureTest extends TestCase
+{
+    private const URL = 'https://example.com/api/portal/webhooks/square';
+    private const KEY = 'test_secret_key_xyz';
+    private const PAYLOAD = '{"type":"payment.completed","data":{"id":"abc123"}}';
+
+    private function expectedSignature(string $url, string $payload, string $key): string
+    {
+        return base64_encode(hash_hmac('sha256', $url . $payload, $key, true));
+    }
+
+    public function test_returns_true_for_valid_signature(): void
+    {
+        $sig = $this->expectedSignature(self::URL, self::PAYLOAD, self::KEY);
+        $this->assertTrue(verify_square_webhook_signature(self::URL, self::PAYLOAD, self::KEY, $sig));
+    }
+
+    public function test_returns_false_for_tampered_payload(): void
+    {
+        $sig = $this->expectedSignature(self::URL, self::PAYLOAD, self::KEY);
+        $tamperedPayload = '{"type":"payment.completed","data":{"id":"WRONG"}}';
+        $this->assertFalse(verify_square_webhook_signature(self::URL, $tamperedPayload, self::KEY, $sig));
+    }
+
+    public function test_returns_false_for_empty_signature(): void
+    {
+        $this->assertFalse(verify_square_webhook_signature(self::URL, self::PAYLOAD, self::KEY, ''));
+    }
+
+    public function test_returns_false_for_empty_key(): void
+    {
+        $sig = $this->expectedSignature(self::URL, self::PAYLOAD, self::KEY);
+        $this->assertFalse(verify_square_webhook_signature(self::URL, self::PAYLOAD, '', $sig));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+define('PROJECT_ROOT', dirname(__DIR__));
+
+require_once PROJECT_ROOT . '/vendor/autoload.php';
+
+// Load .env.testing first so its values land in $_ENV with mutable rights.
+// db_connect.php below will then load .env with createImmutable, which
+// (per phpdotenv contract) won't overwrite values already set here.
+$dotenv = Dotenv\Dotenv::createMutable(PROJECT_ROOT, '.env.testing');
+$dotenv->load();
+
+// Hard guard: refuse to run tests against any non-test database.
+if (($_ENV['DB_NAME'] ?? '') !== 'argo_books_test') {
+    fwrite(STDERR, "Refusing to run: DB_NAME must be 'argo_books_test' (got '" . ($_ENV['DB_NAME'] ?? '') . "')\n");
+    exit(1);
+}
+
+require_once PROJECT_ROOT . '/env_helper.php';
+require_once PROJECT_ROOT . '/db_connect.php';
+require_once PROJECT_ROOT . '/config/pricing.php';
+require_once PROJECT_ROOT . '/license_functions.php';
+require_once PROJECT_ROOT . '/api/portal/portal-helper.php';
+require_once PROJECT_ROOT . '/_email_helpers.php';
+require_once PROJECT_ROOT . '/email_sender.php';
+require_once PROJECT_ROOT . '/api/portal/webhooks/_square_helpers.php';
+require_once PROJECT_ROOT . '/api/portal/webhooks/_stripe_refund_db.php';
+require_once PROJECT_ROOT . '/cron/_renewal_helpers.php';
+
+// db_connect.php assigns $pdo at "top-level" of the included file, but when
+// included from a function/method scope (e.g. PHPUnit's TestRunner) that
+// "top-level" is actually local to the caller. Promote it to $GLOBALS so
+// production code paths that do `global $pdo;` see the connection.
+$GLOBALS['pdo'] = $pdo ?? null;
+
+if ($GLOBALS['pdo'] === null) {
+    fwrite(STDERR, "Test DB connection failed — verify argo_books_test exists and credentials in .env.testing match your local MySQL.\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds 67 tests (42 unit + 25 integration) covering high-stakes paths: license key generation/validation/redemption, AES-256-GCM round-trips, processing-fee math, Square webhook HMAC, Stripe refund DB updates, subscription renewal credit/idempotency logic, and email header sanitization.
- Four surgical refactors extract previously-inline logic into pure helpers (`sanitize_header_value`, `verify_square_webhook_signature`, `apply_stripe_refund_to_db`, `decide_renewal_charge` + `recently_renewed`) so it can be exercised without standing up the cron loop or live webhook handlers — call sites updated to delegate, behavior preserved.
- Local-only run via `vendor/bin/phpunit`; no CI added. Bootstrap hard-aborts unless `DB_NAME=argo_books_test`, so production data cannot be touched. Tests use a separate `argo_books_test` schema with transaction-rolled fixtures (or manual cleanup for functions that own their own transactions).

## Test plan

- [x] `vendor/bin/phpunit --testsuite=Unit` — 42 tests pass in <100ms
- [x] `vendor/bin/phpunit --testsuite=Integration` — 25 tests pass against `argo_books_test`
- [x] `vendor/bin/phpunit` (full) — 67 tests, 130 assertions, all green
- [x] Cleanup verified: `SELECT COUNT(*)` on `premium_subscription_keys`, `premium_subscriptions`, `premium_subscription_payments`, `portal_payments`, `portal_invoices`, `portal_companies` all return 0 after a full run
- [x] Bootstrap guard verified to abort when `DB_NAME != argo_books_test`
- [ ] Sanity-check on a sandbox env that the refactored Square webhook still verifies real signatures
- [ ] Sanity-check on a sandbox env that the refactored Stripe refund flow still updates invoice balance
- [ ] Sanity-check on a sandbox env that a renewal cron run still processes credit-covered renewals end to end

See [tests/README.md](tests/README.md) for setup instructions (PHP on PATH, create test DB, import schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)