### PR TITLE
feat(admin/auth): trust device for 30 days to skip TOTP step

### DIFF
--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -2065,3 +2065,25 @@ tbody tr:hover {
     border-bottom-color: var(--primary-blue);
 }
 
+
+
+/* "Trust this device for 30 days" checkbox on the 2FA verification form */
+.trust-device-group {
+    margin-top: -8px;
+}
+
+.trust-device-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9em;
+    cursor: pointer;
+    user-select: none;
+}
+
+.trust-device-label input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    cursor: pointer;
+}

--- a/admin/login.php
+++ b/admin/login.php
@@ -116,6 +116,11 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
                     $_SESSION['admin_logged_in'] = true;
                     $_SESSION['admin_username'] = $actual_username;
 
+                    // Mirror the normal 2FA-success path: a successful login
+                    // (whether by TOTP or trust cookie) resets both buckets so
+                    // prior failed 2FA attempts don't bite the user when their
+                    // trust cookie eventually expires.
+                    clear_rate_limit_attempts($clientIp, 'admin_2fa');
                     clear_rate_limit_attempts($clientIp, 'admin_login');
 
                     $stmt = $pdo->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
@@ -203,24 +208,6 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
                 </div>
 
                 <input type="hidden" name="verify_code" value="1">
-
-                <style>
-                    .trust-device-group { margin-top: -8px; }
-                    .trust-device-label {
-                        display: flex;
-                        align-items: center;
-                        gap: 8px;
-                        font-size: 0.9em;
-                        cursor: pointer;
-                        user-select: none;
-                    }
-                    .trust-device-label input[type="checkbox"] {
-                        width: 16px;
-                        height: 16px;
-                        margin: 0;
-                        cursor: pointer;
-                    }
-                </style>
 
                 <div class="center">
                     <button type="button" onclick="submitVerificationForm()" id="submit-button" class="btn btn-blue">Verify</button>

--- a/admin/login.php
+++ b/admin/login.php
@@ -13,6 +13,7 @@ session_start();
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../rate_limit_helper.php';
 require_once __DIR__ . '/settings/2fa.php';
