### PR TITLE
Remove A/B automation toggle (now runs whenever outreach is enabled)

### DIFF
--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -4,7 +4,6 @@
  *
  * Renders toggles for:
  *   - Auto-send vs Review-before-send (state: auto_send_mode)
- *   - A/B automation on/off (state: ab_auto_enabled)
  *
  * Plus read-only status: current A/B test, daily send limit,
  * and a tail of today's pipeline log filtered to automation lines.
@@ -70,15 +69,6 @@ function settings_tab_handle_post($pdo)
             $_SESSION['message'] = 'Send mode set to: ' . ($mode === 'auto' ? 'Auto-send' : 'Review before send');
             $_SESSION['message_type'] = 'success';
         }
-        header('Location: index.php?tab=settings'); exit;
-    }
-
-    if ($action === 'set_ab_auto_enabled') {
-        $enabled = $_POST['enabled'] ?? '';
-        $val = ($enabled === '1') ? '1' : '0';
-        settings_tab_set_state($pdo, 'ab_auto_enabled', $val);
-        $_SESSION['message'] = 'A/B automation: ' . ($val === '1' ? 'ON' : 'OFF');
-        $_SESSION['message_type'] = 'success';
         header('Location: index.php?tab=settings'); exit;
     }
 
@@ -154,7 +144,6 @@ function settings_tab_render($pdo)
     $autoSendMode = settings_tab_get_state($pdo, 'auto_send_mode', 'auto');
     if (!in_array($autoSendMode, ['auto', 'review'], true)) $autoSendMode = 'auto';
 
-    $abAutoEnabled = settings_tab_get_state($pdo, 'ab_auto_enabled', '1') === '1';
     require_once __DIR__ . '/../../../cron/lib/outreach_helpers.php';
     $rotationOrder = ab_auto_rotation_order();
     $abNextType = settings_tab_get_state($pdo, 'ab_auto_next_type', $rotationOrder[0]);
@@ -164,8 +153,6 @@ function settings_tab_render($pdo)
 
     $dailyLimit = (int) ($_ENV['OUTREACH_DAILY_SEND_LIMIT'] ?? 10);
     $followupLimit = (int) ($_ENV['OUTREACH_DAILY_FOLLOWUP_LIMIT'] ?? 30);
-    $ctrFloor = (float) settings_tab_get_state($pdo, 'ab_ctr_floor', '0.01');
-    $replyFloor = (float) settings_tab_get_state($pdo, 'ab_reply_floor', '0.005');
 
     // Active A/B test snapshot — show whichever variant_type is currently
     // running (only one is active at a time, regardless of type).
@@ -222,19 +209,6 @@ function settings_tab_render($pdo)
         }
     }
     ?>
-
-    <?php if ($abAutoEnabled === false): ?>
-        <div class="panel" style="border-left:3px solid #f59e0b;">
-            <div class="panel-content">
-                <strong>A/B automation is off.</strong>
-                <?php if (settings_tab_get_state($pdo, 'ab_auto_last_pause_reason')): ?>
-                    The last automated run paused itself: <em><?php echo htmlspecialchars((string) settings_tab_get_state($pdo, 'ab_auto_last_pause_reason')); ?></em>
-                <?php else: ?>
-                    Flip the toggle below to let the pipeline create and promote tests on its own.
-                <?php endif; ?>
-            </div>
-        </div>
-    <?php endif; ?>
 
     <div class="panel">
         <div class="panel-header">
@@ -296,55 +270,6 @@ function settings_tab_render($pdo)
                     <button type="submit" class="segmented-option <?php echo $autoSendMode === 'review' ? 'active' : ''; ?>">
                         <span class="segmented-title">Review before send</span>
                         <span class="segmented-desc">Pipeline generates drafts and stops. Review or edit them in the Leads tab, then click Send Email (or use bulk send).</span>
