### PR TITLE
Add Shopify discovery source to outreach pipeline

### DIFF
--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -830,6 +830,33 @@ function send_followup_row($pdo, array $followupRow, ?string &$reason = null): b
     return false;
 }
 
+// ─── Email Gatekeeping Helper ───
+
+/**
+ * Returns true if the email's local part matches a "gatekept" role prefix —
+ * signals a multi-person operation (support desk, partnerships team, etc.)
+ * rather than a solo-founder inbox. CASL implied-consent outreach targets
+ * individual business owners, so these addresses should be rejected.
+ * Returns true for empty/malformed input as a defensive default.
+ */
+function filter_gatekept_email($email)
+{
+    if (empty($email)) return true;
+
+    $at = strpos($email, '@');
+    if ($at === false) return true;
+
+    $local = strtolower(substr($email, 0, $at));
+
+    static $gatekept = [
+        'support', 'partnerships', 'help', 'sales', 'careers', 'jobs',
+        'press', 'media', 'legal', 'billing', 'noreply', 'no-reply',
+        'donotreply', 'abuse', 'webmaster', 'postmaster',
+    ];
+
+    return in_array($local, $gatekept, true);
+}
+
 // ─── Email Scraping Helper ───
 
 /**

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -847,6 +847,7 @@ function filter_gatekept_email($email)
     if ($at === false) return true;
 
     $local = strtolower(substr($email, 0, $at));
+    if ($local === '') return true;
 
     static $gatekept = [
         'support', 'partnerships', 'help', 'sales', 'careers', 'jobs',

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -841,6 +841,7 @@ function send_followup_row($pdo, array $followupRow, ?string &$reason = null): b
  */
 function filter_gatekept_email($email)
 {
+    $email = trim($email);
     if (empty($email)) return true;
 
     $at = strpos($email, '@');

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -169,7 +169,7 @@ function fetch_shopify_products_json(string $storefrontUrl, int $timeout = 10): 
         'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
     ]);
 
-    $raw = @file_get_contents($endpoint, false, $context);
+    $raw = @file_get_contents($endpoint, false, $context, 0, 2097152);  // 2 MB cap
 
     // Check HTTP status from response headers
     if (isset($http_response_header) && is_array($http_response_header)) {
@@ -189,6 +189,9 @@ function fetch_shopify_products_json(string $storefrontUrl, int $timeout = 10): 
 
     $decoded = json_decode($raw, true);
     if (!is_array($decoded)) {
+        if (strlen($raw) >= 2097152) {
+            error_log("Shopify /products.json too large (>2MB) at $endpoint");
+        }
         return null;
     }
 
@@ -238,6 +241,7 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
             CURLOPT_USERAGENT       => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             CURLOPT_SSL_VERIFYPEER  => true,
             CURLOPT_ENCODING        => '',  // accept compressed responses
+            CURLOPT_MAXFILESIZE     => 2097152,  // 2 MB cap (enforced only when Content-Length is sent)
         ]);
         $html      = curl_exec($ch);
         $curlError = curl_error($ch);
@@ -250,6 +254,18 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
                 'fit'       => false,
                 'reason'    => 'fetch_failed',
                 'detail'    => 'HTTP fetch failed' . ($curlError ? ": {$curlError}" : " (HTTP {$httpCode})"),