+require_once __DIR__ . '/trusted_devices.php';
 
 // Check if user is already logged in
 if (isset($_SESSION['admin_logged_in']) && $_SESSION['admin_logged_in'] === true) {
@@ -55,6 +56,20 @@ if (isset($_SESSION['awaiting_2fa']) && $_SESSION['awaiting_2fa'] === true) {
                     clear_rate_limit_attempts($clientIp, 'admin_2fa');
                     clear_rate_limit_attempts($clientIp, 'admin_login');
 
+                    // If the user ticked "Trust this device for 30 days",
+                    // issue a token so subsequent logins from this browser
+                    // can skip the TOTP step (password is still required).
+                    if (!empty($_POST['trust_device'])) {
+                        $u = get_user_by_username($username);
+                        if ($u) {
+                            issue_trusted_device_token(
+                                (int)$u['id'],
+                                $_SERVER['HTTP_USER_AGENT'] ?? '',
+                                $clientIp
+                            );
+                        }
+                    }
+
                     // Update last login time
                     $stmt = $pdo->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
                     $stmt->execute([$username]);
@@ -92,6 +107,24 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
             $actual_username = $user['username']; // Get actual username with correct case
 
             if (is_2fa_enabled($actual_username)) {
+                // If the browser has a valid "trust this device" cookie for
+                // this admin, skip the TOTP step. The password was just
+                // verified above; the cookie alone never grants access.
+                $trusted_for = verify_trusted_device_cookie($clientIp);
+                if ($trusted_for !== null && strcasecmp($trusted_for, $actual_username) === 0) {
+                    session_regenerate_id(true);
+                    $_SESSION['admin_logged_in'] = true;
+                    $_SESSION['admin_username'] = $actual_username;
+
+                    clear_rate_limit_attempts($clientIp, 'admin_login');
+
+                    $stmt = $pdo->prepare('UPDATE admin_users SET last_login = CURRENT_TIMESTAMP WHERE username = ?');
+                    $stmt->execute([$actual_username]);
+
+                    header('Location: index.php');
+                    exit;
+                }
+
                 // 2FA is enabled, show the verification form. Don't clear the
                 // password-attempt counter yet — we only count this as success
                 // once 2FA also passes.
@@ -162,7 +195,32 @@ elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
                     <input type="number" id="verification_code" name="verification_code" class="verification-code" required autofocus placeholder="000000" min="0" max="999999">
                 </div>
 
+                <div class="form-group trust-device-group">
+                    <label class="trust-device-label">
+                        <input type="checkbox" id="trust_device" name="trust_device" value="1">
+                        Trust this device for 30 days (skip the code on this browser)
+                    </label>
+                </div>
+
                 <input type="hidden" name="verify_code" value="1">
+
+                <style>
+                    .trust-device-group { margin-top: -8px; }
+                    .trust-device-label {
+                        display: flex;
+                        align-items: center;
+                        gap: 8px;
+                        font-size: 0.9em;
+                        cursor: pointer;
+                        user-select: none;
+                    }
+                    .trust-device-label input[type="checkbox"] {
+                        width: 16px;
+                        height: 16px;
+                        margin: 0;
+                        cursor: pointer;
+                    }
+                </style>
 
                 <div class="center">
                     <button type="button" onclick="submitVerificationForm()" id="submit-button" class="btn btn-blue">Verify</button>

--- a/admin/settings/2fa.php
+++ b/admin/settings/2fa.php
@@ -1,6 +1,7 @@
 <?php
 date_default_timezone_set('UTC');
 require_once __DIR__ . '/totp.php';
+require_once __DIR__ . '/../trusted_devices.php';
 
 /**
  * Get user by username (case-insensitive)
@@ -60,6 +61,14 @@ function disable_2fa($username)
         global $pdo;
         $stmt = $pdo->prepare('UPDATE admin_users SET two_factor_secret = NULL, two_factor_enabled = 0 WHERE username = ?');
         $success = $stmt->execute([$user['username']]) && $stmt->rowCount() > 0;
+
+        // Trusted-device cookies only make sense while 2FA is enabled — they
+        // bypass the TOTP step. Clear them on disable so a re-enable cannot
+        // silently re-trust devices the user no longer recognises.
+        if ($success) {
+            revoke_all_trusted_devices((int)$user['id']);
+        }
+
         return $success;
     } catch (Exception $e) {
         return false;

--- a/admin/settings/index.php
+++ b/admin/settings/index.php
@@ -87,6 +87,11 @@ include __DIR__ . '/../admin_header.php';
         <?php if ($is_enabled): ?>
             <h2>Your account is currently protected with 2FA</h2>
 
+            <p>
+                <a href="trusted-devices.php" class="link">Manage trusted devices</a>
+                — review the browsers that can skip the 2FA step for 30 days.
+            </p>
+
             <form method="post" onsubmit="return confirm('Are you sure you want to disable two-factor authentication? This will make your account less secure.');">
                 <div class="center">
                     <button type="submit" name="disable_2fa" class="btn btn-red">Disable 2FA</button>

--- a/admin/settings/trusted-devices.php
+++ b/admin/settings/trusted-devices.php
@@ -1,0 +1,120 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db_connect.php';
+require_once __DIR__ . '/2fa.php';
+require_once __DIR__ . '/../trusted_devices.php';
+
+if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== true) {
+    header('Location: ../login.php');
+    exit;
+}
+
+$page_title = 'Trusted Devices';
+$page_description = 'Devices that can skip the 2FA code on this account. Revoke any device that is no longer yours.';
+
+$username = $_SESSION['admin_username'];
+$user = get_user_by_username($username);
+
+$error = '';
+$success = '';
+
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $posted_csrf = $_POST['csrf_token'] ?? '';
+    if (!hash_equals($_SESSION['csrf_token'], $posted_csrf)) {
+        $error = 'Security token mismatch. Please try again.';
+    } elseif (!$user) {
+        $error = 'Could not load your account.';
+    } elseif (isset($_POST['revoke_all'])) {
+        $n = revoke_all_trusted_devices((int)$user['id']);
+        $success = $n === 1 ? '1 trusted device revoked.' : "$n trusted devices revoked.";
+        clear_trusted_device_cookie();
+    } elseif (!empty($_POST['revoke_id'])) {
+        $device_id = (int)$_POST['revoke_id'];
+        if (revoke_trusted_device((int)$user['id'], $device_id)) {
+            $success = 'Trusted device revoked.';
+        } else {
+            $error = 'Could not revoke that device.';
+        }
+    }
+}
+
+$devices = $user ? list_trusted_devices((int)$user['id']) : [];
+$csrf = $_SESSION['csrf_token'];
+
+include __DIR__ . '/../admin_header.php';
+?>
+
+<div class="container">
+    <?php if ($error): ?>
+        <div class="error-message"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+    <?php if ($success): ?>
+        <div class="success-message"><?= htmlspecialchars($success) ?></div>
+    <?php endif; ?>
+
+    <p>
+        <a href="index.php" class="link">&larr; Back to 2FA settings</a>
+    </p>
+
+    <?php if (empty($devices)): ?>
+        <div class="center">
+            <h2>No trusted devices</h2>
+            <p>When you sign in, tick "Trust this device for 30 days" to skip the verification code on this browser for 30 days.</p>
+        </div>
+    <?php else: ?>
+        <div class="center" style="margin-bottom: 16px;">
+            <form method="post" style="display: inline;" onsubmit="return confirm('Revoke ALL trusted devices? You will need to enter a 2FA code on every device next time you sign in.');">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <button type="submit" name="revoke_all" value="1" class="btn btn-red">Revoke all trusted devices</button>
+            </form>
+        </div>
+
+        <div class="table-container">
+            <table class="table-auto-size">
+                <thead>
+                    <tr>
+                        <th>Device</th>
+                        <th>IP</th>
+                        <th>Added</th>
+                        <th>Last used</th>
+                        <th>Expires</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($devices as $d): ?>
+                        <tr>
+                            <td>
+                                <strong><?= htmlspecialchars($d['label'] ?: 'Unknown device') ?></strong>
+                                <?php if (!empty($d['user_agent'])): ?>
+                                    <br><small style="opacity: 0.7;"><?= htmlspecialchars($d['user_agent']) ?></small>
+                                <?php endif; ?>
+                            </td>
+                            <td><?= htmlspecialchars($d['ip_address'] ?: '—') ?></td>
+                            <td><?= htmlspecialchars(date('Y-m-d H:i', strtotime($d['created_at']))) ?></td>
+                            <td><?= htmlspecialchars(date('Y-m-d H:i', strtotime($d['last_used_at']))) ?></td>
+                            <td><?= htmlspecialchars(date('Y-m-d', strtotime($d['expires_at']))) ?></td>
+                            <td>
+                                <form method="post" style="display: inline;" onsubmit="return confirm('Revoke this device? You will need to enter a 2FA code from this browser next time.');">
+                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                    <input type="hidden" name="revoke_id" value="<?= (int)$d['id'] ?>">
+                                    <button type="submit" class="btn btn-small btn-red">Revoke</button>
+                                </form>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</div>
+
+        </main>
+    </div>
+</body>
+
+</html>

--- a/admin/settings/trusted-devices.php
+++ b/admin/settings/trusted-devices.php
@@ -23,7 +23,10 @@ if (!isset($_SESSION['csrf_token'])) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $posted_csrf = $_POST['csrf_token'] ?? '';
+    // Cast guards against array input (e.g. ?csrf_token[]=x) which would
+    // TypeError hash_equals. Matches the defensive pattern in
+    // admin/_actions/refund_admin_action.php + portal_company_action.php.
+    $posted_csrf = (string)($_POST['csrf_token'] ?? '');
     if (!hash_equals($_SESSION['csrf_token'], $posted_csrf)) {
         $error = 'Security token mismatch. Please try again.';
     } elseif (!$user) {

--- a/admin/trusted_devices.php
+++ b/admin/trusted_devices.php
@@ -16,7 +16,6 @@
 
 require_once __DIR__ . '/../db_connect.php';
 require_once __DIR__ . '/../env_helper.php';
-require_once __DIR__ . '/../rate_limit_helper.php';
 
 const ADMIN_TRUST_COOKIE = 'admin_trust_token';
 const ADMIN_TRUST_TTL_DAYS = 30;
@@ -35,20 +34,28 @@ function issue_trusted_device_token($user_id, $user_agent, $ip)
 
     $label = derive_device_label($user_agent);
 
-    $stmt = $pdo->prepare(
-        'INSERT INTO admin_trusted_devices
-            (user_id, selector, validator_hash, label, user_agent, ip_address, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? DAY))'
-    );
-    $stmt->execute([
-        $user_id,
-        $selector,
-        $validator_hash,
-        $label,
-        substr((string)$user_agent, 0, 255),
-        substr((string)$ip, 0, 45),
-        ADMIN_TRUST_TTL_DAYS,
-    ]);
+    // Fail closed: if the INSERT throws (missing migration, transient DB
+    // error, etc.) we don't set the cookie. The caller's login proceeds
+    // normally; the user just doesn't gain trusted-device status this time.
+    try {
+        $stmt = $pdo->prepare(
+            'INSERT INTO admin_trusted_devices
+                (user_id, selector, validator_hash, label, user_agent, ip_address, expires_at)
+             VALUES (?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? DAY))'
+        );
+        $stmt->execute([
+            $user_id,
+            $selector,
+            $validator_hash,
+            $label,
+            substr((string)$user_agent, 0, 255),
+            substr((string)$ip, 0, 45),
+            ADMIN_TRUST_TTL_DAYS,
+        ]);
+    } catch (Throwable $e) {
+        error_log('issue_trusted_device_token failed: ' . $e->getMessage());
+        return;
+    }
 
     $secure = env('APP_ENV', 'sandbox') === 'production';
     setcookie(ADMIN_TRUST_COOKIE, $selector . '.' . $validator, [
@@ -81,31 +88,39 @@ function verify_trusted_device_cookie($ip)
         return null;
     }
 
-    $stmt = $pdo->prepare(
-        'SELECT d.id, d.validator_hash, d.expires_at, u.username
-         FROM admin_trusted_devices d
-         JOIN admin_users u ON u.id = d.user_id
-         WHERE d.selector = ? AND d.expires_at > NOW()
-         LIMIT 1'
-    );
-    $stmt->execute([$selector]);
-    $row = $stmt->fetch();
-    if (!$row) {
+    // Trust-cookie verification must NEVER throw — that would block the admin
+    // from logging in entirely if the table is missing or the DB hiccups. Any
+    // error here falls through to the normal TOTP prompt.
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT d.id, d.validator_hash, d.expires_at, u.username
+             FROM admin_trusted_devices d
+             JOIN admin_users u ON u.id = d.user_id
+             WHERE d.selector = ? AND d.expires_at > NOW()
+             LIMIT 1'
+        );
+        $stmt->execute([$selector]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            return null;
+        }
+
+        if (!hash_equals($row['validator_hash'], hash('sha256', $validator))) {
+            return null;
+        }
+
+        $upd = $pdo->prepare(
+            'UPDATE admin_trusted_devices
+             SET last_used_at = NOW(), ip_address = ?
+             WHERE id = ?'
+        );
+        $upd->execute([substr((string)$ip, 0, 45), $row['id']]);
+
+        return $row['username'];
+    } catch (Throwable $e) {
+        error_log('verify_trusted_device_cookie failed: ' . $e->getMessage());
         return null;
     }
-
-    if (!hash_equals($row['validator_hash'], hash('sha256', $validator))) {
-        return null;
-    }
-
-    $upd = $pdo->prepare(
-        'UPDATE admin_trusted_devices
-         SET last_used_at = NOW(), ip_address = ?
-         WHERE id = ?'
-    );
-    $upd->execute([substr((string)$ip, 0, 45), $row['id']]);
-
-    return $row['username'];
 }
 
 /** Revoke a single device, scoped to the owning user. */

--- a/admin/trusted_devices.php
+++ b/admin/trusted_devices.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Trusted device helpers — let an admin skip the TOTP step on devices they've
+ * opted in on, for 30 days. The password step is always still required.
+ *
+ * Storage uses a split-token pattern (selector + validator), the same approach
+ * Symfony and Spring Security use for "remember me":
+ *
+ *   cookie value  = "<selector>.<validator>"
+ *   DB row        = (selector plaintext for O(1) lookup, validator_hash = sha256(validator))
+ *
+ * A database read therefore cannot grant authentication on its own — the
+ * attacker would need the validator from the user's cookie. hash_equals() is
+ * used on the validator compare to avoid timing leaks.
+ */
+
+require_once __DIR__ . '/../db_connect.php';
+require_once __DIR__ . '/../env_helper.php';
+require_once __DIR__ . '/../rate_limit_helper.php';
+
+const ADMIN_TRUST_COOKIE = 'admin_trust_token';
+const ADMIN_TRUST_TTL_DAYS = 30;
+
+/**
+ * Issue a new trusted-device token for $user_id, persist the hashed row, and
+ * set the cookie on the response.
+ */
+function issue_trusted_device_token($user_id, $user_agent, $ip)
+{
+    global $pdo;
+
+    $selector  = bin2hex(random_bytes(8));   // 16 hex chars
+    $validator = bin2hex(random_bytes(32));  // 64 hex chars (256 bits)
+    $validator_hash = hash('sha256', $validator);
+
+    $label = derive_device_label($user_agent);
+
+    $stmt = $pdo->prepare(
+        'INSERT INTO admin_trusted_devices
+            (user_id, selector, validator_hash, label, user_agent, ip_address, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL ? DAY))'
+    );
+    $stmt->execute([
+        $user_id,
+        $selector,
+        $validator_hash,
+        $label,
+        substr((string)$user_agent, 0, 255),
+        substr((string)$ip, 0, 45),
+        ADMIN_TRUST_TTL_DAYS,
+    ]);
+
+    $secure = env('APP_ENV', 'sandbox') === 'production';
+    setcookie(ADMIN_TRUST_COOKIE, $selector . '.' . $validator, [
+        'expires'  => time() + (ADMIN_TRUST_TTL_DAYS * 86400),
+        'path'     => '/admin/',
+        'secure'   => $secure,
+        'httponly' => true,
+        'samesite' => 'Strict',
+    ]);
+}
+
+/**
+ * Returns the username (canonical case) the current cookie is valid for, or
+ * null. On success, last_used_at + ip_address are bumped.
+ *
+ * Returns null silently for any malformed or expired cookie; the caller just
+ * falls through to the normal TOTP flow.
+ */
+function verify_trusted_device_cookie($ip)
+{
+    global $pdo;
+
+    $raw = $_COOKIE[ADMIN_TRUST_COOKIE] ?? '';
+    if (!is_string($raw) || strpos($raw, '.') === false) {
+        return null;
+    }
+
+    [$selector, $validator] = explode('.', $raw, 2);
+    if (!preg_match('/^[a-f0-9]{16}$/', $selector) || !preg_match('/^[a-f0-9]{64}$/', $validator)) {
+        return null;
+    }
+
+    $stmt = $pdo->prepare(
+        'SELECT d.id, d.validator_hash, d.expires_at, u.username
+         FROM admin_trusted_devices d
+         JOIN admin_users u ON u.id = d.user_id
+         WHERE d.selector = ? AND d.expires_at > NOW()
+         LIMIT 1'
+    );
+    $stmt->execute([$selector]);
+    $row = $stmt->fetch();
+    if (!$row) {
+        return null;
+    }
+
+    if (!hash_equals($row['validator_hash'], hash('sha256', $validator))) {
+        return null;
+    }
+
+    $upd = $pdo->prepare(
+        'UPDATE admin_trusted_devices
+         SET last_used_at = NOW(), ip_address = ?
+         WHERE id = ?'
+    );
+    $upd->execute([substr((string)$ip, 0, 45), $row['id']]);
+
+    return $row['username'];
+}
+
+/** Revoke a single device, scoped to the owning user. */
+function revoke_trusted_device($user_id, $device_id)
+{
+    global $pdo;
+    $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE id = ? AND user_id = ?');
+    $stmt->execute([$device_id, $user_id]);
+    return $stmt->rowCount() > 0;
+}
+
+/** Revoke every trusted device for a user. Returns the count removed. */
+function revoke_all_trusted_devices($user_id)
+{
+    global $pdo;
+    $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE user_id = ?');
+    $stmt->execute([$user_id]);
+    return $stmt->rowCount();
+}
+
+/** Expire the cookie on the client. Safe to call even if no cookie is set. */
+function clear_trusted_device_cookie()
+{
+    $secure = env('APP_ENV', 'sandbox') === 'production';
+    setcookie(ADMIN_TRUST_COOKIE, '', [
+        'expires'  => time() - 3600,
+        'path'     => '/admin/',
+        'secure'   => $secure,
+        'httponly' => true,
+        'samesite' => 'Strict',
+    ]);
+}
+
+/** List active trusted devices for a user, most recently used first. */
+function list_trusted_devices($user_id)
+{
+    global $pdo;
+    $stmt = $pdo->prepare(
+        'SELECT id, label, user_agent, ip_address, created_at, last_used_at, expires_at
+         FROM admin_trusted_devices
+         WHERE user_id = ? AND expires_at > NOW()
+         ORDER BY last_used_at DESC'
+    );
+    $stmt->execute([$user_id]);
+    return $stmt->fetchAll();
+}
+
+/**
+ * Best-effort human label from the User-Agent string. UA strings are unreliable
+ * for security decisions, but they're fine as a display hint so an admin can
+ * tell their devices apart when revoking.
+ */
+function derive_device_label($user_agent)
+{
+    $ua = (string)$user_agent;
+    if ($ua === '') return 'Unknown device';
+
+    if (stripos($ua, 'Edg/') !== false)         $browser = 'Edge';
+    elseif (stripos($ua, 'Chrome/') !== false)  $browser = 'Chrome';
+    elseif (stripos($ua, 'Firefox/') !== false) $browser = 'Firefox';
+    elseif (stripos($ua, 'Safari/') !== false)  $browser = 'Safari';
+    else                                        $browser = 'Browser';
+
+    if (stripos($ua, 'Windows') !== false)   $os = 'Windows';
+    elseif (stripos($ua, 'Mac OS') !== false) $os = 'macOS';
+    elseif (stripos($ua, 'Android') !== false) $os = 'Android';
+    elseif (stripos($ua, 'iPhone') !== false || stripos($ua, 'iPad') !== false) $os = 'iOS';
+    elseif (stripos($ua, 'Linux') !== false)  $os = 'Linux';
+    else $os = 'device';
+
+    return "$browser on $os";
+}

--- a/admin/trusted_devices.php
+++ b/admin/trusted_devices.php
@@ -108,37 +108,54 @@ function verify_trusted_device_cookie($ip)
         if (!hash_equals($row['validator_hash'], hash('sha256', $validator))) {
             return null;
         }
+    } catch (Throwable $e) {
+        error_log('verify_trusted_device_cookie failed: ' . $e->getMessage());
+        return null;
+    }
 
+    // Metadata update is best-effort: the auth decision was already made above
+    // when the validator matched. A transient UPDATE failure must not force
+    // the user back to TOTP — they're already authenticated.
+    try {
         $upd = $pdo->prepare(
             'UPDATE admin_trusted_devices
              SET last_used_at = NOW(), ip_address = ?
              WHERE id = ?'
         );
         $upd->execute([substr((string)$ip, 0, 45), $row['id']]);
-
-        return $row['username'];
     } catch (Throwable $e) {
-        error_log('verify_trusted_device_cookie failed: ' . $e->getMessage());
-        return null;
+        error_log('verify_trusted_device_cookie metadata update failed: ' . $e->getMessage());
     }
+
+    return $row['username'];
 }
 
 /** Revoke a single device, scoped to the owning user. */
 function revoke_trusted_device($user_id, $device_id)
 {
     global $pdo;
-    $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE id = ? AND user_id = ?');
-    $stmt->execute([$device_id, $user_id]);
-    return $stmt->rowCount() > 0;
+    try {
+        $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE id = ? AND user_id = ?');
+        $stmt->execute([$device_id, $user_id]);
+        return $stmt->rowCount() > 0;
+    } catch (Throwable $e) {
+        error_log('revoke_trusted_device failed: ' . $e->getMessage());
+        return false;
+    }
 }
 
 /** Revoke every trusted device for a user. Returns the count removed. */
 function revoke_all_trusted_devices($user_id)
 {
     global $pdo;
-    $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE user_id = ?');
-    $stmt->execute([$user_id]);
-    return $stmt->rowCount();
+    try {
+        $stmt = $pdo->prepare('DELETE FROM admin_trusted_devices WHERE user_id = ?');
+        $stmt->execute([$user_id]);
+        return $stmt->rowCount();
+    } catch (Throwable $e) {
+        error_log('revoke_all_trusted_devices failed: ' . $e->getMessage());
+        return 0;
+    }
 }
 
 /** Expire the cookie on the client. Safe to call even if no cookie is set. */