-                    </button>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <div class="panel">
-        <div class="panel-header">
-            <h2>A/B automation</h2>
-        </div>
-        <div class="panel-content">
-            <p class="hint" style="margin-top:0;">
-                When on, the pipeline runs A/B cycles by itself: it auto-generates variants each cycle (or uses the fixed pool for sender / format / personalization), promotes the winner when it has enough data (or after 14&ndash;28 days), and starts the next cycle &mdash; rotating across types so it tests one lever, then another, and so on.
-                Promotion is scored on reply rate when any variant has a reply, falling back to CTR otherwise. It will self-pause if the winner's reply rate drops below <?php echo number_format($replyFloor * 100, 2); ?>% (when promoting on replies), or if CTR drops below <?php echo number_format($ctrFloor * 100, 1); ?>% (deliverability check, always evaluated).
-            </p>
-            <p class="hint">
-                Rotation order:
-            </p>
-            <ol class="hint" style="margin-top:0;">
-                <li><strong>Subject line</strong> &mdash; AI-generated subject styles.</li>
-                <li><strong>Sender from-name</strong> &mdash; "Evan" vs "Evan from Argo Books" vs "Argo Books".</li>
-                <li><strong>Format</strong> &mdash; full HTML email vs plain text.</li>
-                <li><strong>Personalization</strong> &mdash; with vs without the AI-generated business summary.</li>
-            </ol>
-            <p class="hint">
-                Body, CTA, and preheader tests aren't in the rotation: those need wording you write yourself, so they're always started by hand from the A/B Tests tab. Manual tests still work either way &mdash; they just delay the rotation while they run.
-                <?php if ($abAutoEnabled): ?>
-                    <br><br>The next type the cron will start is <strong><?php echo htmlspecialchars($abNextType); ?></strong> (assuming nothing else is running by then).
-                <?php endif; ?>
-            </p>
-            <div class="segmented-toggle">
-                <form method="POST" style="display:contents;">
-                    <input type="hidden" name="tab" value="settings">
-                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
-                    <input type="hidden" name="action" value="set_ab_auto_enabled">
-                    <input type="hidden" name="enabled" value="1">
-                    <button type="submit" class="segmented-option <?php echo $abAutoEnabled ? 'active' : ''; ?>">
-                        <span class="segmented-title">On</span>
-                        <span class="segmented-desc">Runs in the daily outreach cron.</span>
-                    </button>
-                </form>
-                <form method="POST" style="display:contents;">
-                    <input type="hidden" name="tab" value="settings">
-                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
-                    <input type="hidden" name="action" value="set_ab_auto_enabled">
-                    <input type="hidden" name="enabled" value="0">
-                    <button type="submit" class="segmented-option <?php echo !$abAutoEnabled ? 'active' : ''; ?>">
-                        <span class="segmented-title">Off</span>
-                        <span class="segmented-desc">Active test keeps running; no new cycles start.</span>
                     </button>
                 </form>
             </div>
@@ -498,11 +423,7 @@ function settings_tab_render($pdo)
                     </div>
                 </div>
             <?php else: ?>
