### PR TITLE
Add Discovery tab with Google Places + Shopify panels

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -641,6 +641,22 @@ function shopify_import($pdo)
         json_response(['success' => false, 'message' => 'canonical_url is required'], 400);
     }
 
+    // Daily import cap — shared with the cron via shopify_imports_today, so
+    // UI imports must respect it or the cron's same-day imports get silently
+    // blocked. Operator can raise OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT in
+    // .env if they need to bypass.
+    _shopify_reset_daily_counters_if_needed($pdo);
+    $importsLimit = (int) ($_ENV['OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT'] ?? 5);
+    $importsToday = (int) _shopify_state_get($pdo, 'shopify_imports_today', '0');
+    if ($importsToday >= $importsLimit) {
+        json_response([
+            'success'       => false,
+            'message'       => "Daily Shopify import limit reached ($importsToday/$importsLimit). Resets at midnight or raise OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT in .env.",
+            'imports_today' => $importsToday,
+            'imports_limit' => $importsLimit,
+        ], 429);
+    }
+
     // Re-evaluate server-side — don't trust client-passed metadata
     $result = evaluate_shopify_candidate($canonicalUrl);
     if (empty($result['fit'])) {

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -53,7 +53,7 @@ function is_pipeline_running(): bool
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 // Block actions that conflict with a running pipeline
-$pipelineActions = ['send_email', 'generate_draft', 'import_leads', 'search_businesses', 'regenerate_followup'];
+$pipelineActions = ['send_email', 'generate_draft', 'import_leads', 'search_businesses', 'regenerate_followup', 'shopify_run_dork', 'shopify_import'];
 if (in_array($action, $pipelineActions) && is_pipeline_running()) {
     echo json_encode([
         'success' => false,
@@ -89,6 +89,17 @@ switch ($action) {
         break;
     case 'import_leads':
         import_leads($pdo);
+        break;
+
+    // Shopify discovery
+    case 'shopify_get_status':
+        shopify_get_status($pdo);
+        break;
+    case 'shopify_run_dork':
+        shopify_run_dork($pdo);
+        break;
+    case 'shopify_import':
+        shopify_import($pdo);
         break;
 
     // AI draft
@@ -504,6 +515,216 @@ function import_leads($pdo)
         json_response(['success' => true, 'imported' => $imported, 'skipped' => $skipped, 'message' => "Imported $imported leads, skipped $skipped duplicates"]);
     } catch (Exception $e) {
         outreach_log("Import failed: " . $e->getMessage());
+        json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
+    }
+}
+
+// ─── Shopify Discovery ───
+// Helpers (serpapi_query, shopify_canonical_url, evaluate_shopify_candidate) live in cron/lib/shopify_discovery.php
+
+function _shopify_state_get($pdo, string $key, string $default = ''): string
+{
+    $stmt = $pdo->prepare("SELECT state_value FROM outreach_pipeline_state WHERE state_key = ?");
+    $stmt->execute([$key]);
+    $val = $stmt->fetchColumn();
+    return $val === false ? $default : (string) $val;
+}
+
+function _shopify_state_set($pdo, string $key, string $value): void
+{
+    $pdo->prepare("INSERT INTO outreach_pipeline_state (state_key, state_value)
+        VALUES (?, ?) ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)")
+        ->execute([$key, $value]);
+}
+
+function _shopify_reset_daily_counters_if_needed($pdo): void
+{
+    $today = date('Y-m-d');
+    if (_shopify_state_get($pdo, 'shopify_last_reset_date', '') !== $today) {
+        _shopify_state_set($pdo, 'serpapi_calls_today', '0');
+        _shopify_state_set($pdo, 'shopify_imports_today', '0');
+        _shopify_state_set($pdo, 'shopify_last_reset_date', $today);
+    }
+}
+
+function shopify_get_status($pdo)
+{
+    _shopify_reset_daily_counters_if_needed($pdo);
+    json_response([
+        'success'             => true,
+        'enabled'             => ($_ENV['OUTREACH_SHOPIFY_ENABLED'] ?? 'false') === 'true',
+        'has_key'             => !empty($_ENV['SERPAPI_KEY']),
+        'serpapi_calls_today' => (int) _shopify_state_get($pdo, 'serpapi_calls_today', '0'),
+        'serpapi_limit'       => (int) ($_ENV['SERPAPI_DAILY_QUERY_LIMIT'] ?? 3),
+        'imports_today'       => (int) _shopify_state_get($pdo, 'shopify_imports_today', '0'),
+        'imports_limit'       => (int) ($_ENV['OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT'] ?? 5),
+    ]);
+}
+
+function shopify_run_dork($pdo)
+{
+    require_once __DIR__ . '/../../cron/lib/shopify_discovery.php';
+
+    $data  = json_decode(file_get_contents('php://input'), true) ?: [];
+    $query = trim($data['query'] ?? '');
+    $limit = min(10, max(1, (int) ($data['limit'] ?? 10)));
+
+    if ($query === '') {
+        json_response(['success' => false, 'message' => 'Query is required'], 400);
+    }
+
+    $apiKey = $_ENV['SERPAPI_KEY'] ?? '';
+    if ($apiKey === '') {
+        json_response(['success' => false, 'message' => 'SerpAPI key not configured. Set SERPAPI_KEY in .env'], 500);
+    }
+
+    _shopify_reset_daily_counters_if_needed($pdo);
+    $serpapiLimit = (int) ($_ENV['SERPAPI_DAILY_QUERY_LIMIT'] ?? 3);
+    $callsToday   = (int) _shopify_state_get($pdo, 'serpapi_calls_today', '0');
+    if ($callsToday >= $serpapiLimit) {
+        json_response([
+            'success' => false,
+            'message' => "SerpAPI daily limit reached ($callsToday/$serpapiLimit). Resets at midnight or raise SERPAPI_DAILY_QUERY_LIMIT in .env.",
+        ], 429);
+    }
+
+    $serpResults = serpapi_query($query, $apiKey, $limit);
+    _shopify_state_set($pdo, 'serpapi_calls_today', (string) ($callsToday + 1));
+
+    $evaluated = [];
+    foreach ($serpResults as $r) {
+        $canonical = shopify_canonical_url($r['link'] ?? '');
+        if ($canonical === '') continue;
+
+        // Flag if already imported as a lead
+        $check = $pdo->prepare("SELECT id FROM outreach_leads WHERE website = ? LIMIT 1");
+        $check->execute([$canonical]);
+        $existingLeadId = $check->fetchColumn();
+
+        $result    = evaluate_shopify_candidate($canonical);
+        $meta      = $result['metadata'] ?? [];
+        $evaluated[] = [
+            'canonical_url'    => $canonical,
+            'serp_title'       => $r['title'] ?? '',
+            'fit'              => (bool) ($result['fit'] ?? false),
+            'reason'           => $result['reason'] ?? '',
+            'detail'           => $result['detail'] ?? '',
+            'final_url'        => $result['final_url'] ?? $canonical,
+            'business_name'    => $meta['business_name'] ?? '',
+            'email'            => $meta['email'] ?? '',
+            'products_count'   => $meta['products_count'] ?? null,
+            'first_product_at' => $meta['first_product_created_at'] ?? null,
+            'country'          => $meta['country'] ?? '',
+            'already_imported' => $existingLeadId !== false,
+            'existing_lead_id' => $existingLeadId !== false ? (int) $existingLeadId : null,
+        ];
+    }
+
+    json_response([
+        'success'             => true,
+        'results'             => $evaluated,
+        'serpapi_calls_today' => $callsToday + 1,
+        'serpapi_limit'       => $serpapiLimit,
+        'imports_today'       => (int) _shopify_state_get($pdo, 'shopify_imports_today', '0'),
+        'imports_limit'       => (int) ($_ENV['OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT'] ?? 5),
+    ]);
+}
+
+function shopify_import($pdo)
+{
+    require_once __DIR__ . '/../../cron/lib/shopify_discovery.php';
+
+    $data         = json_decode(file_get_contents('php://input'), true) ?: [];
+    $canonicalUrl = trim($data['canonical_url'] ?? '');
+
+    if ($canonicalUrl === '') {
+        json_response(['success' => false, 'message' => 'canonical_url is required'], 400);
+    }
+
+    // Re-evaluate server-side — don't trust client-passed metadata
+    $result = evaluate_shopify_candidate($canonicalUrl);
+    if (empty($result['fit'])) {
+        json_response([
+            'success' => false,
+            'message' => 'Store no longer passes evaluation: ' . ($result['reason'] ?? 'unknown'),
+            'reason'  => $result['reason'] ?? '',
+            'detail'  => $result['detail'] ?? '',
+        ], 400);
+    }
+
+    $meta         = $result['metadata'];
+    $finalUrl     = $result['final_url'];
+    $email        = $meta['email'] ?? '';
+    $businessName = $meta['business_name'] ?? '';
+
+    if ($email === '') {
+        json_response(['success' => false, 'message' => 'Re-evaluation returned fit but no email — refusing to import'], 500);
+    }
+
+    // Dedup against existing leads (email OR website)
+    $check = $pdo->prepare("SELECT id FROM outreach_leads WHERE email = ? OR website = ? LIMIT 1");
+    $check->execute([$email, $finalUrl]);
+    if ($existing = $check->fetchColumn()) {
+        json_response([
+            'success'          => false,
+            'message'          => 'A lead with this email or website already exists',
+            'existing_lead_id' => (int) $existing,
+        ], 409);
+    }
+
+    try {
+        $businessSummary = sprintf(
+            "Shopify store. %s products. First product created %s.",
+            $meta['products_count'] ?? '?',
+            $meta['first_product_created_at'] ?? 'unknown date'
+        );
+
+        $stmt = $pdo->prepare("INSERT INTO outreach_leads
+            (business_name, email, website, source, contact_page_url, business_summary)
+            VALUES (?, ?, ?, 'shopify_auto', ?, ?)");
+        $stmt->execute([
+            $businessName ?: $canonicalUrl,
+            $email,
+            $finalUrl,
+            $finalUrl,
+            $businessSummary,
+        ]);
+        $leadId = (int) $pdo->lastInsertId();
+
+        // UPSERT the candidate row so the cron's INSERT IGNORE skips it next time
+        $stmt = $pdo->prepare("INSERT INTO outreach_shopify_candidates
+            (canonical_url, myshopify_url, status, lead_id, harvested_email,
+             products_count, first_product_created_at, detected_country, last_query)
+            VALUES (?, ?, 'imported', ?, ?, ?, ?, ?, 'admin-ui')
+            ON DUPLICATE KEY UPDATE
+                status                   = 'imported',
+                lead_id                  = VALUES(lead_id),
+                harvested_email          = VALUES(harvested_email),
+                products_count           = VALUES(products_count),
+                first_product_created_at = VALUES(first_product_created_at),
+                detected_country         = VALUES(detected_country)");
+        $stmt->execute([
+            $canonicalUrl,
+            $canonicalUrl,
+            $leadId,
+            $email,
+            $meta['products_count'] ?? null,
+            $meta['first_product_created_at'] ?? null,
+            $meta['country'] ?? null,
+        ]);
+
+        log_activity($pdo, $leadId, 'lead_created', 'Imported from Shopify discovery UI');
+
+        $imports = (int) _shopify_state_get($pdo, 'shopify_imports_today', '0');
+        _shopify_state_set($pdo, 'shopify_imports_today', (string) ($imports + 1));
+
+        json_response([
+            'success'       => true,
+            'lead_id'       => $leadId,
+            'imports_today' => $imports + 1,
+        ]);
+    } catch (Exception $e) {
+        outreach_log("Shopify import failed: " . $e->getMessage());
         json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
     }
 }

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['tab'])) {
 
 // Determine active tab from ?tab=
 $activeTab = $_GET['tab'] ?? 'leads';
-if (!in_array($activeTab, ['leads', 'ab-tests', 'followups', 'settings'], true)) {
+if (!in_array($activeTab, ['discovery', 'leads', 'ab-tests', 'followups', 'settings'], true)) {
     $activeTab = 'leads';
 }
 
@@ -57,59 +57,19 @@ include __DIR__ . '/../admin_header.php';
 
 <!-- Page-level tabs -->
 <div class="section-tabs">
+    <button class="section-tab <?php echo $activeTab === 'discovery' ? 'active' : ''; ?>" data-tab="discovery">Discovery</button>
     <button class="section-tab <?php echo $activeTab === 'leads' ? 'active' : ''; ?>" data-tab="leads">Leads</button>
     <button class="section-tab <?php echo $activeTab === 'followups' ? 'active' : ''; ?>" data-tab="followups">Follow-ups</button>
     <button class="section-tab <?php echo $activeTab === 'ab-tests' ? 'active' : ''; ?>" data-tab="ab-tests">A/B Tests</button>
     <button class="section-tab <?php echo $activeTab === 'settings' ? 'active' : ''; ?>" data-tab="settings">Settings</button>
 </div>
 
-<div id="leads" class="tab-content <?php echo $activeTab === 'leads' ? 'active' : ''; ?>">
+<div id="discovery" class="tab-content <?php echo $activeTab === 'discovery' ? 'active' : ''; ?>">
 
-<!-- Pipeline Running Banner -->
-<div id="pipelineBanner" style="display:none; background:#fff3cd; color:#856404; border:1px solid #ffc107; border-radius:6px; padding:12px 16px; margin-bottom:16px; font-weight:500;">
-    The outreach cron pipeline is currently running. Sending, drafting, and discovery are temporarily disabled to prevent conflicts.
-</div>
-
-<!-- Dashboard Stats -->
-<div class="stats-row" id="statsRow">
-    <div class="stat-card">
-        <div class="stat-label">Total Leads</div>
-        <div class="stat-value" id="statTotal">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">New</div>
-        <div class="stat-value stat-new" id="statNew">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Drafts Pending</div>
-        <div class="stat-value stat-pending" id="statDraftsPending">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Follow-ups pending review</div>
-        <div class="stat-value stat-pending" id="statFollowupsPending">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Contacted</div>
-        <div class="stat-value stat-contacted" id="statContacted">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Replied</div>
-        <div class="stat-value stat-replied" id="statReplied">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Interested</div>
-        <div class="stat-value stat-interested" id="statInterested">0</div>
-    </div>
-    <div class="stat-card">
-        <div class="stat-label">Clicked</div>
-        <div class="stat-value stat-clicked" id="statClicked">0</div>
-    </div>
-</div>
-
-<!-- Business Discovery Panel -->
+<!-- Google Places Discovery Panel -->
 <div class="panel discovery-panel">
     <div class="panel-header" onclick="togglePanel('discoveryContent')">
-        <h2><?= svg_icon('search', 18) ?> Business Discovery</h2>
+        <h2><?= svg_icon('search', 18) ?> Google Places</h2>
         <span class="panel-toggle" id="discoveryToggle">&#9660;</span>
     </div>
     <div class="panel-content" id="discoveryContent">
@@ -180,6 +140,117 @@ include __DIR__ . '/../admin_header.php';
                 </table>
             </div>
         </div>
+    </div>
+</div>
+
+<!-- Shopify Discovery Panel -->
+<div class="panel discovery-panel">
+    <div class="panel-header" onclick="togglePanel('shopifyContent')">
+        <h2><?= svg_icon('search', 18) ?> Shopify</h2>
+        <span class="panel-toggle" id="shopifyToggle">&#9660;</span>
+    </div>
+    <div class="panel-content" id="shopifyContent">
+        <div class="discovery-form">
+            <div class="form-row">
+                <div class="form-group" style="flex: 2;">
+                    <label for="shopifyDork">SerpAPI dork query</label>
+                    <select id="shopifyDork" onchange="onShopifyDorkChange()">
+                        <?php
+                        require_once __DIR__ . '/../../cron/lib/shopify_discovery.php';
+                        foreach (SHOPIFY_DORK_POOL as $dork) {
+                            echo '<option value="' . htmlspecialchars($dork, ENT_QUOTES) . '">' . htmlspecialchars($dork, ENT_QUOTES) . '</option>';
+                        }
+                        ?>
+                        <option value="__custom__">Custom query…</option>
+                    </select>
+                    <input type="text" id="shopifyDorkCustom" placeholder='site:myshopify.com "your query"' style="display:none; margin-top:8px;">
+                </div>
+                <div class="form-group">
+                    <label for="shopifyLimit">Limit</label>
+                    <select id="shopifyLimit">
+                        <option value="5">5</option>
+                        <option value="10" selected>10</option>
+                    </select>
+                </div>
+                <div class="form-group form-group-btn">
+                    <button class="btn btn-blue" onclick="runShopifyDiscovery()" id="shopifyRunBtn">Run</button>
+                </div>
+            </div>
+            <p style="margin:8px 0 0; color:#666; font-size:13px;">
+                SerpAPI usage today: <span id="serpapiUsage">…</span>
+                &nbsp;·&nbsp; Each run uses one SerpAPI query from your daily quota.
+            </p>
+        </div>
+
+        <div id="shopifyResults" style="display:none; margin-top:16px;">
+            <div class="discovery-actions">
+                <span id="shopifyResultsCount">0 results</span>
+                <div>
+                    <button class="btn btn-small btn-blue" onclick="importAllShopifyFits()" id="shopifyImportAllBtn">Import All Fits</button>
+                </div>
+            </div>
+            <div class="discovery-table-wrapper">
+                <table class="data-table discovery-table">
+                    <thead>
+                        <tr>
+                            <th>Store</th>
+                            <th>Email</th>
+                            <th>Products</th>
+                            <th>Oldest Product</th>
+                            <th>Country</th>
+                            <th>Result</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody id="shopifyResultsBody"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+</div> <!-- /#discovery -->
+
+<div id="leads" class="tab-content <?php echo $activeTab === 'leads' ? 'active' : ''; ?>">
+
+<!-- Pipeline Running Banner -->
+<div id="pipelineBanner" style="display:none; background:#fff3cd; color:#856404; border:1px solid #ffc107; border-radius:6px; padding:12px 16px; margin-bottom:16px; font-weight:500;">
+    The outreach cron pipeline is currently running. Sending, drafting, and discovery are temporarily disabled to prevent conflicts.
+</div>
+
+<!-- Dashboard Stats -->
+<div class="stats-row" id="statsRow">
+    <div class="stat-card">
+        <div class="stat-label">Total Leads</div>
+        <div class="stat-value" id="statTotal">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">New</div>
+        <div class="stat-value stat-new" id="statNew">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Drafts Pending</div>
+        <div class="stat-value stat-pending" id="statDraftsPending">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Follow-ups pending review</div>
+        <div class="stat-value stat-pending" id="statFollowupsPending">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Contacted</div>
+        <div class="stat-value stat-contacted" id="statContacted">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Replied</div>
+        <div class="stat-value stat-replied" id="statReplied">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Interested</div>
+        <div class="stat-value stat-interested" id="statInterested">0</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Clicked</div>
+        <div class="stat-value stat-clicked" id="statClicked">0</div>
     </div>
 </div>
 

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -1398,3 +1398,210 @@ window.loadLeadFollowups = async function() {
         ).join('') +
     '</tbody></table>';
 };
+
+// ─── Shopify Discovery ───
+
+let shopifyResults = [];
+
+function onShopifyDorkChange() {
+    const sel = document.getElementById('shopifyDork');
+    const custom = document.getElementById('shopifyDorkCustom');
+    if (!sel || !custom) return;
+    custom.style.display = sel.value === '__custom__' ? '' : 'none';
+    if (sel.value === '__custom__') custom.focus();
+}
+
+function _shopifyUpdateUsageDisplay(callsToday, limit, importsToday, importsLimit) {
+    const span = document.getElementById('serpapiUsage');
+    if (!span) return;
+    let txt = `${callsToday}/${limit} queries`;
+    if (typeof importsToday === 'number' && typeof importsLimit === 'number') {
+        txt += `, ${importsToday}/${importsLimit} imports`;
+    }
+    span.textContent = txt;
+}
+
+async function loadShopifyStatus() {
+    try {
+        const data = await api('shopify_get_status');
+        if (data.success) {
+            _shopifyUpdateUsageDisplay(
+                data.serpapi_calls_today,
+                data.serpapi_limit,
+                data.imports_today,
+                data.imports_limit
+            );
+        }
+    } catch (e) { /* non-fatal */ }
+}
+
+async function runShopifyDiscovery() {
+    const dorkSel = document.getElementById('shopifyDork');
+    const custom = document.getElementById('shopifyDorkCustom');
+    const limit = parseInt(document.getElementById('shopifyLimit').value, 10) || 10;
+    const btn = document.getElementById('shopifyRunBtn');
+
+    let query = dorkSel.value;
+    if (query === '__custom__') {
+        query = custom.value.trim();
+        if (!query) {
+            notify('Enter a custom query first');
+            custom.focus();
+            return;
+        }
+    }
+
+    btn.disabled = true;
+    btn.textContent = 'Running…';
+
+    try {
+        const data = await api('shopify_run_dork', {
+            method: 'POST',
+            body: { query, limit }
+        });
+
+        if (!data.success) {
+            notify(data.message || 'Shopify discovery failed');
+            return;
+        }
+
+        shopifyResults = data.results || [];
+        _shopifyUpdateUsageDisplay(
+            data.serpapi_calls_today,
+            data.serpapi_limit,
+            data.imports_today,
+            data.imports_limit
+        );
+        document.getElementById('shopifyResults').style.display = 'block';
+        renderShopifyResults();
+    } catch (e) {
+        notify(e.message);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Run';
+    }
+}
+
+function renderShopifyResults() {
+    const body = document.getElementById('shopifyResultsBody');
+    const countEl = document.getElementById('shopifyResultsCount');
+    const importAllBtn = document.getElementById('shopifyImportAllBtn');
+
+    const fitCount = shopifyResults.filter(r => r.fit && !r.already_imported).length;
+    const rejectCount = shopifyResults.filter(r => !r.fit).length;
+    const dupCount = shopifyResults.filter(r => r.fit && r.already_imported).length;
+    countEl.textContent =
+        `${shopifyResults.length} results — ${fitCount} fit, ${rejectCount} rejected` +
+        (dupCount > 0 ? `, ${dupCount} already imported` : '');
+
+    if (importAllBtn) {
+        importAllBtn.disabled = fitCount === 0;
+        importAllBtn.textContent = fitCount > 0 ? `Import ${fitCount} Fit${fitCount !== 1 ? 's' : ''}` : 'Import All Fits';
+    }
+
+    if (shopifyResults.length === 0) {
+        body.innerHTML = '<tr><td colspan="7" style="text-align:center; padding:24px; color:#666;">SerpAPI returned no results for this query.</td></tr>';
+        return;
+    }
+
+    body.innerHTML = shopifyResults.map((r, idx) => {
+        const safe = (s) => escapeHtml(String(s ?? ''));
+        const displayUrl = r.final_url || r.canonical_url;
+        const store = r.business_name
+            ? `<div><strong>${safe(r.business_name)}</strong></div><div style="font-size:12px;"><a href="${safe(displayUrl)}" target="_blank" rel="noopener">${safe(displayUrl)}</a></div>`
+            : `<a href="${safe(displayUrl)}" target="_blank" rel="noopener">${safe(displayUrl)}</a>`;
+
+        let resultCell;
+        if (r.fit && r.already_imported) {
+            resultCell = `<span class="status-badge status-contacted">already imported (#${r.existing_lead_id})</span>`;
+        } else if (r.fit) {
+            resultCell = '<span class="status-badge status-replied">fit</span>';
+        } else {
+            const detailLine = r.detail ? `<div style="font-size:11px; color:#888; margin-top:2px;">${safe(r.detail)}</div>` : '';
+            resultCell = `<span class="status-badge status-paused">${safe(r.reason || 'rejected')}</span>${detailLine}`;
+        }
+
+        let actionCell = '—';
+        if (r.fit && !r.already_imported) {
+            actionCell = `<button class="btn btn-small btn-blue" onclick="importShopifyRow(${idx}, this)">Import</button>`;
+        }
+
+        return '<tr>' +
+            `<td>${store}</td>` +
+            `<td>${safe(r.email) || '—'}</td>` +
+            `<td>${r.products_count != null ? safe(r.products_count) : '—'}</td>` +
+            `<td>${safe(r.first_product_at) || '—'}</td>` +
+            `<td>${safe(r.country) || '—'}</td>` +
+            `<td>${resultCell}</td>` +
+            `<td>${actionCell}</td>` +
+        '</tr>';
+    }).join('');
+}
+
+async function importShopifyRow(idx, btn) {
+    const row = shopifyResults[idx];
+    if (!row || !row.fit) return;
+    btn.disabled = true;
+    btn.textContent = 'Importing…';
+    try {
+        const data = await api('shopify_import', {
+            method: 'POST',
+            body: { canonical_url: row.canonical_url }
+        });
+        if (data.success) {
+            shopifyResults[idx].already_imported = true;
+            shopifyResults[idx].existing_lead_id = data.lead_id;
+            renderShopifyResults();
+            loadStats();
+        } else {
+            notify(data.message || 'Import failed');
+            btn.disabled = false;
+            btn.textContent = 'Import';
+        }
+    } catch (e) {
+        notify(e.message);
+        btn.disabled = false;
+        btn.textContent = 'Import';
+    }
+}
+
+async function importAllShopifyFits() {
+    const fits = shopifyResults
+        .map((r, idx) => ({ row: r, idx }))
+        .filter(x => x.row.fit && !x.row.already_imported);
+
+    if (fits.length === 0) return;
+    if (!confirm(`Import ${fits.length} Shopify store${fits.length === 1 ? '' : 's'} as new leads?`)) return;
+
+    const btn = document.getElementById('shopifyImportAllBtn');
+    btn.disabled = true;
+    btn.textContent = 'Importing…';
+
+    let imported = 0;
+    let failed = 0;
+    for (const { row, idx } of fits) {
+        try {
+            const data = await api('shopify_import', {
+                method: 'POST',
+                body: { canonical_url: row.canonical_url }
+            });
+            if (data.success) {
+                shopifyResults[idx].already_imported = true;
+                shopifyResults[idx].existing_lead_id = data.lead_id;
+                imported++;
+            } else {
+                failed++;
+            }
+        } catch (e) {
+            failed++;
+        }
+    }
+
+    renderShopifyResults();
+    loadStats();
+    notify(`Imported ${imported} lead${imported === 1 ? '' : 's'}` + (failed > 0 ? `, ${failed} failed` : ''));
+}
+
+// Load Shopify status on page load so the usage display is populated
+document.addEventListener('DOMContentLoaded', loadShopifyStatus);
+

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -6,7 +6,7 @@ Argo Books has a built-in outreach system that finds small businesses and writes
 
 It also has a A/B test system to learn what works, so it constantly improves itself.
 
-Everything lives in the admin dashboard under **Outreach**, which has four tabs: **Leads**, **Follow-ups**, **A/B Tests**, and **Settings**.
+Everything lives in the admin dashboard under **Outreach**, which has five tabs: **Discovery**, **Leads**, **Follow-ups**, **A/B Tests**, and **Settings**.
 
 ## Google Places channel
 
@@ -35,13 +35,21 @@ Finds small Canadian Shopify sellers in their first 3–24 months — stores tha
 3. It then scrapes the store's contact page for a direct email address. Role-mailbox addresses (`support@`, `partnerships@`, etc.) are rejected; only personal or general-contact addresses are accepted.
 4. Stores that pass all checks are imported as leads (`status='imported'`). Stores that fail are recorded with a `reject_reason` so they aren't re-evaluated on future runs.
 
+## The Discovery tab
+
+Manual discovery for both channels — useful for spot-checking what the cron would find before letting it run on its own, or for sourcing leads outside the cron schedule.
+
+- **Google Places** — the city / province / category / size / limit form. Searches Google Places live and previews matching businesses with their scraped contact emails. Pick which ones to import.
+- **Shopify** — pick a SerpAPI dork from the rotation (or write a custom one) and run it. Each result gets evaluated by the same filter as the cron (Canadian signal, 3–24 month age, 5+ products, non-gatekept email, not agency-operated) and the table shows fit / rejected / already-imported with the reject reason. Import any fit row, or "Import All Fits" in bulk.
+
+Both panels show the daily quota state so you don't blow through SerpAPI's free tier mid-day. The Shopify panel respects the same `SERPAPI_DAILY_QUERY_LIMIT` and `OUTREACH_DAILY_SHOPIFY_DISCOVERY_LIMIT` env vars the cron uses.
+
 ## The Leads tab
 
 This is the list of businesses the system has found or that you've added manually.
 
 From here you can:
 
-- **Search the web for new businesses** in a specific city and category, preview the results, and pick which ones to import.
 - **Add a lead manually** or import a CSV spreadsheet.
 - **Open a lead** to see the AI-generated email, edit the draft before it's sent, or mark the conversation status (interested / not interested / onboarded / replied).
 - **Bulk-generate drafts** or **bulk-send emails** for a group of leads you've selected.


### PR DESCRIPTION
## Summary

Adds a new **Discovery** tab as the first tab on the outreach admin page. Google Places gets moved out of the Leads tab (where its panel was previously embedded) into this new tab, and a new Shopify panel sits alongside it.

This solves the gap noted yesterday: the Leads tab had a UI for Google Places but no equivalent for Shopify, so the only way to test Shopify discovery was via CLI.

## UI

| Panel | Inputs | What runs | Output |
|---|---|---|---|
| **Google Places** (relocated) | City / Province / Category / Size / Limit | Existing `search_businesses` flow | Preview table, Import Selected / All (unchanged) |
| **Shopify** (new) | Dork query (pick from rotation pool or write a custom one) + Limit (1-10) | SerpAPI query → `evaluate_shopify_candidate` per result | Table of store / email / products / oldest product / country / fit-or-reject reason. Per-row Import + bulk Import All Fits |

Both panels show the daily quota state. The Shopify panel refuses to run if `SERPAPI_KEY` is missing or the daily cap is hit, and the run/import endpoints are added to the pipeline-lock conflict list (they refuse mid-cron).

## Backend additions (`admin/outreach/api.php`)

- `shopify_get_status` — returns current SerpAPI calls + Shopify imports vs daily caps
- `shopify_run_dork` — runs the dork, evaluates each result with the same filter pipeline as the cron, returns the rows for display. Increments `serpapi_calls_today` regardless of result.
- `shopify_import` — **re-evaluates server-side** (never trusts client metadata), inserts the lead with `source='shopify_auto'`, UPSERTs an `outreach_shopify_candidates` row so the cron skips it next time. Dedups on email OR website.

## Test plan

- [ ] Open `/admin/outreach/` — Discovery tab shows first; Leads/Follow-ups/A/B Tests/Settings still work
- [ ] Google Places panel: search Saskatoon plumbers → same UX as before (results preview → Import Selected)
- [ ] Shopify panel: load the page — usage display shows `N/3 queries, N/5 imports`
- [ ] Shopify panel with `SERPAPI_KEY` empty in `.env`: Run button returns a clean "SerpAPI key not configured" error
- [ ] Shopify panel with quota exhausted: Run button returns 429 with "daily limit reached" message
- [ ] Shopify panel happy path: pick a dork → Run → table populates with fit/reject rows → click Import on a fit → row updates to "already imported (#leadId)" → check `outreach_leads` for new `shopify_auto` row + activity log entry
- [ ] Bulk Import All Fits: with N fits in the table, click → confirm prompt → all import sequentially → final counts shown
- [ ] Custom dork query mode: pick "Custom query…" in the dropdown → text input appears → submit
- [ ] While `outreach_pipeline.lock` is held, the Shopify Run / Import endpoints refuse with the pipeline-running banner message

🤖 Generated with [Claude Code](https://claude.com/claude-code)