@@ -158,14 +175,19 @@ function clear_trusted_device_cookie()
 function list_trusted_devices($user_id)
 {
     global $pdo;
-    $stmt = $pdo->prepare(
-        'SELECT id, label, user_agent, ip_address, created_at, last_used_at, expires_at
-         FROM admin_trusted_devices
-         WHERE user_id = ? AND expires_at > NOW()
-         ORDER BY last_used_at DESC'
-    );
-    $stmt->execute([$user_id]);
-    return $stmt->fetchAll();
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT id, label, user_agent, ip_address, created_at, last_used_at, expires_at
+             FROM admin_trusted_devices
+             WHERE user_id = ? AND expires_at > NOW()
+             ORDER BY last_used_at DESC'
+        );
+        $stmt->execute([$user_id]);
+        return $stmt->fetchAll();
+    } catch (Throwable $e) {
+        error_log('list_trusted_devices failed: ' . $e->getMessage());
+        return [];
+    }
 }
 
 /**

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -36,6 +36,27 @@ CREATE TABLE IF NOT EXISTS admin_users (
 --   ALTER TABLE admin_users
 --     ADD COLUMN last_2fa_counter BIGINT NOT NULL DEFAULT 0 AFTER two_factor_enabled;
 
+-- Trusted admin devices (skip TOTP step on opted-in devices for 30 days).
+-- Split-token pattern: cookie holds "selector.validator"; DB stores selector
+-- in plaintext (for O(1) lookup) and a SHA-256 hash of the validator so a DB
+-- read cannot impersonate the user. The trust cookie ONLY bypasses TOTP --
+-- the password step is still required on every login.
+CREATE TABLE IF NOT EXISTS admin_trusted_devices (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    selector CHAR(16) NOT NULL UNIQUE,
+    validator_hash CHAR(64) NOT NULL,
+    label VARCHAR(120),
+    user_agent VARCHAR(255),
+    ip_address VARCHAR(45),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME NOT NULL,
+    CONSTRAINT fk_atd_user FOREIGN KEY (user_id) REFERENCES admin_users(id) ON DELETE CASCADE,
+    INDEX idx_atd_user_id (user_id),
+    INDEX idx_atd_expires (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Create users table
 CREATE TABLE IF NOT EXISTS community_users (
     id INT PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
## Summary

- Adds opt-in **"Trust this device for 30 days"** checkbox on the admin 2FA verification form. Subsequent logins from a trusted device skip TOTP. Password is still required on every login.
- New **Trusted Devices** settings page lists active devices with per-row and "revoke all" buttons. Disabling 2FA wipes all trusted-device rows for that user.
- Uses the split-token pattern (selector + validator). DB stores selector plaintext for O(1) lookup and SHA-256 of the validator, so a DB read alone cannot impersonate the user.

## Files

- `admin/trusted_devices.php` — new helper (issue / verify / revoke / list)
- `admin/login.php` — trust-cookie shortcut after password verifies; checkbox on TOTP form; token issued on successful TOTP if box checked
- `admin/settings/2fa.php` — `disable_2fa()` also revokes trusted devices
- `admin/settings/trusted-devices.php` — new management page
- `admin/settings/index.php` — link to the new page
- `mysql_schema.sql` — new `admin_trusted_devices` table

## Schema migration

This PR does **not** auto-run the migration. After merge, run this against both `argo_books` and `argo_books_sandbox` (whichever apply):

```sql
CREATE TABLE IF NOT EXISTS admin_trusted_devices (
    id INT PRIMARY KEY AUTO_INCREMENT,
    user_id INT NOT NULL,
    selector CHAR(16) NOT NULL UNIQUE,
    validator_hash CHAR(64) NOT NULL,
    label VARCHAR(120),
    user_agent VARCHAR(255),
    ip_address VARCHAR(45),
    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    last_used_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    expires_at DATETIME NOT NULL,
    CONSTRAINT fk_atd_user FOREIGN KEY (user_id) REFERENCES admin_users(id) ON DELETE CASCADE,
    INDEX idx_atd_user_id (user_id),
    INDEX idx_atd_expires (expires_at)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

## Security model

| Threat | Mitigation |
|---|---|
| Cookie stolen via XSS | `httponly` |
| Cookie stolen via CSRF | `samesite=Strict` |
| Cookie sniffed on wire | `secure` flag in production |
| Cookie value brute-forced | 256 bits of entropy in validator |
| DB read leaks tokens | Only validator-hash stored |
| Cookie outlives need | 30-day hard expiry (`expires_at > NOW()`) |
| User wants to revoke | Per-device + revoke-all UI |
| 2FA disabled by attacker | `disable_2fa()` revokes all trust rows |
| Admin user deleted | `ON DELETE CASCADE` removes rows |
| Cookie reused for different admin | Tokens bound to `user_id` |
| Rate-limiting bypass | Trust path still requires correct password (5/15min limit) |

What this does NOT defend against: attacker with both password AND access to a trusted device's cookie store. Same tradeoff as Google's "remember this computer" — 30-day TTL + revoke UI cap the blast radius.

## Test plan

- [ ] Run the `CREATE TABLE` migration in HeidiSQL
- [ ] Log in with password + TOTP, tick "Trust this device for 30 days". Confirm `admin_trust_token` cookie set and DB row created
- [ ] Log out and log back in — TOTP form should be skipped
- [ ] Clear the cookie in DevTools, log in — TOTP form returns
- [ ] Open `/admin/settings/trusted-devices.php`, click Revoke — next login prompts for TOTP
- [ ] Click "Revoke all trusted devices" — all rows deleted
- [ ] Disable 2FA from settings — all trusted-device rows for that user removed
- [ ] In a second browser, sign in as a different admin user (if applicable) — cookie from admin A does not skip TOTP for admin B
- [ ] Manually set a row's `expires_at` to the past in HeidiSQL — login prompts for TOTP
- [ ] DevTools → Cookies → confirm `HttpOnly`, `SameSite=Strict` flags; `Secure` in production env

🤖 Generated with [Claude Code](https://claude.com/claude-code)