-                <p class="empty-state">No active A/B test.
-                    <?php if ($abAutoEnabled): ?>
-                        The next pipeline run will create one.
-                    <?php endif; ?>
-                </p>
+                <p class="empty-state">No active A/B test. The next pipeline run will create one.</p>
             <?php endif; ?>
         </div>
     </div>

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -1574,13 +1574,11 @@ function ab_known_variant_types()
 /**
  * Evaluate the active test of a given variant type and promote a winner if
  * any exit criterion is met. Side effect: on trigger, UPDATE the test row to
- * completed with winner_variant_id set; optionally self-pauses automation if
- * the winning CTR is below the configured safety floor.
+ * completed with winner_variant_id set.
  *
  * Returns one of:
  *   ['action' => 'none', 'reason' => '...', 'variant_type' => $variantType, ...]
  *   ['action' => 'promoted', 'test_id' => N, 'variant_type' => $variantType, ...]
- *   ['action' => 'paused_safety', 'test_id' => N, 'variant_type' => $variantType, ...]
  *
  * Exit criteria (any one triggers promotion):
  *   a) leader significant at p<0.05 vs EVERY other variant AND every variant sent >= 30
@@ -1660,43 +1658,8 @@ function ab_check_and_promote_active_test($pdo, $variantType = 'subject')
     $pdo->prepare("UPDATE outreach_ab_tests SET winner_variant_id = ?, status = 'completed', completed_at = NOW() WHERE id = ?")
         ->execute([$winner['id'], $test['id']]);
 
-    // Safety-floor checks. CTR floor is always evaluated — it's a
-    // deliverability signal (CTR below 1% suggests the email isn't even
-    // reaching inboxes) regardless of which metric drove promotion. Reply
-    // floor is only evaluated when we promoted on reply rate.
-    $floorStmt = $pdo->prepare("SELECT state_key, state_value FROM outreach_pipeline_state WHERE state_key IN ('ab_ctr_floor','ab_reply_floor')");
-    $floorStmt->execute();
-    $floorRows = $floorStmt->fetchAll();
-    $ctrFloor = 0.01;
-    $replyFloor = 0.005;
-    foreach ($floorRows as $row) {
-        if ($row['state_key'] === 'ab_ctr_floor')   $ctrFloor   = (float) $row['state_value'];
-        if ($row['state_key'] === 'ab_reply_floor') $replyFloor = (float) $row['state_value'];
-    }
-
-    $pausedForSafety = false;
-    $pauseReason = null;
-    if ($winner['sent_count'] >= 20) {
-        if ($metric === 'reply_rate' && $winner['reply_rate'] < $replyFloor) {
-            $pauseReason = 'Winner reply rate ' . number_format($winner['reply_rate'] * 100, 2)
-                . '% below floor ' . number_format($replyFloor * 100, 2)
-                . '% on test #' . (int) $test['id'];
-        } elseif ($winner['ctr'] < $ctrFloor) {
-            $pauseReason = 'Winner CTR ' . number_format($winner['ctr'] * 100, 2)
-                . '% below floor ' . number_format($ctrFloor * 100, 2)
-                . '% on test #' . (int) $test['id'];
-        }
-    }
-    if ($pauseReason !== null) {
-        $pauseStmt = $pdo->prepare("INSERT INTO outreach_pipeline_state (state_key, state_value) VALUES (?, ?)
-            ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)");
-        $pauseStmt->execute(['ab_auto_enabled', '0']);
-        $pauseStmt->execute(['ab_auto_last_pause_reason', $pauseReason]);
-        $pausedForSafety = true;
-    }
-
     return [
-        'action' => $pausedForSafety ? 'paused_safety' : 'promoted',
+        'action' => 'promoted',
         'variant_type' => $variantType,
         'test_id' => (int) $test['id'],
         'test_name' => $test['name'],

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -439,12 +439,6 @@ function stepManageAbTests($pdo, $dryRun)
 {
     logPipeline('--- Step 2.5: Manage A/B Tests ---');
 
-    $enabled = getState($pdo, 'ab_auto_enabled', '1');
-    if ($enabled !== '1') {
-        logPipeline('A/B automation is OFF (ab_auto_enabled != 1). Skipping.');
-        return;
-    }
-
     // followup_sequence-specific shape check: if the active followup_sequence
     // test's variant intents no longer match the current followup_sequence_config
     // touch list (e.g. admin added a touch), auto-pause it.
@@ -479,7 +473,6 @@ function stepManageAbTests($pdo, $dryRun)
     //    one test can be active at a time per the framework's invariant; the
     //    loop is type-agnostic so any wired type can promote cleanly.
     $anyStillRunning = false;
-    $anyPaused = false;
     foreach ($allTypes as $type) {
         $evalResult = ab_check_and_promote_active_test($pdo, $type);
         $type = $evalResult['variant_type'] ?? $type;
@@ -498,20 +491,6 @@ function stepManageAbTests($pdo, $dryRun)
                 $metric,
                 $evalResult['age_days']
             ));
-        } elseif ($evalResult['action'] === 'paused_safety') {
-            $metric = $evalResult['metric'] ?? 'ctr';
-            $rate = $metric === 'reply_rate'
-                ? ($evalResult['winner_reply_rate'] ?? 0)
-                : $evalResult['winner_ctr'];
-            logPipeline(sprintf(
-                "A/B auto-paused for safety: %s test #%d promoted variant %s but %s %.2f%% fell below floor. ab_auto_enabled set to 0.",
-                $type,
-                $evalResult['test_id'],
-                $evalResult['winner_label'],
-                $metric === 'reply_rate' ? 'reply rate' : 'CTR',
-                $rate * 100
-            ), 'WARN');
-            $anyPaused = true;
         } elseif ($evalResult['action'] === 'none' && ($evalResult['reason'] ?? '') === 'criteria_not_met') {
             logPipeline(sprintf(
                 "A/B %s test #%d '%s' still running (age %d days, min sent %d) — no promotion criteria met yet.",
@@ -524,10 +503,6 @@ function stepManageAbTests($pdo, $dryRun)
             $anyStillRunning = true;
         }
     }
-
-    // Safety-pause short-circuits new-cycle creation across all types — admin
-    // needs to flip A/B automation back on in Settings before anything moves.
-    if ($anyPaused) return;
 
     // If any test is still running (any type), don't start a new cycle yet
     // — keep the one-active-test-at-a-time invariant.

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -85,9 +85,7 @@ Once a winner is promoted, the cron immediately starts the next cycle.
 
 ### Safety pause
 
-If the cron's own pick turns out badly — winner CTR under the configured floor (default 1%, stored in `outreach_pipeline_state.ab_ctr_floor`) — disables the A/B tests and shows an "A/B automation is off" banner at the top of the Settings tab. Flip the toggle below it to resume. This is so a run of bad cycles can't quietly drag CTR downward.
-
-The follow-up sequence A/B type also auto-pauses if the configured touch count changes while a test is active (e.g. you add a 4th touch in Settings but the active test only has intents for 3 touches). The mismatch shows up in the banner so you can either match the test to the new shape or revert the Settings change.
+The follow-up sequence A/B type auto-pauses if the configured touch count changes while a test is active (e.g. you add a 4th touch in Settings but the active test only has intents for 3 touches). The mismatch shows up in the A/B Tests tab so you can either match the test to the new shape or revert the Settings change.
 
 ## The Follow-ups tab
 
@@ -114,13 +112,13 @@ You can also see the per-lead sequence (every touch + status + scheduled date) b
 
 ## The Settings tab
 
-The Settings tab has three runtime toggles plus the sequence configuration:
+The Settings tab has two runtime controls plus the sequence configuration:
 
+- **Outreach system** — master enable/disable for the whole pipeline.
 - **Send mode** — Auto-send vs Review-before-send (affects both first emails AND follow-ups).
-- **A/B automation** — on/off for the auto-cycle that creates and promotes A/B tests.
 - **Follow-up sequence** — an editable table of touches. Each row is one touch: how many days after the previous touch it sends (1-90), and a default "intent" string that drives Gemini's wording (used when no follow-up A/B test is active). Add/remove rows for between 0 and 6 follow-up touches. Setting 0 touches disables follow-ups entirely.
 
-The Settings tab also shows the active A/B test snapshot and a tail of the day's pipeline log for quick health checks.
+A/B automation runs unconditionally whenever the outreach system is enabled — there's no separate on/off toggle. The Settings tab also shows the active A/B test snapshot and a tail of the day's pipeline log for quick health checks.
 
 ## What you should do
 


### PR DESCRIPTION
## Summary

- Removes the **A/B automation** on/off toggle from the Settings tab. A/B automation now runs unconditionally whenever the outreach system itself is enabled.
- Removes the CTR/reply-rate self-pause mechanism that previously flipped \`ab_auto_enabled=0\` when a winner's CTR dropped below the configured floor. With the toggle gone there was no admin-friendly way to un-pause, so the safety net is removed entirely per discussion.
- Updates \`read-me/Email outreach.md\` to reflect the new behavior.

The followup_sequence shape-mismatch auto-pause (in the A/B Tests tab) is unrelated and still works.

## What's removed

- \`set_ab_auto_enabled\` POST handler in [admin/outreach/tabs/settings.php](admin/outreach/tabs/settings.php)
- The whole \`<div class=\"panel\">\` for \"A/B automation\" in the Settings tab
- The \"A/B automation is off\" warning banner at the top of Settings
- The \`if (\$enabled !== '1') return;\` guard at the top of \`stepManageAbTests\` in [cron/outreach_pipeline.php](cron/outreach_pipeline.php)
- The \`paused_safety\` elseif branch and the \`\$anyPaused\` short-circuit
- The 20-line safety-pause block in \`ab_check_and_promote_active_test()\` in [cron/lib/outreach_helpers.php](cron/lib/outreach_helpers.php) — the lines that read \`ab_ctr_floor\` / \`ab_reply_floor\` and write \`ab_auto_enabled=0\` / \`ab_auto_last_pause_reason\`. The return shape no longer has \`'action' => 'paused_safety'\`.
- The doc's old \"Safety pause\" paragraph about the manual toggle. The shape-mismatch paragraph stays.

## Migration

No migration required. The existing \`outreach_pipeline_state\` rows for \`ab_auto_enabled\` and \`ab_auto_last_pause_reason\` become unread and harmless — they can be left in place, or cleaned up with:

\`\`\`sql
DELETE FROM outreach_pipeline_state WHERE state_key IN ('ab_auto_enabled', 'ab_auto_last_pause_reason');
\`\`\`

(Optional. The state keys \`ab_ctr_floor\` and \`ab_reply_floor\` also become unread but were already documented as configurable knobs — leaving them in case the floor mechanism is re-added later.)

## Test plan

- [ ] Load \`/admin/outreach/?tab=settings\` — verify the A/B automation panel is gone, no \"A/B automation is off\" banner appears even when ab_auto_enabled='0' is set in state
- [ ] Run \`php cron/outreach_pipeline.php --dry-run\` — verify the pipeline still completes; Step 2.5 should no longer log \"A/B automation is OFF\"
- [ ] Manually set \`ab_auto_enabled='0'\` in \`outreach_pipeline_state\` and run the pipeline — verify A/B management still runs (because the gate is gone)
- [ ] Verify the Follow-ups tab and the sequence Settings panel still work — they share the same Settings file

🤖 Generated with [Claude Code](https://claude.com/claude-code)