+                'final_url' => $url,
+                'metadata'  => [],
+            ];
+        }
+
+        // Backup size guard: bail if response exceeds 2 MB regardless of Content-Length
+        if (is_string($html) && strlen($html) >= 2097152) {
+            error_log("Shopify storefront HTML too large (>2MB) at $url");
+            return [
+                'fit'       => false,
+                'reason'    => 'fetch_failed',
+                'detail'    => 'Storefront HTML response exceeded 2 MB size cap',
                 'final_url' => $url,
                 'metadata'  => [],
             ];

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -315,6 +315,7 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
     // Step 4: Age check — find the OLDEST product created_at
     // -------------------------------------------------------------------------
     $oldestTs = null;
+    $oldestDt = null;
     foreach ($products as $product) {
         if (empty($product['created_at'])) {
             continue;

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -12,6 +12,29 @@
 
 require_once __DIR__ . '/outreach_helpers.php';
 
+/**
+ * Reject URLs whose host resolves to a private, reserved, or loopback address.
+ * Defends against SSRF from crafted redirect chains. Returns true if the URL is
+ * safe to fetch from a server-side context.
+ */
+function _shopify_url_is_safe_external(string $url): bool
+{
+    $host = parse_url($url, PHP_URL_HOST);
+    if (!is_string($host) || $host === '') {
+        return false;
+    }
+    // If already a literal IP, validate directly
+    if (filter_var($host, FILTER_VALIDATE_IP)) {
+        return (bool) filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+    }
+    // Resolve hostname (synchronous; OK in cron context)
+    $ip = gethostbyname($host);
+    if ($ip === $host) {
+        return false;  // resolution failed
+    }
+    return (bool) filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+}
+
 const SHOPIFY_DORK_POOL = [
     'site:myshopify.com "based in canada" "contact"',
     'site:myshopify.com "ships from canada" "founded"',
@@ -200,7 +223,13 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         $html = $htmlOverride;
     } else {
         // Use cURL to reliably capture the final URL after redirects
+        if (!_shopify_url_is_safe_external($url)) {
+            return ['fit' => false, 'reason' => 'fetch_failed', 'detail' => 'Input URL host resolves to private/reserved IP', 'final_url' => $url, 'metadata' => []];
+        }
         $ch = curl_init($url);
+        if ($ch === false) {
+            return ['fit' => false, 'reason' => 'fetch_failed', 'detail' => 'curl_init failed', 'final_url' => $url, 'metadata' => []];
+        }
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER  => true,
             CURLOPT_FOLLOWLOCATION  => true,
@@ -214,7 +243,7 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         $curlError = curl_error($ch);
         $httpCode  = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $effective = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-        unset($ch);  // curl_close deprecated in PHP 8.4; unset achieves same cleanup
+        unset($ch);  // curl_close deprecated in PHP 8.5; unset achieves same cleanup
 
         if ($html === false || $curlError !== '' || $httpCode < 200 || $httpCode >= 400) {
             return [
@@ -228,6 +257,10 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
 
         if (!empty($effective)) {
             $finalUrl = rtrim($effective, '/');
+        }
+
+        if (!_shopify_url_is_safe_external($finalUrl)) {
+            return ['fit' => false, 'reason' => 'fetch_failed', 'detail' => 'Redirect target resolves to private/reserved IP', 'final_url' => $finalUrl, 'metadata' => []];
         }
     }
 
@@ -298,11 +331,15 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         }
     }
 
-    $nowTs     = time();
-    $ageMonths = ($oldestTs !== null) ? (($nowTs - $oldestTs) / (30.44 * 86400)) : 0;
-    $ageDays   = ($oldestTs !== null) ? (int) round(($nowTs - $oldestTs) / 86400) : 0;
+    if ($oldestTs === null) {
+        return ['fit' => false, 'reason' => 'age_unknown', 'detail' => 'No parseable created_at on any product', 'final_url' => $finalUrl, 'metadata' => $metadata];
+    }
 
-    if ($oldestTs !== null && $ageMonths < 3) {
+    $nowTs     = time();
+    $ageMonths = ($nowTs - $oldestTs) / (30.44 * 86400);
+    $ageDays   = (int) round(($nowTs - $oldestTs) / 86400);
+
+    if ($ageMonths < 3) {
         return [
             'fit'       => false,
             'reason'    => 'too_new',
@@ -312,7 +349,7 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         ];
     }
 
-    if ($oldestTs !== null && $ageMonths > 24) {
+    if ($ageMonths > 24) {
         $monthsInt = (int) round($ageMonths);
         return [
             'fit'       => false,
@@ -324,11 +361,8 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
     }
 
     // Store the oldest created_at as MySQL DATETIME
-    $mysqlDatetime = '';
-    if ($oldestTs !== null) {
-        /** @var DateTime $oldestDt */
-        $mysqlDatetime = $oldestDt->format('Y-m-d H:i:s');
-    }
+    /** @var DateTime $oldestDt */
+    $mysqlDatetime = $oldestDt->format('Y-m-d H:i:s');
     $metadata['first_product_created_at'] = $mysqlDatetime;
 
     // -------------------------------------------------------------------------
@@ -377,19 +411,34 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
     if ($htmlOverride !== null) {
         // Extract from the injected HTML (mirrors logic in _scrape_email_from_website_uncached)
         $email = null;
+        $falsePositives = ['example.com', 'sentry.io', 'wixpress.com', 'wordpress.org', 'w3.org', 'schema.org', 'googleapis.com', 'gravatar.com'];
         $decodedHtml = urldecode($htmlOverride);
-        if (preg_match('/mailto:\s*([^\s"\'<>]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/', $decodedHtml, $mEmail)) {
-            $candidate = trim(urldecode($mEmail[1]));
-            if (preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
-                $email = $candidate;
+        if (preg_match_all('/mailto:\s*([^\s"\'<>]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/', $decodedHtml, $mEmail)) {
+            foreach ($mEmail[1] as $raw) {
+                $candidate = trim(urldecode($raw));
+                if (!preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
+                    continue;
+                }
+                $isFp = false;
+                foreach ($falsePositives as $fp) {
+                    if (str_contains(strtolower($candidate), $fp)) { $isFp = true; break; }
+                }
+                if (!$isFp) { $email = $candidate; break; }
             }
         }
         if ($email === null) {
             $text = preg_replace('/[^\x20-\x7E\n\r\t]/', ' ', strip_tags($decodedHtml));
-            if (preg_match('/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/', $text, $mEmail)) {
-                $candidate = trim($mEmail[0]);
-                if (preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
-                    $email = $candidate;
+            if (preg_match_all('/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/', $text, $mEmail)) {
+                foreach ($mEmail[0] as $raw) {
+                    $candidate = trim($raw);
+                    if (!preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
+                        continue;
+                    }
+                    $isFp = false;
+                    foreach ($falsePositives as $fp) {
+                        if (str_contains(strtolower($candidate), $fp)) { $isFp = true; break; }
+                    }
+                    if (!$isFp) { $email = $candidate; break; }
                 }
             }
         }

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -117,13 +117,15 @@ function serpapi_query(string $query, string $apiKey, int $limit = 10): array
 }
 
 /**
- * Canonicalize a candidate Shopify store URL.
+ * Canonicalize a candidate Shopify store URL to its origin.
  *
- * Lowercases scheme + host, drops query string and fragment, drops trailing
- * slash on path. Returns the original trimmed string on parse_url failure.
+ * Lowercases scheme + host, drops query, fragment, AND path. The candidate
+ * identity is the store (one row per store), not the URL — so a SerpAPI hit
+ * on /pages/contact and another on /products/foo for the same store dedup
+ * to a single row. Returns the original trimmed string on parse_url failure.
  *
  * @param string $url Raw URL
- * @return string     Canonicalized URL
+ * @return string     Origin URL (scheme://host)
  */
 function shopify_canonical_url(string $url): string
 {
@@ -139,9 +141,12 @@ function shopify_canonical_url(string $url): string
 
     $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : 'https';
     $host   = strtolower($parts['host']);
-    $path   = isset($parts['path']) ? rtrim($parts['path'], '/') : '';
 
-    return $scheme . '://' . $host . $path;
+    // Origin only — path is intentionally dropped. SerpAPI dorks that include
+    // "contact"/"about" keywords often return deep links, but our candidate
+    // identity is the store (one row per store), and downstream evaluator
+    // logic needs the origin to build /products.json correctly.
+    return $scheme . '://' . $host;
 }
 
 /**
@@ -161,8 +166,11 @@ function fetch_shopify_products_json(string $storefrontUrl, int $timeout = 10): 
     $context = stream_context_create([
         'http' => [
             'timeout'         => $timeout,
-            'follow_location' => 1,
-            'max_redirects'   => 3,
+            // Redirects disabled: /products.json lives on the same origin as
+            // the storefront; a redirect target could be an internal/private
+            // URL (SSRF vector). Fail closed instead.
+            'follow_location' => 0,
+            'max_redirects'   => 0,
             'user_agent'      => 'Mozilla/5.0',
             'ignore_errors'   => true,
         ],
@@ -247,7 +255,7 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         $curlError = curl_error($ch);
         $httpCode  = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $effective = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-        unset($ch);  // curl_close deprecated in PHP 8.5; unset achieves same cleanup
+        curl_close($ch);
 
         if ($html === false || $curlError !== '' || $httpCode < 200 || $httpCode >= 400) {
             return [
@@ -272,7 +280,10 @@ function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?
         }
 
         if (!empty($effective)) {
-            $finalUrl = rtrim($effective, '/');
+            // Normalize to origin — drops any path the redirect chain ended at,
+            // so downstream /products.json and contact-page probing work
+            // correctly when the candidate URL was a deep link.
+            $finalUrl = shopify_canonical_url($effective);
         }
 
         if (!_shopify_url_is_safe_external($finalUrl)) {

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Shopify-store discovery helpers used by the outreach pipeline.
+ *
+ * Discovers small, recent Canadian Shopify stores via SerpAPI dorking + storefront
+ * fitness checks. CASL implied-consent: emails come exclusively from the store's own
+ * contact page via scrape_email_from_website().
+ *
+ * Pure helpers: no DB writes, no cron-state mutations. Caller (stepDiscoverShopify)
+ * orchestrates DB + state.
+ */
+
+require_once __DIR__ . '/outreach_helpers.php';
+
+const SHOPIFY_DORK_POOL = [
+    'site:myshopify.com "based in canada" "contact"',
+    'site:myshopify.com "ships from canada" "founded"',
+    'site:myshopify.com "made in canada" "small batch"',
+    'site:myshopify.com "toronto" "shop"',
+    'site:myshopify.com "vancouver" "small business"',
+    'site:myshopify.com "calgary" OR "edmonton" "handmade"',
+    'site:myshopify.com "ottawa" OR "montreal" "founded in 2024"',
+    'site:myshopify.com "proudly canadian" "contact us"',
+    'site:myshopify.com "shipping across canada" "about"',
+    'site:myshopify.com "canadian small business" "contact"',
+];
+
+/**
+ * Query SerpAPI for organic results matching $query.
+ *
+ * @param string $query   Google dork query string
+ * @param string $apiKey  SerpAPI API key
+ * @param int    $limit   Max results (default 10)
+ * @return array          Array of ['link'=>..., 'title'=>..., 'snippet'=>...] entries
+ */
+function serpapi_query(string $query, string $apiKey, int $limit = 10): array
+{
+    $url = 'https://serpapi.com/search.json?engine=google'
+        . '&q=' . urlencode($query)
+        . '&api_key=' . urlencode($apiKey)
+        . '&num=' . (int) $limit
+        . '&hl=en&gl=ca';
+
+    $context = stream_context_create([
+        'http' => [
+            'timeout'          => 30,
+            'follow_location'  => 1,
+            'max_redirects'    => 3,
+            'user_agent'       => 'Mozilla/5.0',
+            'ignore_errors'    => true,
+        ],
+        'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
+    ]);
+
+    $attempt = 0;
+    $raw     = false;
+    while ($attempt < 2) {
+        $raw = @file_get_contents($url, false, $context);
+        if ($raw !== false && $raw !== '') {
+            break;
+        }
+        $attempt++;
+        if ($attempt < 2) {
+            sleep(1);
+        }
+    }
+
+    if ($raw === false || $raw === '') {
+        error_log("serpapi_query: empty/false response for query: {$query}");
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        error_log('serpapi_query: JSON decode failure for query: ' . $query);
+        return [];
+    }
+
+    if (empty($decoded['organic_results']) || !is_array($decoded['organic_results'])) {
+        error_log('serpapi_query: no organic_results for query: ' . $query);
+        return [];
+    }
+
+    $results = [];
+    foreach (array_slice($decoded['organic_results'], 0, $limit) as $item) {
+        $results[] = [
+            'link'    => isset($item['link'])    ? (string) $item['link']    : '',
+            'title'   => isset($item['title'])   ? (string) $item['title']   : '',
+            'snippet' => isset($item['snippet']) ? (string) $item['snippet'] : '',
+        ];
+    }
+
+    return $results;
+}
+
+/**
+ * Canonicalize a candidate Shopify store URL.
+ *
+ * Lowercases scheme + host, drops query string and fragment, drops trailing
+ * slash on path. Returns the original trimmed string on parse_url failure.
+ *
+ * @param string $url Raw URL
+ * @return string     Canonicalized URL
+ */
+function shopify_canonical_url(string $url): string
+{
+    $url = trim($url);
+    if ($url === '') {
+        return '';
+    }
+
+    $parts = parse_url($url);
+    if ($parts === false || empty($parts['host'])) {
+        return $url;
+    }
+
+    $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : 'https';
+    $host   = strtolower($parts['host']);
+    $path   = isset($parts['path']) ? rtrim($parts['path'], '/') : '';
+
+    return $scheme . '://' . $host . $path;
+}
+
+/**
+ * Fetch and decode a Shopify storefront /products.json endpoint.
+ *
+ * Returns the decoded JSON array on success, or null on any failure.
+ * Callers should check $result['products'] for the actual product list.
+ *
+ * @param string $storefrontUrl Base storefront URL (no trailing slash required)
+ * @param int    $timeout       HTTP timeout in seconds (default 10)
+ * @return array|null           Decoded JSON or null on failure
+ */
+function fetch_shopify_products_json(string $storefrontUrl, int $timeout = 10): ?array
+{
+    $endpoint = rtrim($storefrontUrl, '/') . '/products.json?limit=50';
+
+    $context = stream_context_create([
+        'http' => [
+            'timeout'         => $timeout,
+            'follow_location' => 1,
+            'max_redirects'   => 3,
+            'user_agent'      => 'Mozilla/5.0',
+            'ignore_errors'   => true,
+        ],
+        'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
+    ]);
+
+    $raw = @file_get_contents($endpoint, false, $context);
+
+    // Check HTTP status from response headers
+    if (isset($http_response_header) && is_array($http_response_header)) {
+        // First header line is the HTTP status line, e.g. "HTTP/1.1 200 OK"
+        $statusLine = $http_response_header[0] ?? '';
+        if (preg_match('/\s(\d{3})\s/', $statusLine, $m)) {
+            $statusCode = (int) $m[1];
+            if ($statusCode === 404 || $statusCode < 200 || $statusCode >= 300) {
+                return null;
+            }
+        }
+    }
+
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return null;
+    }
+
+    if (!isset($decoded['products']) || !is_array($decoded['products'])) {
+        return null;
+    }
+
+    return $decoded;
+}
+
+/**
+ * Evaluate a Shopify storefront URL for outreach fitness.
+ *
+ * Runs a pipeline of checks (agency detection, products count, age, country,
+ * email) and returns a structured result. The $htmlOverride and
+ * $productsOverride params skip network fetches for testing.
+ *
+ * @param string     $url              Candidate storefront URL
+ * @param string|null $htmlOverride    Inject HTML instead of fetching live
+ * @param array|null  $productsOverride Inject products.json decoded array instead of fetching live
+ * @return array     ['fit'=>bool, 'reason'=>string, 'final_url'=>string, 'metadata'=>array, ...]
+ */
+function evaluate_shopify_candidate(string $url, ?string $htmlOverride = null, ?array $productsOverride = null): array
+{
+    $finalUrl = $url;
+    $metadata = [];
+
+    // -------------------------------------------------------------------------
+    // Step 1: Fetch storefront HTML (or use injected override)
+    // -------------------------------------------------------------------------
+    if ($htmlOverride !== null) {
+        $html = $htmlOverride;
+    } else {
+        // Use cURL to reliably capture the final URL after redirects
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_MAXREDIRS       => 3,
+            CURLOPT_TIMEOUT         => 10,
+            CURLOPT_USERAGENT       => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+            CURLOPT_SSL_VERIFYPEER  => true,
+            CURLOPT_ENCODING        => '',  // accept compressed responses
+        ]);
+        $html      = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $httpCode  = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $effective = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+        unset($ch);  // curl_close deprecated in PHP 8.4; unset achieves same cleanup
+
+        if ($html === false || $curlError !== '' || $httpCode < 200 || $httpCode >= 400) {
+            return [
+                'fit'       => false,
+                'reason'    => 'fetch_failed',
+                'detail'    => 'HTTP fetch failed' . ($curlError ? ": {$curlError}" : " (HTTP {$httpCode})"),
+                'final_url' => $url,
+                'metadata'  => [],
+            ];
+        }
+
+        if (!empty($effective)) {
+            $finalUrl = rtrim($effective, '/');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 2: Agency detection
+    // -------------------------------------------------------------------------
+    if (preg_match('/powered\s+by\s+(?!shopify\b)([^<\n]{1,80})/i', $html, $agencyMatch)) {
+        $detail = strip_tags($agencyMatch[0]);
+        $detail = trim($detail);
+        $detail = substr($detail, 0, 200);
+        return [
+            'fit'       => false,
+            'reason'    => 'agency_operated',
+            'detail'    => $detail,
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 3: Fetch /products.json (or use injected override) + count check
+    // -------------------------------------------------------------------------
+    if ($productsOverride !== null) {
+        $productsData = $productsOverride;
+    } else {
+        $productsData = fetch_shopify_products_json($finalUrl);
+    }
+
+    if ($productsData === null) {
+        return [
+            'fit'       => false,
+            'reason'    => 'not_shopify',
+            'detail'    => 'No /products.json or invalid response',
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    $products = $productsData['products'] ?? [];
+
+    if (count($products) < 5) {
+        return [
+            'fit'       => false,
+            'reason'    => 'too_few_products',
+            'detail'    => 'Only ' . count($products) . ' products',
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 4: Age check — find the OLDEST product created_at
+    // -------------------------------------------------------------------------
+    $oldestTs = null;
+    foreach ($products as $product) {
+        if (empty($product['created_at'])) {
+            continue;
+        }
+        try {
+            $dt = new DateTime($product['created_at']);
+            $ts = $dt->getTimestamp();
+            if ($oldestTs === null || $ts < $oldestTs) {
+                $oldestTs = $ts;
+                $oldestDt = $dt;
+            }
+        } catch (Exception) {
+            // Skip unparseable dates
+        }
+    }
+
+    $nowTs     = time();
+    $ageMonths = ($oldestTs !== null) ? (($nowTs - $oldestTs) / (30.44 * 86400)) : 0;
+    $ageDays   = ($oldestTs !== null) ? (int) round(($nowTs - $oldestTs) / 86400) : 0;
+
+    if ($oldestTs !== null && $ageMonths < 3) {
+        return [
+            'fit'       => false,
+            'reason'    => 'too_new',
+            'detail'    => "First product created {$ageDays} days ago",
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    if ($oldestTs !== null && $ageMonths > 24) {
+        $monthsInt = (int) round($ageMonths);
+        return [
+            'fit'       => false,
+            'reason'    => 'too_old',
+            'detail'    => "First product created {$monthsInt} months ago",
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    // Store the oldest created_at as MySQL DATETIME
+    $mysqlDatetime = '';
+    if ($oldestTs !== null) {
+        /** @var DateTime $oldestDt */
+        $mysqlDatetime = $oldestDt->format('Y-m-d H:i:s');
+    }
+    $metadata['first_product_created_at'] = $mysqlDatetime;
+
+    // -------------------------------------------------------------------------
+    // Step 5: Country (Canada) check
+    // -------------------------------------------------------------------------
+    // Canadian postal code: valid first letters only (no D, F, I, O, Q, U, W, Z)
+    $isCanadian = false;
+
+    if (preg_match('/\b[ABCEGHJ-NPRSTVXY]\d[A-Z][ \-]?\d[A-Z]\d\b/i', $html)) {
+        $isCanadian = true;
+    } else {
+        $canadaSignals = [
+            'made in canada',
+            'based in canada',
+            'proudly canadian',
+            'ships from canada',
+            'canadian small business',
+            ', canada',
+        ];
+        $htmlLower = strtolower($html);
+        foreach ($canadaSignals as $signal) {
+            if (str_contains($htmlLower, $signal)) {
+                $isCanadian = true;
+                break;
+            }
+        }
+    }
+
+    if (!$isCanadian) {
+        return [
+            'fit'       => false,
+            'reason'    => 'not_canadian',
+            'detail'    => 'No CA postal code or Canadian address signal',
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    $metadata['country'] = 'CA';
+
+    // -------------------------------------------------------------------------
+    // Step 6: Harvest contact email
+    // When HTML is injected (test mode), extract email directly from the override
+    // so no live network call is needed. For live mode, use the full scraper.
+    // -------------------------------------------------------------------------
+    if ($htmlOverride !== null) {
+        // Extract from the injected HTML (mirrors logic in _scrape_email_from_website_uncached)
+        $email = null;
+        $decodedHtml = urldecode($htmlOverride);
+        if (preg_match('/mailto:\s*([^\s"\'<>]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/', $decodedHtml, $mEmail)) {
+            $candidate = trim(urldecode($mEmail[1]));
+            if (preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
+                $email = $candidate;
+            }
+        }
+        if ($email === null) {
+            $text = preg_replace('/[^\x20-\x7E\n\r\t]/', ' ', strip_tags($decodedHtml));
+            if (preg_match('/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/', $text, $mEmail)) {
+                $candidate = trim($mEmail[0]);
+                if (preg_match('/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/', $candidate)) {
+                    $email = $candidate;
+                }
+            }
+        }
+    } else {
+        $email = scrape_email_from_website($finalUrl);
+    }
+
+    if ($email === null) {
+        return [
+            'fit'       => false,
+            'reason'    => 'no_contact_email',
+            'detail'    => 'No email harvested from contact pages',
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    if (filter_gatekept_email($email)) {
+        return [
+            'fit'       => false,
+            'reason'    => 'gatekept_email',
+            'detail'    => "Skipped {$email} (role mailbox)",
+            'final_url' => $finalUrl,
+            'metadata'  => $metadata,
+        ];
+    }
+
+    $metadata['email'] = $email;
+
+    // -------------------------------------------------------------------------
+    // Step 7: Extract business name from <title>
+    // -------------------------------------------------------------------------
+    if (preg_match('/<title[^>]*>([^<]+)<\/title>/i', $html, $titleMatch)) {
+        $name = html_entity_decode(trim($titleMatch[1]), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $name = substr($name, 0, 200);
+    } else {
+        $parsed = parse_url($finalUrl);
+        $name   = $parsed['host'] ?? $finalUrl;
+    }
+
+    $metadata['business_name']  = $name;
+    $metadata['products_count'] = count($products);
+
+    // -------------------------------------------------------------------------
+    // Step 8: Return fit result
+    // -------------------------------------------------------------------------
+    return [
+        'fit'       => true,
+        'reason'    => 'ok',
+        'final_url' => $finalUrl,
+        'metadata'  => [
+            'business_name'            => $metadata['business_name'],
+            'email'                    => $metadata['email'],
+            'products_count'           => $metadata['products_count'],
+            'first_product_created_at' => $metadata['first_product_created_at'],
+            'country'                  => $metadata['country'],
+        ],
+    ];
+}

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -15,7 +15,8 @@
  *
  * Manual execution:
  *   php outreach_pipeline.php
- *   php outreach_pipeline.php --discover-only   # Only run discovery + import
+ *   php outreach_pipeline.php --discover-only   # Only run discovery + import (Google Places + Shopify)
+ *   php outreach_pipeline.php --shopify-only    # Only run Shopify discovery
  *   php outreach_pipeline.php --draft-only      # Only run draft generation
  *   php outreach_pipeline.php --send-only       # Only run send (same as outreach_email.php)
  *   php outreach_pipeline.php --dry-run         # Log what would happen without doing it
@@ -36,6 +37,7 @@ $dotenv->load();
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../email_sender.php';
 require_once __DIR__ . '/lib/outreach_helpers.php';
+require_once __DIR__ . '/lib/shopify_discovery.php';
 
 // ─── Lock file to prevent overlapping runs ───
 
@@ -62,10 +64,11 @@ define('DAILY_DRAFT_LIMIT', (int) ($_ENV['OUTREACH_DAILY_DRAFT_LIMIT'] ?? 100));
 // Parse CLI flags ($argv is null under CGI, fall back to empty array)
 $args = array_slice($argv ?? [], 1);
 $discoverOnly = in_array('--discover-only', $args);
+$shopifyOnly = in_array('--shopify-only', $args);
 $draftOnly = in_array('--draft-only', $args);
 $sendOnly = in_array('--send-only', $args);
 $dryRun = in_array('--dry-run', $args);
-$runAll = !$discoverOnly && !$draftOnly && !$sendOnly;
+$runAll = !$discoverOnly && !$draftOnly && !$sendOnly && !$shopifyOnly;
 
 // ─── Target Cities (Saskatchewan first, then expand outward) ───
 
@@ -190,6 +193,11 @@ try {
     // ─── STEP 1 & 2: Discover + Import ───
     if ($runAll || $discoverOnly) {
         stepDiscover($pdo, $dryRun);
+    }
+
+    // ─── STEP 1b: Discover Shopify Stores (parallel discovery source) ───
+    if ($runAll || $discoverOnly || $shopifyOnly) {
+        stepDiscoverShopify($pdo, $dryRun);
     }
 
     // ─── STEP 2.5: Manage A/B Tests (auto-promote winners, auto-create next cycle) ───
@@ -433,6 +441,222 @@ function stepDiscover($pdo, $dryRun)
     } catch (PDOException $e) {
         // Cleanup failure shouldn't fail the pipeline — table may not exist yet.
     }
+}
+
+function stepDiscoverShopify($pdo, $dryRun)
+{
+    logPipeline('--- Step 1b: Discover Shopify Stores ---');
+
+    // ─── Guard 1: Feature flag ───
+    $enabled = $_ENV['OUTREACH_SHOPIFY_ENABLED'] ?? 'false';
+    if ($enabled !== 'true') {
+        logPipeline('Shopify discovery is DISABLED via OUTREACH_SHOPIFY_ENABLED. Skipping.');
+        return;
+    }
+
+    // ─── Guard 2: SerpAPI key ───
+    $serpapiKey = $_ENV['SERPAPI_KEY'] ?? '';
+    if (empty($serpapiKey)) {
+        logPipeline('SERPAPI_KEY not configured. Skipping Shopify discovery.', 'WARN');
+        return;
+    }
+
+    // ─── Guard 3: Daily counter reset ───
+    $today = date('Y-m-d');
+    $lastReset = getState($pdo, 'shopify_last_reset_date', '');
+    if ($lastReset !== $today) {
+        setState($pdo, 'shopify_imports_today', '0');
+        setState($pdo, 'serpapi_calls_today', '0');
+        setState($pdo, 'shopify_last_reset_date', $today);
+        logPipeline("Daily Shopify counters reset for $today.");
+    }
+
+    // ─── Guard 4: SerpAPI daily limit ───
+    $serpapiLimit = (int) ($_ENV['SERPAPI_DAILY_QUERY_LIMIT'] ?? 3);
+    $serpapiCallsToday = (int) getState($pdo, 'serpapi_calls_today', '0');
+    if ($serpapiCallsToday >= $serpapiLimit) {
+        logPipeline("SerpAPI daily limit reached ($serpapiCallsToday/$serpapiLimit). Skipping Shopify discovery.");
+        return;
+    }
+
+    // ─── Guard 5: Shopify import daily limit ───
+    $shopifyImportLimit = (int) ($_ENV['OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT'] ?? 5);
+    $shopifyImportsToday = (int) getState($pdo, 'shopify_imports_today', '0');
+    if ($shopifyImportsToday >= $shopifyImportLimit) {
+        logPipeline("Shopify import daily limit reached ($shopifyImportsToday/$shopifyImportLimit). Skipping Shopify discovery.");
+        return;
+    }
+
+    // ─── Pick next dork query ───
+    $dorkPool = SHOPIFY_DORK_POOL;
+    $cursor = (int) getState($pdo, 'shopify_dork_cursor', '0');
+    $query = $dorkPool[$cursor % count($dorkPool)];
+    $nextCursor = $cursor + 1;
+    setState($pdo, 'shopify_dork_cursor', (string) $nextCursor);
+
+    logPipeline("Shopify discovery: dork cursor=$cursor, query='$query'");
+
+    // ─── Dry run ───
+    if ($dryRun) {
+        logPipeline("[DRY RUN] Would call SerpAPI with query='$query', then evaluate up to $shopifyImportLimit Shopify candidates.");
+        return;
+    }
+
+    // ─── Call SerpAPI ───
+    $results = serpapi_query($query, $serpapiKey, 10);
+    // Increment serpapi_calls_today regardless of result
+    setState($pdo, 'serpapi_calls_today', (string) ($serpapiCallsToday + 1));
+
+    if (empty($results)) {
+        logPipeline("SerpAPI returned no results for query='$query'. Skipping candidate evaluation.");
+        return;
+    }
+
+    logPipeline("SerpAPI returned " . count($results) . " results for query='$query'.");
+
+    // ─── Insert candidates via INSERT IGNORE, collect newly-inserted ───
+    $newCandidates = [];
+    foreach ($results as $result) {
+        $rawLink = $result['link'] ?? '';
+        if ($rawLink === '') {
+            continue;
+        }
+        $canonical = shopify_canonical_url($rawLink);
+        if ($canonical === '') {
+            continue;
+        }
+
+        $stmt = $pdo->prepare(
+            "INSERT IGNORE INTO outreach_shopify_candidates (canonical_url, status, last_query)
+             VALUES (?, 'pending', ?)"
+        );
+        $stmt->execute([$canonical, $query]);
+
+        if ($stmt->rowCount() === 1) {
+            // Newly inserted — add to evaluation queue
+            $newCandidates[] = $canonical;
+        }
+    }
+
+    logPipeline("Inserted " . count($newCandidates) . " new candidates into outreach_shopify_candidates.");
+
+    // ─── Evaluate newly-pending candidates ───
+    $evaluated = 0;
+    $imported  = 0;
+    $rejected  = 0;
+    $errored   = 0;
+
+    foreach ($newCandidates as $canonical) {
+        if ($shopifyImportsToday >= $shopifyImportLimit) {
+            break;
+        }
+
+        $evaluated++;
+
+        try {
+            $evalResult = evaluate_shopify_candidate($canonical);
+        } catch (Exception $e) {
+            logPipeline("Error evaluating candidate '$canonical': " . $e->getMessage(), 'ERROR');
+            $errored++;
+            continue;
+        }
+
+        if ($evalResult['fit'] === true) {
+            $meta      = $evalResult['metadata'];
+            $email     = $meta['email'] ?? null;
+            $finalUrl  = $evalResult['final_url'] ?? $canonical;
+
+            // Dedup check: email or website already in outreach_leads
+            $dupCheck = $pdo->prepare(
+                "SELECT id FROM outreach_leads WHERE email = ? OR website = ? LIMIT 1"
+            );
+            $dupCheck->execute([$email, $finalUrl]);
+            if ($dupCheck->fetch()) {
+                // Mark candidate as rejected / duplicate
+                $upd = $pdo->prepare(
+                    "UPDATE outreach_shopify_candidates
+                     SET status='rejected', reject_reason='duplicate'
+                     WHERE canonical_url = ?"
+                );
+                $upd->execute([$canonical]);
+                logPipeline("Shopify candidate '$canonical' skipped — already in outreach_leads (duplicate).");
+                $rejected++;
+                continue;
+            }
+
+            // Build business_summary
+            $productsCount          = $meta['products_count'] ?? 0;
+            $firstProductCreatedAt  = $meta['first_product_created_at'] ?? '';
+            $businessSummary = "Shopify store. {$productsCount} products."
+                . ($firstProductCreatedAt ? " First product created {$firstProductCreatedAt}." : '')
+                . " Discovered via: {$query}";
+
+            // Insert lead
+            $insLead = $pdo->prepare(
+                "INSERT INTO outreach_leads
+                 (business_name, email, website, source, contact_page_url, business_summary)
+                 VALUES (?, ?, ?, 'shopify_auto', ?, ?)"
+            );
+            $insLead->execute([
+                $meta['business_name'] ?? $canonical,
+                $email,
+                $finalUrl,
+                $finalUrl,
+                $businessSummary,
+            ]);
+            $leadId = (int) $pdo->lastInsertId();
+
+            // Update candidate as imported
+            $updCand = $pdo->prepare(
+                "UPDATE outreach_shopify_candidates
+                 SET status='imported',
+                     lead_id=?,
+                     harvested_email=?,
+                     products_count=?,
+                     first_product_created_at=?,
+                     detected_country=?,
+                     myshopify_url=?
+                 WHERE canonical_url = ?"
+            );
+            $updCand->execute([
+                $leadId,
+                $email,
+                $productsCount,
+                $firstProductCreatedAt ?: null,
+                $meta['country'] ?? null,
+                $canonical,
+                $canonical,
+            ]);
+
+            log_activity($pdo, $leadId, 'lead_created', "Auto-imported from Shopify via dork: $query");
+
+            $shopifyImportsToday++;
+            setState($pdo, 'shopify_imports_today', (string) $shopifyImportsToday);
+
+            logPipeline("Imported Shopify lead #$leadId: '{$meta['business_name']}' <$email> from $canonical");
+            $imported++;
+
+        } else {
+            // Rejected — update candidate
+            $rejectReason = $evalResult['reason'] ?? 'unknown';
+            $rejectDetail = substr($evalResult['detail'] ?? '', 0, 500);
+
+            $updRej = $pdo->prepare(
+                "UPDATE outreach_shopify_candidates
+                 SET status='rejected', reject_reason=?, reject_detail=?
+                 WHERE canonical_url = ?"
+            );
+            $updRej->execute([$rejectReason, $rejectDetail, $canonical]);
+
+            logPipeline("Shopify candidate '$canonical' rejected: $rejectReason — $rejectDetail");
+            $rejected++;
+        }
+    }
+
+    logPipeline(
+        "Shopify discovery: query='$query', results=" . count($results)
+        . ", evaluated=$evaluated, imported=$imported, rejected=$rejected, errored=$errored"
+    );
 }
 
 function stepManageAbTests($pdo, $dryRun)

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -557,6 +557,9 @@ function stepDiscoverShopify($pdo, $dryRun)
             $evalResult = evaluate_shopify_candidate($canonical);
         } catch (Exception $e) {
             logPipeline("Error evaluating candidate '$canonical': " . $e->getMessage(), 'ERROR');
+            $pdo->prepare(
+                "UPDATE outreach_shopify_candidates SET status='error', reject_detail=? WHERE canonical_url=?"
+            )->execute([substr($e->getMessage(), 0, 500), $canonical]);
             $errored++;
             continue;
         }

--- a/cron/test_shopify_discovery_smoke.php
+++ b/cron/test_shopify_discovery_smoke.php
@@ -15,7 +15,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->load();
 
 if (($_ENV['APP_ENV'] ?? '') === 'production') {
-    fwrite(STDERR, "REFUSING TO RUN: APP_ENV='production'.\n");
+    fwrite(STDERR, "REFUSING TO RUN: APP_ENV='production'. Smoke tests touch live data.\n");
     exit(2);
 }
 
@@ -31,7 +31,8 @@ function assert_true($cond, $msg) {
 }
 
 // ─── Shared fixture ───
-$caProducts = ['products' => array_fill(0, 10, ['created_at' => '2024-08-12T10:23:45-04:00'])];
+$goodDate   = (new DateTime('-14 months'))->format(DateTime::RFC3339);
+$caProducts = ['products' => array_fill(0, 10, ['created_at' => $goodDate])];
 
 // ─── Section 1: filter_gatekept_email ───
 echo "Section 1: filter_gatekept_email\n";
@@ -104,17 +105,21 @@ assert_true(stripos($r['detail'] ?? '', 'Awesome Agency') !== false, "agency_ope
 // from offline smoke testing; see report for explanation.
 
 // too_few_products
-$fewProducts = ['products' => array_fill(0, 3, ['created_at' => '2024-08-12T10:23:45-04:00'])];
+$fewDate     = (new DateTime('-14 months'))->format(DateTime::RFC3339);
+$fewProducts = ['products' => array_fill(0, 3, ['created_at' => $fewDate])];
 $r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $fewProducts);
 assert_true($r['reason'] === 'too_few_products', "too_few_products: reason correct");
+assert_true(str_contains($r['detail'] ?? '', '3'), "too_few_products: detail mentions count 3");
 
-// too_new (1 month old — today is 2026-05-17)
-$newProducts = ['products' => array_fill(0, 10, ['created_at' => '2026-04-15T10:00:00-04:00'])];
+// too_new (~1 month ago — always within the too_new window)
+$newDate     = (new DateTime('-1 month'))->format(DateTime::RFC3339);
+$newProducts = ['products' => array_fill(0, 10, ['created_at' => $newDate])];
 $r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $newProducts);
 assert_true($r['reason'] === 'too_new', "too_new: reason correct");
 
-// too_old (31 months old)
-$oldProducts = ['products' => array_fill(0, 10, ['created_at' => '2023-10-01T10:00:00-04:00'])];
+// too_old (~27 months ago — past the 24-month ceiling)
+$oldDate     = (new DateTime('-27 months'))->format(DateTime::RFC3339);
+$oldProducts = ['products' => array_fill(0, 10, ['created_at' => $oldDate])];
 $r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $oldProducts);
 assert_true($r['reason'] === 'too_old', "too_old: reason correct");
 

--- a/cron/test_shopify_discovery_smoke.php
+++ b/cron/test_shopify_discovery_smoke.php
@@ -15,7 +15,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->load();
 
 if (($_ENV['APP_ENV'] ?? '') === 'production') {
-    fwrite(STDERR, "REFUSING TO RUN: APP_ENV='production'. Smoke tests touch live data.\n");
+    fwrite(STDERR, "REFUSING TO RUN: APP_ENV='production'.\n");
     exit(2);
 }
 
@@ -53,12 +53,12 @@ assert_true(
     "Uppercased host + query + fragment stripped"
 );
 assert_true(
-    shopify_canonical_url('http://example.ca/path/') === 'http://example.ca/path',
-    "Trailing slash on path stripped"
+    shopify_canonical_url('http://example.ca/path/') === 'http://example.ca',
+    "Path stripped (origin only)"
 );
 assert_true(
-    shopify_canonical_url('https://example.ca/path') === 'https://example.ca/path',
-    "Already-canonical URL unchanged"
+    shopify_canonical_url('https://example.ca/path') === 'https://example.ca',
+    "Deep-link path stripped to origin"
 );
 assert_true(
     shopify_canonical_url('  ') === '',

--- a/cron/test_shopify_discovery_smoke.php
+++ b/cron/test_shopify_discovery_smoke.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Shopify discovery smoke tests.
+ *
+ * Run via: php cron/test_shopify_discovery_smoke.php
+ *
+ * Pure-logic tests for the helpers in cron/lib/shopify_discovery.php using
+ * injected HTML and product-JSON fixtures. No network, no DB.
+ *
+ * DO NOT RUN AGAINST PRODUCTION. Aborts immediately if APP_ENV='production'.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->load();
+
+if (($_ENV['APP_ENV'] ?? '') === 'production') {
+    fwrite(STDERR, "REFUSING TO RUN: APP_ENV='production'.\n");
+    exit(2);
+}
+
+require_once __DIR__ . '/lib/shopify_discovery.php';  // pulls in outreach_helpers too
+
+$pass = 0;
+$fail = 0;
+
+function assert_true($cond, $msg) {
+    global $pass, $fail;
+    if ($cond) { echo "  ✓ $msg\n"; $pass++; }
+    else       { echo "  ✗ $msg\n"; $fail++; }
+}
+
+// ─── Shared fixture ───
+$caProducts = ['products' => array_fill(0, 10, ['created_at' => '2024-08-12T10:23:45-04:00'])];
+
+// ─── Section 1: filter_gatekept_email ───
+echo "Section 1: filter_gatekept_email\n";
+assert_true(filter_gatekept_email('support@store.ca')       === true,  "support@store.ca is gatekept");
+assert_true(filter_gatekept_email('SUPPORT@store.ca')       === true,  "SUPPORT@store.ca is gatekept (case-insensitive)");
+assert_true(filter_gatekept_email('no-reply@store.ca')      === true,  "no-reply@store.ca is gatekept");
+assert_true(filter_gatekept_email('partnerships@store.ca')  === true,  "partnerships@store.ca is gatekept");
+assert_true(filter_gatekept_email('hello@store.ca')         === false, "hello@store.ca is not gatekept");
+assert_true(filter_gatekept_email('jane@store.ca')          === false, "jane@store.ca is not gatekept");
+assert_true(filter_gatekept_email('contact@store.ca')       === false, "contact@store.ca is not gatekept");
+assert_true(filter_gatekept_email('')                        === true,  "empty string is gatekept (defensive)");
+assert_true(filter_gatekept_email('  support@store.ca  ')  === true,  "whitespace-padded support@store.ca is gatekept (trim)");
+
+// ─── Section 2: shopify_canonical_url ───
+echo "Section 2: shopify_canonical_url\n";
+assert_true(
+    shopify_canonical_url('https://Foo.MyShopify.com/?utm=1#x') === 'https://foo.myshopify.com',
+    "Uppercased host + query + fragment stripped"
+);
+assert_true(
+    shopify_canonical_url('http://example.ca/path/') === 'http://example.ca/path',
+    "Trailing slash on path stripped"
+);
+assert_true(
+    shopify_canonical_url('https://example.ca/path') === 'https://example.ca/path',
+    "Already-canonical URL unchanged"
+);
+assert_true(
+    shopify_canonical_url('  ') === '',
+    "Whitespace-only returns empty string"
+);
+
+// ─── Section 3: evaluate_shopify_candidate — fit path ───
+echo "Section 3: evaluate_shopify_candidate — fit path\n";
+$caHtml = <<<HTML
+<html>
+<head><title>Cool Maple Co</title></head>
+<body>
+<header>Welcome to Cool Maple Co</header>
+<footer>Made in Canada. Powered by Shopify. <a href="mailto:hello@coolmaple.ca">hello@coolmaple.ca</a></footer>
+</body>
+</html>
+HTML;
+
+$result = evaluate_shopify_candidate('https://coolmaple.myshopify.com', $caHtml, $caProducts);
+
+assert_true($result['fit'] === true,                              "fit === true for happy-path CA store");
+assert_true(($result['metadata']['email'] ?? '') === 'hello@coolmaple.ca', "metadata.email is hello@coolmaple.ca");
+assert_true(($result['metadata']['country'] ?? '') === 'CA',     "metadata.country is CA");
+assert_true(($result['metadata']['products_count'] ?? 0) === 10, "metadata.products_count is 10");
+assert_true(
+    str_contains($result['metadata']['business_name'] ?? '', 'Cool Maple Co'),
+    "metadata.business_name contains 'Cool Maple Co'"
+);
+$parsedDate = DateTime::createFromFormat('Y-m-d H:i:s', $result['metadata']['first_product_created_at'] ?? '');
+assert_true($parsedDate !== false, "metadata.first_product_created_at is a valid Y-m-d H:i:s datetime");
+
+// ─── Section 4: evaluate_shopify_candidate — reject paths ───
+echo "Section 4: evaluate_shopify_candidate — reject paths\n";
+
+// agency_operated
+$agencyHtml = '<html><body>Made in Canada hello@x.ca. Powered by Awesome Agency.</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $agencyHtml, $caProducts);
+assert_true($r['reason'] === 'agency_operated', "agency_operated: reason correct");
+assert_true(stripos($r['detail'] ?? '', 'Awesome Agency') !== false, "agency_operated: detail contains 'Awesome Agency'");
+
+// not_shopify — NOTE: not reachable via $productsOverride because any non-null array skips
+// the $productsData === null check. To trigger not_shopify cleanly would require a live
+// network call (or mocking fetch_shopify_products_json). This path is intentionally omitted
+// from offline smoke testing; see report for explanation.
+
+// too_few_products
+$fewProducts = ['products' => array_fill(0, 3, ['created_at' => '2024-08-12T10:23:45-04:00'])];
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $fewProducts);
+assert_true($r['reason'] === 'too_few_products', "too_few_products: reason correct");
+
+// too_new (1 month old — today is 2026-05-17)
+$newProducts = ['products' => array_fill(0, 10, ['created_at' => '2026-04-15T10:00:00-04:00'])];
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $newProducts);
+assert_true($r['reason'] === 'too_new', "too_new: reason correct");
+
+// too_old (31 months old)
+$oldProducts = ['products' => array_fill(0, 10, ['created_at' => '2023-10-01T10:00:00-04:00'])];
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $oldProducts);
+assert_true($r['reason'] === 'too_old', "too_old: reason correct");
+
+// age_unknown (malformed created_at)
+$badAgeProducts = ['products' => array_fill(0, 10, ['created_at' => 'completely-malformed-string'])];
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $caHtml, $badAgeProducts);
+assert_true($r['reason'] === 'age_unknown', "age_unknown: reason correct");
+
+// not_canadian
+$usaHtml = '<html><body>Made in USA hello@x.com</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $usaHtml, $caProducts);
+assert_true($r['reason'] === 'not_canadian', "not_canadian: reason correct");
+
+// no_contact_email
+$noEmailHtml = '<html><body>Made in Canada (no email anywhere)</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $noEmailHtml, $caProducts);
+assert_true($r['reason'] === 'no_contact_email', "no_contact_email: reason correct");
+
+// gatekept_email
+$gatekeptHtml = '<html><body>Made in Canada support@store.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $gatekeptHtml, $caProducts);
+assert_true($r['reason'] === 'gatekept_email', "gatekept_email: reason correct");
+assert_true(str_contains($r['detail'] ?? '', 'support@store.ca'), "gatekept_email: detail contains 'support@store.ca'");
+
+// ─── Section 5: Canada-signal detection ───
+echo "Section 5: Canada-signal detection\n";
+
+// Postal code only (no other Canada phrases) — K1A 0B1 is a valid Canadian postal code
+$postalOnlyHtml = '<html><body>Pickup at K1A 0B1 hello@x.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $postalOnlyHtml, $caProducts);
+assert_true($r['fit'] === true, "Postal code alone (K1A 0B1) passes Canada gate");
+
+// Postal code without space: M5V3A8
+$postalNoSpaceHtml = '<html><body>Location: M5V3A8. hello@x.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $postalNoSpaceHtml, $caProducts);
+assert_true($r['fit'] === true, "Postal code without space (M5V3A8) passes Canada gate");
+
+// Postal code with space: M5V 3A8
+$postalWithSpaceHtml = '<html><body>Location: M5V 3A8. hello@x.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $postalWithSpaceHtml, $caProducts);
+assert_true($r['fit'] === true, "Postal code with space (M5V 3A8) passes Canada gate");
+
+// Phrase "based in canada" without postal code
+$basedInHtml = '<html><body>Based in Canada. hello@maple.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $basedInHtml, $caProducts);
+assert_true($r['fit'] === true, "'based in canada' phrase passes Canada gate");
+
+// Phrase "proudly canadian" without postal code
+$proudlyHtml = '<html><body>Proudly Canadian. hello@maple.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $proudlyHtml, $caProducts);
+assert_true($r['fit'] === true, "'proudly canadian' phrase passes Canada gate");
+
+// Just the word "Canada" alone (no postal code, no qualifying phrase) — should FAIL
+$justCanadaHtml = '<html><body>We ship to Canada. hello@x.ca</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $justCanadaHtml, $caProducts);
+assert_true($r['reason'] === 'not_canadian', "Bare 'Canada' without postal code or signal phrase → not_canadian");
+
+// ─── Section 6: Powered-by-Shopify exclusion ───
+echo "Section 6: Powered-by-Shopify exclusion\n";
+
+// "Powered by Shopify" must NOT trigger agency_operated
+$shopifyPoweredHtml = '<html><body>Made in Canada hello@x.ca. Powered by Shopify</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $shopifyPoweredHtml, $caProducts);
+assert_true($r['fit'] === true, "'Powered by Shopify' does not trigger agency_operated");
+
+// Caps variant
+$shopifyPoweredCapsHtml = '<html><body>Made in Canada hello@x.ca. POWERED BY SHOPIFY</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $shopifyPoweredCapsHtml, $caProducts);
+assert_true($r['fit'] === true, "'POWERED BY SHOPIFY' (all caps) does not trigger agency_operated");
+
+// Any other "Powered by X" must reject
+$acmeHtml = '<html><body>Made in Canada hello@x.ca. Powered by Acme</body></html>';
+$r = evaluate_shopify_candidate('https://test.myshopify.com', $acmeHtml, $caProducts);
+assert_true($r['reason'] === 'agency_operated', "'Powered by Acme' → agency_operated");
+
+echo "\n========================================\n";
+echo "Result: $pass passed, $fail failed\n";
+echo "========================================\n";
+exit($fail === 0 ? 0 : 1);

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -969,4 +969,4 @@ CREATE TABLE IF NOT EXISTS outreach_shopify_candidates (
     UNIQUE KEY uniq_canonical_url (canonical_url),
     INDEX idx_status_checked (status, checked_at),
     INDEX idx_lead (lead_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -946,3 +946,27 @@ CREATE TABLE IF NOT EXISTS outreach_scrape_cache (
     last_attempted_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX idx_scrape_attempted (last_attempted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Tracks Shopify storefronts discovered via SerpAPI dorking.
+-- Acts as a dedup cache + reject-reason audit log so SerpAPI quota
+-- isn't wasted re-evaluating known stores. Fit candidates are imported
+-- into outreach_leads (source='shopify_auto') and linked via lead_id.
+CREATE TABLE IF NOT EXISTS outreach_shopify_candidates (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    canonical_url VARCHAR(500) NOT NULL,
+    myshopify_url VARCHAR(500) DEFAULT NULL,
+    status ENUM('imported','rejected','error','pending') NOT NULL DEFAULT 'pending',
+    reject_reason VARCHAR(100) DEFAULT NULL,
+    reject_detail VARCHAR(500) DEFAULT NULL,
+    products_count INT DEFAULT NULL,
+    first_product_created_at DATETIME DEFAULT NULL,
+    detected_country VARCHAR(8) DEFAULT NULL,
+    harvested_email VARCHAR(255) DEFAULT NULL,
+    lead_id INT DEFAULT NULL,
+    last_query VARCHAR(255) DEFAULT NULL,
+    checked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_canonical_url (canonical_url),
+    INDEX idx_status_checked (status, checked_at),
+    INDEX idx_lead (lead_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -22,6 +22,70 @@ Once a day the outreach cron does a routine:
 8. **Drafts each follow-up** with Gemini about a day before it's due to send. Each one personalizes against the lead's business, the original first email, and a per-touch "intent" (e.g. "gentle bump", "different angle", "final note before closing"). The intent comes from the active follow-up A/B test or the default in Settings.
 9. **Sends follow-ups** that are approved, up to the daily follow-up cap (`OUTREACH_DAILY_FOLLOWUP_LIMIT`, default 75 across all touch positions). In Auto-send mode, drafts auto-approve and go straight out. In Review-before-send mode, they queue in the Follow-ups tab for you to approve.
 
+## Shopify discovery
+
+Alongside the Google Places pipeline, the system has a second discovery source that finds small Canadian Shopify stores and pulls them into the same outreach flow.
+
+### Purpose
+
+Google Places finds brick-and-mortar businesses. Shopify discovery targets Canadian e-commerce sellers in their first 3–24 months — stores that are past the "just launched" stage but haven't yet found solid accounting software. These become `outreach_leads` rows with `source='shopify_auto'` and go through the same draft → send → follow-up sequence as any other lead.
+
+### How it works
+
+1. SerpAPI runs a `site:myshopify.com` dork query, returning `.myshopify.com` storefronts.
+2. The evaluator fetches each storefront's `/products.json`, checks product count (5–∞) and age of the oldest product (3–24 months), and looks for a Canadian address signal (postal code or province) on the storefront.
+3. It then scrapes the store's contact page for a direct email address. Role-mailbox addresses (`support@`, `partnerships@`, etc.) are rejected; only personal or general-contact addresses are accepted.
+4. Stores that pass all checks are imported as leads (`status='imported'`). Stores that fail are recorded with a `reject_reason` so they aren't re-evaluated on future runs.
+
+All discovered leads are stored in `outreach_shopify_candidates` before being promoted to `outreach_leads`. The table acts as a dedup cache — if SerpAPI returns the same storefront URL again, the existing row is found and skipped without burning a quota request.
+
+### CASL
+
+Every email address comes from the store's own public contact page — no social scraping, no third-party lists. This is the implied-consent lane under CASL, the same footing as a business card picked up at a trade show. Do not change the source to anything that pulls from data brokers or social profiles without a legal review.
+
+### Config
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SERPAPI_KEY` | _(empty)_ | Your SerpAPI key. Discovery is disabled if this is blank. |
+| `OUTREACH_SHOPIFY_ENABLED` | `false` | Master on/off for Shopify discovery. Set to `true` to enable. |
+| `OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT` | `5` | Max new leads imported per cron run. |
+| `SERPAPI_DAILY_QUERY_LIMIT` | `3` | Max SerpAPI requests per cron run. |
+
+SerpAPI's free tier is 100 searches/month. The defaults (`SERPAPI_DAILY_QUERY_LIMIT=3`, cron runs daily) cap usage at ~90 searches/month, leaving a small buffer. Increase the limit if you upgrade to a paid plan.
+
+### Manual runs
+
+```bash
+# Run only the Shopify discovery step (skips Google Places, email sends, follow-ups)
+php cron/outreach_pipeline.php --shopify-only
+
+# Preview what would be imported without writing anything
+php cron/outreach_pipeline.php --shopify-only --dry-run
+```
+
+`--dry-run` works with or without `--shopify-only` and suppresses all DB writes and email sends across the whole pipeline.
+
+### Reject reasons
+
+Each rejected candidate gets a `reject_reason` written to `outreach_shopify_candidates.reject_reason`. When reading the table in HeidiSQL or the admin UI:
+
+| Reason | Meaning |
+|---|---|
+| `fetch_failed` | Couldn't load the storefront (timeout, 4xx/5xx, network error). |
+| `agency_operated` | Store footer says "Powered by [agency name]" — skip, it's a client site not a self-run store. |
+| `not_shopify` | `/products.json` missing or returned invalid JSON — not a real Shopify store. |
+| `too_few_products` | Fewer than 5 products — too small to be worth outreach. |
+| `too_new` | First product created less than 3 months ago — store is still in soft-launch. |
+| `too_old` | First product created more than 24 months ago — likely already has tooling in place. |
+| `age_unknown` | No parseable `created_at` on any product — couldn't determine store age. |
+| `not_canadian` | No Canadian postal code or address signal found on the storefront. |
+| `no_contact_email` | Couldn't find any email address on the contact page. |
+| `gatekept_email` | Only role-mailbox addresses found (`support@`, `partnerships@`, `hello@`, etc.). |
+| `duplicate` | A lead with that email or website already exists in `outreach_leads`. |
+
+`reject_detail` (VARCHAR 500) carries more context when available — e.g. the exact email address that was flagged as a role mailbox.
+
 ## The Leads tab
 
 This is the list of businesses the system has found or that you've added manually.

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -8,9 +8,11 @@ It also has a A/B test system to learn what works, so it constantly improves its
 
 Everything lives in the admin dashboard under **Outreach**, which has four tabs: **Leads**, **A/B Tests**, **Follow-ups**, and **Settings**.
 
-## How it works
+## Google Places channel
 
-Once a day the outreach cron does a routine:
+Google Places finds small brick-and-mortar businesses.
+
+### How it works
 
 1. **Picks a city**, rotating through Saskatchewan first and then expanding outward into the rest of Canada.
 2. **Finds small businesses** there by category (plumbers, cafes, salons, and 90-odd other small-business types) and grabs their public contact email from their website.
@@ -22,13 +24,9 @@ Once a day the outreach cron does a routine:
 8. **Drafts each follow-up** with Gemini about a day before it's due to send. Each one personalizes against the lead's business, the original first email, and a per-touch "intent" (e.g. "gentle bump", "different angle", "final note before closing"). The intent comes from the active follow-up A/B test or the default in Settings.
 9. **Sends follow-ups** that are approved, up to the daily follow-up cap (`OUTREACH_DAILY_FOLLOWUP_LIMIT`, default 75 across all touch positions). In Auto-send mode, drafts auto-approve and go straight out. In Review-before-send mode, they queue in the Follow-ups tab for you to approve.
 
-## Shopify discovery
+## Shopify channel
 
-Alongside the Google Places pipeline, the system has a second discovery source that finds small Canadian Shopify stores and pulls them into the same outreach flow.
-
-### Purpose
-
-Google Places finds brick-and-mortar businesses. Shopify discovery targets Canadian e-commerce sellers in their first 3–24 months — stores that are past the "just launched" stage but haven't yet found solid accounting software. These become `outreach_leads` rows with `source='shopify_auto'` and go through the same draft → send → follow-up sequence as any other lead.
+Finds small Canadian Shopify sellers in their first 3–24 months — stores that are past the "just launched" stage but likely haven't yet found solid accounting software
 
 ### How it works
 
@@ -36,55 +34,6 @@ Google Places finds brick-and-mortar businesses. Shopify discovery targets Canad
 2. The evaluator fetches each storefront's `/products.json`, checks product count (5–∞) and age of the oldest product (3–24 months), and looks for a Canadian address signal (postal code or province) on the storefront.
 3. It then scrapes the store's contact page for a direct email address. Role-mailbox addresses (`support@`, `partnerships@`, etc.) are rejected; only personal or general-contact addresses are accepted.
 4. Stores that pass all checks are imported as leads (`status='imported'`). Stores that fail are recorded with a `reject_reason` so they aren't re-evaluated on future runs.
-
-All discovered leads are stored in `outreach_shopify_candidates` before being promoted to `outreach_leads`. The table acts as a dedup cache — if SerpAPI returns the same storefront URL again, the existing row is found and skipped without burning a quota request.
-
-### CASL
-
-Every email address comes from the store's own public contact page — no social scraping, no third-party lists. This is the implied-consent lane under CASL, the same footing as a business card picked up at a trade show. Do not change the source to anything that pulls from data brokers or social profiles without a legal review.
-
-### Config
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `SERPAPI_KEY` | _(empty)_ | Your SerpAPI key. Discovery is disabled if this is blank. |
-| `OUTREACH_SHOPIFY_ENABLED` | `false` | Master on/off for Shopify discovery. Set to `true` to enable. |
-| `OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT` | `5` | Max new leads imported per cron run. |
-| `SERPAPI_DAILY_QUERY_LIMIT` | `3` | Max SerpAPI requests per cron run. |
-
-SerpAPI's free tier is 100 searches/month. The defaults (`SERPAPI_DAILY_QUERY_LIMIT=3`, cron runs daily) cap usage at ~90 searches/month, leaving a small buffer. Increase the limit if you upgrade to a paid plan.
-
-### Manual runs
-
-```bash
-# Run only the Shopify discovery step (skips Google Places, email sends, follow-ups)
-php cron/outreach_pipeline.php --shopify-only
-
-# Preview what would be imported without writing anything
-php cron/outreach_pipeline.php --shopify-only --dry-run
-```
-
-`--dry-run` works with or without `--shopify-only` and suppresses all DB writes and email sends across the whole pipeline.
-
-### Reject reasons
-
-Each rejected candidate gets a `reject_reason` written to `outreach_shopify_candidates.reject_reason`. When reading the table in HeidiSQL or the admin UI:
-
-| Reason | Meaning |
-|---|---|
-| `fetch_failed` | Couldn't load the storefront (timeout, 4xx/5xx, network error). |
-| `agency_operated` | Store footer says "Powered by [agency name]" — skip, it's a client site not a self-run store. |
-| `not_shopify` | `/products.json` missing or returned invalid JSON — not a real Shopify store. |
-| `too_few_products` | Fewer than 5 products — too small to be worth outreach. |
-| `too_new` | First product created less than 3 months ago — store is still in soft-launch. |
-| `too_old` | First product created more than 24 months ago — likely already has tooling in place. |
-| `age_unknown` | No parseable `created_at` on any product — couldn't determine store age. |
-| `not_canadian` | No Canadian postal code or address signal found on the storefront. |
-| `no_contact_email` | Couldn't find any email address on the contact page. |
-| `gatekept_email` | Only role-mailbox addresses found (`support@`, `partnerships@`, `sales@`, `no-reply@`, etc.). `hello@`, `info@`, `contact@`, and firstname-shaped addresses are accepted as plausible founder mailboxes. |
-| `duplicate` | A lead with that email or website already exists in `outreach_leads`. |
-
-`reject_detail` (VARCHAR 500) carries more context when available — e.g. the exact email address that was flagged as a role mailbox.
 
 ## The Leads tab
 
@@ -147,34 +96,28 @@ With automation on, the cron ends a test and promotes the leader when **any** of
 
 Once a winner is promoted, the cron immediately starts the next cycle.
 
-### Safety pause
-
-If the cron's own pick turns out badly — winner CTR under the configured floor (default 1%, stored in `outreach_pipeline_state.ab_ctr_floor`) — disables the A/B tests and shows an "A/B automation is off" banner at the top of the Settings tab. Flip the toggle below it to resume. This is so a run of bad cycles can't quietly drag CTR downward.
-
-The follow-up sequence A/B type also auto-pauses if the configured touch count changes while a test is active (e.g. you add a 4th touch in Settings but the active test only has intents for 3 touches). The mismatch shows up in the banner so you can either match the test to the new shape or revert the Settings change.
-
 ## The Follow-ups tab
 
-This is the review queue for follow-up emails. It only matters in Review-before-send mode — in Auto-send mode, follow-ups go straight out and you can ignore this tab.
+This is the review queue for follow-up emails. It only matters in Review-before-send mode. In Auto-send mode, follow-ups are sent right away.
 
 The tab has five sub-views:
 
-- **Pending review** — drafts the system generated in the last ~2 days, waiting for you to approve. The pill carries a count badge so you can tell at a glance whether there's work to do.
+- **Pending review** — drafts waiting for you to approve. The pill carries a count badge so you can tell at a glance whether there's work to do.
 - **Approved & queued** — drafts you've approved that are waiting for their scheduled send time.
-- **Upcoming** — touches that are scheduled but not yet drafted by Gemini (drafting happens ~1 day before each send).
+- **Upcoming** — touches that are scheduled but haven't been drafted yet (drafting happens about a day before each send).
 - **Sent** — what's gone out in the last 30 days.
-- **Halted / failed** — sequences that stopped (lead replied, unsubscribed, bounced, you manually halted, or Gemini failed 3 times on a draft).
+- **Halted / failed** — sequences that stopped (lead replied, unsubscribed, bounced, you manually halted, or the AI couldn't produce a draft).
 
 For each pending row you can:
 
-- **Approve & queue** — sends on the next cron tick after the scheduled time.
-- **Regenerate draft** — re-call Gemini if the wording doesn't feel right.
+- **Approve & queue** — sends after the scheduled time.
+- **Regenerate draft** — re-draft if the wording doesn't feel right.
 - **Skip this touch** — drop just this one touch; the next touch in the sequence still goes out on its original schedule.
 - **Halt sequence** — stop ALL remaining follow-ups for this lead.
 
 Bulk-select via checkboxes to approve, skip, or halt sequences for multiple rows at once.
 
-You can also see the per-lead sequence (every touch + status + scheduled date) by opening any lead in the Leads tab and clicking the **Follow-ups** sub-tab inside the detail modal.
+You can also see the per-lead sequence (every touch + status + scheduled date) by opening any lead in the Leads tab.
 
 ## The Settings tab
 

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -81,7 +81,7 @@ Each rejected candidate gets a `reject_reason` written to `outreach_shopify_cand
 | `age_unknown` | No parseable `created_at` on any product — couldn't determine store age. |
 | `not_canadian` | No Canadian postal code or address signal found on the storefront. |
 | `no_contact_email` | Couldn't find any email address on the contact page. |
-| `gatekept_email` | Only role-mailbox addresses found (`support@`, `partnerships@`, `hello@`, etc.). |
+| `gatekept_email` | Only role-mailbox addresses found (`support@`, `partnerships@`, `sales@`, `no-reply@`, etc.). `hello@`, `info@`, `contact@`, and firstname-shaped addresses are accepted as plausible founder mailboxes. |
 | `duplicate` | A lead with that email or website already exists in `outreach_leads`. |
 
 `reject_detail` (VARCHAR 500) carries more context when available — e.g. the exact email address that was flagged as a role mailbox.


### PR DESCRIPTION
## Summary

Adds a second discovery source to the outreach cron pipeline that finds small Canadian Shopify stores via SerpAPI dorking, alongside the existing Google Places source. Both sources feed into the same `outreach_leads` table and the same draft → send → follow-up sequence downstream.

The filter is intentionally strict: 3–24-month-old stores, 5+ products, Canadian postal code or address signal, non-gatekept contact email, not agency-operated. Emails are harvested exclusively from the store's own contact page (CASL implied-consent).

## What's new

- `cron/lib/shopify_discovery.php` — pure helper module: SerpAPI client, dork pool, URL canonicalization, `/products.json` fetcher, and the `evaluate_shopify_candidate` fitness filter
- `cron/outreach_pipeline.php` — new `stepDiscoverShopify()` step + `--shopify-only` CLI flag
- `cron/lib/outreach_helpers.php` — new `filter_gatekept_email()` helper
- `cron/test_shopify_discovery_smoke.php` — 39-assertion smoke test (pure logic, no network/DB)
- `mysql_schema.sql` — new `outreach_shopify_candidates` tracking/dedup table
- `read-me/Email outreach.md` — new "Shopify discovery" section

## Required setup before deploy

1. Run the new `CREATE TABLE outreach_shopify_candidates` from `mysql_schema.sql`
2. Add these env vars (feature is **off** by default — safe to deploy first, enable later):
   ```
   SERPAPI_KEY=""                              # required
   OUTREACH_SHOPIFY_ENABLED="false"            # master on/off
   OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT="5"  # leads imported per cron run
   SERPAPI_DAILY_QUERY_LIMIT="3"               # SerpAPI calls per day (~90/mo, fits free tier)
   ```

## Test plan

- [x] `php cron/test_shopify_discovery_smoke.php` → 39/39 passing
- [x] `php cron/outreach_pipeline.php --shopify-only --dry-run` → logs planned dork query without network calls
- [x] Live SerpAPI runs (3 dorks consumed): 21 candidates inserted into `outreach_shopify_candidates`, all rejected by strict filter (mix of `too_old`, `not_shopify`, `agency_operated`) — strict filtering works as designed
- [x] Daily quota guard: 4th run cleanly skipped with "SerpAPI daily limit reached (3/3)"
- [x] Feature flag off → step no-ops silently, Google Places discovery continues unaffected
- [ ] After merge: enable in production, verify first import-worthy lead via `SELECT * FROM outreach_leads WHERE source='shopify_auto'`

## CASL note

Every email harvested under this source comes from the storefront's own public contact page (existing `scrape_email_from_website` already prioritizes `/contact`, `/about`, etc.). Gatekept role-mailboxes (`support@`, `partnerships@`, `sales@`, `no-reply@`, …) are rejected. No social scraping, no third-party data brokers.

## Security

- SerpAPI key is never logged or echoed in URLs visible to `error_log`
- SSRF guard on storefront fetch: `_shopify_url_is_safe_external` rejects URLs that resolve to private/reserved/loopback IPs, gated on both the input URL and the post-redirect effective URL
- 2 MB cap on storefront HTML and `/products.json` responses to prevent memory exhaustion
- Errored candidates are now flagged `status='error'` rather than left as orphaned `pending` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)