### PR TITLE
feat(outreach): add Reddit channel with AI scoring + drafting

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -14,6 +14,7 @@ header('Content-Type: application/json');
 
 // Load shared outreach helpers (scrape_email_from_website, search_businesses_core, call_gemini, etc.)
 require_once __DIR__ . '/../../cron/lib/outreach_helpers.php';
+require_once __DIR__ . '/../../cron/lib/reddit_helpers.php';
 
 // CSRF protection for state-changing (non-GET) requests
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
@@ -58,6 +59,26 @@ if (in_array($action, $pipelineActions) && is_pipeline_running()) {
     echo json_encode([
         'success' => false,
         'message' => 'The outreach pipeline cron job is currently running. Please wait a few minutes and try again.'
+    ]);
+    exit;
+}
+
+// Block Reddit actions while the Reddit cron is running
+function is_reddit_monitor_running(): bool
+{
+    $lockFile = __DIR__ . '/../../cron/logs/reddit_monitor.lock';
+    if (!file_exists($lockFile)) return false;
+    $fp = @fopen($lockFile, 'r');
+    if (!$fp) return false;
+    $locked = !flock($fp, LOCK_EX | LOCK_NB);
+    fclose($fp);
+    return $locked;
+}
+$redditCronActions = ['reddit_run_now', 'reddit_regenerate_draft', 'reddit_generate_pending_draft'];
+if (in_array($action, $redditCronActions) && is_reddit_monitor_running()) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'The Reddit discovery cron is currently running. Please wait a few minutes and try again.'
     ]);
     exit;
 }
@@ -162,6 +183,47 @@ switch ($action) {
         break;
     case 'save_followup_draft':
         save_followup_draft($pdo);
+        break;
+
+    // Reddit outreach
+    case 'reddit_get_threads':
+        reddit_api_get_threads($pdo);
+        break;
+    case 'reddit_get_thread':
+        reddit_api_get_thread($pdo);
+        break;
+    case 'reddit_get_stats':
+        reddit_api_get_stats($pdo);
+        break;
+    case 'reddit_pipeline_status':
+        reddit_api_pipeline_status();
+        break;
+    case 'reddit_pipeline_progress':
+        reddit_api_pipeline_progress();
+        break;
+    case 'reddit_run_now':
+        reddit_api_run_now($pdo);
+        break;
+    case 'reddit_mark_replied':
+        reddit_api_mark_replied($pdo);
+        break;
+    case 'reddit_mark_not_fit':
+        reddit_api_mark_not_fit($pdo);
+        break;
+    case 'reddit_mark_skipped':
+        reddit_api_mark_skipped($pdo);
+        break;
+    case 'reddit_save_draft':
+        reddit_api_save_draft($pdo);
+        break;
+    case 'reddit_regenerate_draft':
+        reddit_api_regenerate_draft($pdo);
+        break;
+    case 'reddit_generate_pending_draft':
+        reddit_api_generate_pending_draft($pdo);
+        break;
+    case 'reddit_get_account_info':
+        reddit_api_get_account_info($pdo);
         break;
 
     default:
@@ -1320,5 +1382,369 @@ function save_followup_draft($pdo)
     $stmt = $pdo->prepare("UPDATE outreach_followups SET draft_subject = ?, draft_body = ? WHERE id = ? AND status = 'drafted'");
     $stmt->execute([$subject, $body, $id]);
     echo json_encode(['success' => true]);
+}
+
+// ─── Reddit outreach endpoints ───
+
+function reddit_api_get_threads($pdo)
+{
+    $status = (string) ($_GET['status'] ?? 'actionable');
+    $subreddit = (string) ($_GET['subreddit'] ?? '');
+    $source = (string) ($_GET['source'] ?? '');
+    $days = max(0, (int) ($_GET['days'] ?? 30));
+
+    $where = [];
+    $params = [];
+
+    if ($status === 'actionable') {
+        $where[] = "status IN ('drafted', 'drafted_pending')";
+    } elseif ($status === 'reply_removed') {
+        $where[] = "status = 'replied' AND reply_status IN ('removed', 'removed_or_shadowbanned')";
+    } elseif ($status !== '' && $status !== 'all') {
+        $where[] = 'status = ?';
+        $params[] = $status;
+    }
+
+    if ($subreddit !== '') {
+        $where[] = 'subreddit = ?';
+        $params[] = $subreddit;
+    }
+
+    if (in_array($source, ['watchlist', 'keyword', 'both'], true)) {
+        $where[] = 'discovery_source = ?';
+        $params[] = $source;
+    }
+
+    if ($days > 0) {
+        $where[] = "discovered_at > DATE_SUB(NOW(), INTERVAL $days DAY)";
+    }
+
+    $whereClause = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+    $sql = "SELECT id, reddit_id, subreddit, title, url, ai_relevance, ai_relevance_reason, status,
+                   reply_status, reply_upvotes, reply_replies_count, reply_permalink, draft_body,
+                   discovered_at, posted_at, comment_count, rules_score, discovery_source, mentioned_product
+            FROM reddit_threads $whereClause
+            ORDER BY (ai_relevance IS NULL) ASC, ai_relevance DESC, discovered_at DESC
+            LIMIT 200";
+
+    try {
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        $threads = $stmt->fetchAll();
+    } catch (PDOException $e) {
+        json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
+    }
+
+    json_response(['success' => true, 'threads' => $threads]);
+}
+
+function reddit_api_get_thread($pdo)
+{
+    $id = (int) ($_GET['id'] ?? 0);
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+
+    $stmt = $pdo->prepare("SELECT * FROM reddit_threads WHERE id = ?");
+    $stmt->execute([$id]);
+    $thread = $stmt->fetch();
+    if (!$thread) json_response(['success' => false, 'message' => 'Thread not found'], 404);
+
+    json_response(['success' => true, 'thread' => $thread]);
+}
+
+function reddit_api_get_stats($pdo)
+{
+    try {
+        $stats = [
+            'total' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads")->fetchColumn(),
+            'drafted' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'drafted'")->fetchColumn(),
+            'drafted_pending' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'drafted_pending'")->fetchColumn(),
+            'replied_7d' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'replied' AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 7 DAY)")->fetchColumn(),
+            'daily_used' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'replied' AND mentioned_product = 1 AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 1 DAY)")->fetchColumn(),
+            'weekly_used' => (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'replied' AND mentioned_product = 1 AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 7 DAY)")->fetchColumn(),
+        ];
+
+        // Reply survival: of replies whose status has been checked at least once,
+        // what % are still live? Excludes deleted_by_user (founder's own action).
+        $survival = $pdo->query("
+            SELECT
+                SUM(CASE WHEN reply_status = 'live' THEN 1 ELSE 0 END) AS live_count,
+                SUM(CASE WHEN reply_status IN ('live','removed','removed_or_shadowbanned') THEN 1 ELSE 0 END) AS judged_count
+            FROM reddit_threads
+            WHERE status = 'replied' AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+        ")->fetch();
+        $judged = (int) ($survival['judged_count'] ?? 0);
+        $live = (int) ($survival['live_count'] ?? 0);
+        $stats['survival_pct'] = $judged > 0 ? round(($live / $judged) * 100, 1) : null;
+        $stats['survival_n'] = $judged;
+
+        // Avg upvotes on live replies
+        $avg = $pdo->query("
+            SELECT AVG(reply_upvotes) AS avg_upvotes
+            FROM reddit_threads
+            WHERE reply_status = 'live' AND reply_upvotes IS NOT NULL
+        ")->fetch();
+        $stats['avg_upvotes'] = $avg && $avg['avg_upvotes'] !== null ? round((float) $avg['avg_upvotes'], 1) : null;
+
+        // Profile-link clicks (30d). statistics.php emits a 'reddit_referrer'
+        // event row whenever an inbound page view has a reddit.com Referer.
+        try {
+            $clicks = $pdo->query("
+                SELECT COUNT(*) FROM statistics
+                WHERE event_type = 'reddit_referrer'
+                  AND created_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+            ")->fetchColumn();
+            $stats['profile_clicks_30d'] = (int) $clicks;
+        } catch (PDOException $e) {
+            $stats['profile_clicks_30d'] = 0;
+        }
+
+        // Post limits (for safety meter)
+        $cfg = $pdo->query("SELECT daily_post_limit, weekly_post_limit FROM reddit_settings WHERE id = 1")->fetch();
+        $stats['daily_limit'] = (int) ($cfg['daily_post_limit'] ?? 3);
+        $stats['weekly_limit'] = (int) ($cfg['weekly_post_limit'] ?? 12);
+
+        json_response(['success' => true, 'stats' => $stats]);
+    } catch (PDOException $e) {
+        json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
+    }
+}
+
+function reddit_api_pipeline_status()
+{
+    json_response(['success' => true, 'running' => is_reddit_monitor_running()]);
+}
+
+function reddit_api_pipeline_progress()
+{
+    json_response([
+        'success' => true,
+        'running' => is_reddit_monitor_running(),
+        'progress' => reddit_progress_read(),
+    ]);
+}
+
+function reddit_api_run_now($pdo)
+{
+    // Shared-hosting friendly: many hosts disable exec/shell_exec/proc_open via
+    // disable_functions. Instead of spawning a subprocess, we send the HTTP
+    // response immediately, detach from the client, then run the cron inline
+    // in this same PHP process. $pdo is brought in as a parameter so it stays
+    // in scope when we `require` the cron from inside this function (PHP
+    // doesn't auto-import globals into function scope for included files).
+    $cronPath = realpath(__DIR__ . '/../../cron/reddit_monitor.php');
+    if (!$cronPath) {
+        json_response(['success' => false, 'message' => 'Cron script not found'], 500);
+    }
+
+    // Let the work run as long as it needs and survive client disconnect.
+    @set_time_limit(600);
+    @ignore_user_abort(true);
+
+    // Send the JSON response now so the admin UI doesn't hang while the cron runs.
+    http_response_code(200);
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true, 'message' => 'Reddit discovery started. Refresh in a minute or two to see new threads.']);
+
+    // Release the session lock BEFORE running the inline cron. PHP's default
+    // file-based session handler holds an exclusive lock on the session file
+    // for the duration of the request — without this close, page reloads and
+    // the JS progress polling block for the full multi-minute cron runtime.
+    if (function_exists('session_write_close')) {
+        @session_write_close();
+    }
+
+    // Detach from the client. fastcgi_finish_request is PHP-FPM only; fall back
+    // to flushing buffers on other SAPIs (work continues either way thanks to
+    // ignore_user_abort).
+    if (function_exists('fastcgi_finish_request')) {
+        fastcgi_finish_request();
+    } else {
+        while (function_exists('ob_get_level') && ob_get_level() > 0) {
+            @ob_end_flush();
+        }
+        @flush();
+    }
+
+    outreach_log('Reddit monitor triggered manually from admin (inline)');
+
+    // Bypass the cron's CLI-only guard and run the pipeline inline. After the
+    // cron file finishes, control returns here and PHP exits normally.
+    if (!defined('REDDIT_MONITOR_INLINE')) {
+        define('REDDIT_MONITOR_INLINE', true);
+    }
+    try {
+        require $cronPath;
+    } catch (Throwable $e) {
+        outreach_log('Inline Reddit monitor crashed: ' . $e->getMessage());
+    }
+    exit;
+}
+
+function reddit_api_mark_replied($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    $permalink = trim((string) ($data['permalink'] ?? ''));
+    $mentionedProduct = !empty($data['mentioned_product']) ? 1 : 0;
+    $overrideLimit = !empty($data['override_limit']) ? 1 : 0;
+
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+
+    $commentId = reddit_extract_comment_id_from_permalink($permalink);
+    if ($commentId === null) {
+        json_response(['success' => false, 'message' => 'Invalid Reddit comment permalink. Expected something like https://www.reddit.com/r/.../comments/.../slug/<comment_id>/'], 400);
+    }
+
+    // Enforce post limits unless override is set
+    if ($mentionedProduct && !$overrideLimit) {
+        $cfg = $pdo->query("SELECT daily_post_limit, weekly_post_limit FROM reddit_settings WHERE id = 1")->fetch();
+        $dailyLimit = (int) ($cfg['daily_post_limit'] ?? 3);
+        $weeklyLimit = (int) ($cfg['weekly_post_limit'] ?? 12);
+        $dailyUsed = (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'replied' AND mentioned_product = 1 AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 1 DAY)")->fetchColumn();
+        $weeklyUsed = (int) $pdo->query("SELECT COUNT(*) FROM reddit_threads WHERE status = 'replied' AND mentioned_product = 1 AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 7 DAY)")->fetchColumn();
+        if ($dailyUsed >= $dailyLimit || $weeklyUsed >= $weeklyLimit) {
+            json_response([
+                'success' => false,
+                'message' => "You're at the post limit (daily $dailyUsed/$dailyLimit, weekly $weeklyUsed/$weeklyLimit). Override required.",
+                'requires_override' => true,
+                'daily_used' => $dailyUsed,
+                'daily_limit' => $dailyLimit,
+                'weekly_used' => $weeklyUsed,
+                'weekly_limit' => $weeklyLimit,
+            ], 400);
+        }
+    }
+
+    $stmt = $pdo->prepare("
+        UPDATE reddit_threads
+        SET status = 'replied',
+            reply_permalink = ?,
+            reply_comment_id = ?,
+            reply_posted_at = NOW(),
+            reply_status = 'pending',
+            reply_status_check_count = 0,
+            mentioned_product = ?,
+            override_limit = ?
+        WHERE id = ?
+    ");
+    $stmt->execute([$permalink, $commentId, $mentionedProduct, $overrideLimit, $id]);
+
+    if ($stmt->rowCount() === 0) {
+        json_response(['success' => false, 'message' => 'Thread not found'], 404);
+    }
+
+    json_response(['success' => true]);
+}
+
+function reddit_api_mark_not_fit($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+
+    $stmt = $pdo->prepare("UPDATE reddit_threads SET status = 'not_fit' WHERE id = ?");
+    $stmt->execute([$id]);
+    json_response(['success' => true]);
+}
+
+function reddit_api_mark_skipped($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+
+    $stmt = $pdo->prepare("UPDATE reddit_threads SET status = 'skipped' WHERE id = ?");
+    $stmt->execute([$id]);
+    json_response(['success' => true]);
+}
+
+function reddit_api_save_draft($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    $body = trim((string) ($data['draft_body'] ?? ''));
+
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+    if ($body === '') json_response(['success' => false, 'message' => 'Draft body cannot be empty'], 400);
+    if (strlen($body) > 10000) json_response(['success' => false, 'message' => 'Draft too long (max 10000 chars)'], 400);
+
+    $stmt = $pdo->prepare("UPDATE reddit_threads SET draft_body = ?, status = CASE WHEN status = 'drafted_pending' THEN 'drafted' ELSE status END WHERE id = ?");
+    $stmt->execute([$body, $id]);
+    json_response(['success' => true]);
+}
+
+function reddit_api_regenerate_draft($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    $feedback = trim((string) ($data['feedback'] ?? ''));
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+    if (mb_strlen($feedback) > 2000) {
+        json_response(['success' => false, 'message' => 'Feedback too long (max 2000 chars)'], 400);
+    }
+
+    $stmt = $pdo->prepare("SELECT * FROM reddit_threads WHERE id = ?");
+    $stmt->execute([$id]);
+    $thread = $stmt->fetch();
+    if (!$thread) json_response(['success' => false, 'message' => 'Thread not found'], 404);
+
+    $comments = reddit_fetch_top_comments($pdo, $thread['subreddit'], $thread['reddit_id']);
+    $draft = reddit_generate_draft($thread, $comments, [
+        'previous_draft' => $thread['draft_body'] ?? '',
+        'feedback' => $feedback,
+    ]);
+    if (!empty($draft['error'])) {
+        json_response(['success' => false, 'message' => 'Draft generation failed: ' . $draft['error']], 500);
+    }
+
+    $upd = $pdo->prepare("UPDATE reddit_threads SET draft_body = ?, draft_generated_at = NOW(), status = 'drafted' WHERE id = ?");
+    $upd->execute([$draft['body'], $id]);
+
+    json_response(['success' => true, 'draft_body' => $draft['body']]);
+}
+
+function reddit_api_generate_pending_draft($pdo)
+{
+    // Same as regenerate but only valid for drafted_pending rows
+    $data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+    $id = (int) ($data['id'] ?? 0);
+    if ($id <= 0) json_response(['success' => false, 'message' => 'Missing thread id'], 400);
+
+    $stmt = $pdo->prepare("SELECT * FROM reddit_threads WHERE id = ? AND status = 'drafted_pending'");
+    $stmt->execute([$id]);
+    $thread = $stmt->fetch();
+    if (!$thread) json_response(['success' => false, 'message' => 'Thread not found or not pending'], 404);
+
+    $comments = reddit_fetch_top_comments($pdo, $thread['subreddit'], $thread['reddit_id']);
+    $draft = reddit_generate_draft($thread, $comments);
+    if (!empty($draft['error'])) {
+        json_response(['success' => false, 'message' => 'Draft generation failed: ' . $draft['error']], 500);
+    }
+
+    $upd = $pdo->prepare("UPDATE reddit_threads SET draft_body = ?, draft_generated_at = NOW(), status = 'drafted' WHERE id = ?");
+    $upd->execute([$draft['body'], $id]);
+
+    json_response(['success' => true, 'draft_body' => $draft['body']]);
+}
+
+function reddit_api_get_account_info($pdo)
+{
+    if (empty($_ENV['REDDIT_USERNAME'])) {
+        json_response([
+            'success' => false,
+            'message' => 'REDDIT_USERNAME is not set in .env, so we don\'t know which account to look up. Set it to enable this card.',
+        ]);
+    }
+
+    $info = reddit_fetch_account_about($pdo);
+    if ($info === null) {
+        $hint = reddit_oauth_configured()
+            ? 'OAuth token request failed — verify REDDIT_CLIENT_ID / SECRET / PASSWORD in .env.'
+            : 'Without OAuth, Reddit blocks the account-about endpoint from this server\'s IP. Configure REDDIT_* OAuth env vars to enable.';
+        json_response(['success' => false, 'message' => $hint]);
+    }
+
+    $info['account_age_days'] = $info['created_utc'] > 0 ? floor((time() - $info['created_utc']) / 86400) : null;
+    json_response(['success' => true, 'account' => $info]);
 }
 

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -1420,8 +1420,12 @@ function reddit_api_get_threads($pdo)
     }
 
     $whereClause = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+    // List endpoint deliberately omits draft_body (could be up to ~2KB per row,
+    // not used by the table UI). The thread-detail modal fetches the full row
+    // via reddit_get_thread when opened. `has_draft` lets the UI show a flag.
     $sql = "SELECT id, reddit_id, subreddit, title, url, ai_relevance, ai_relevance_reason, status,
-                   reply_status, reply_upvotes, reply_replies_count, reply_permalink, draft_body,
+                   reply_status, reply_upvotes, reply_replies_count, reply_permalink,
+                   (draft_body IS NOT NULL AND draft_body <> '') AS has_draft,
                    discovered_at, posted_at, comment_count, rules_score, discovery_source, mentioned_product
             FROM reddit_threads $whereClause
             ORDER BY (ai_relevance IS NULL) ASC, ai_relevance DESC, discovered_at DESC

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -17,6 +17,8 @@ if (empty($_SESSION['csrf_token'])) {
 require_once __DIR__ . '/tabs/ab-tests.php';
 require_once __DIR__ . '/tabs/settings.php';
 require_once __DIR__ . '/tabs/followups.php';
+require_once __DIR__ . '/tabs/reddit-threads.php';
+require_once __DIR__ . '/tabs/reddit-settings.php';
 
 // Dispatch POST submissions from tab-specific forms BEFORE any output so
 // redirects via header() still work. CSRF: every state-changing tab form
@@ -34,12 +36,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['tab'])) {
         ab_tests_tab_handle_post($pdo);
     } elseif ($postTab === 'settings') {
         settings_tab_handle_post($pdo);
+    } elseif ($postTab === 'reddit-settings') {
+        reddit_settings_tab_handle_post($pdo);
     }
 }
 
 // Determine active tab from ?tab=
 $activeTab = $_GET['tab'] ?? 'leads';
-if (!in_array($activeTab, ['discovery', 'leads', 'ab-tests', 'followups', 'settings'], true)) {
+$allowedTabs = ['discovery', 'leads', 'ab-tests', 'followups', 'settings', 'reddit-threads', 'reddit-settings'];
+if (!in_array($activeTab, $allowedTabs, true)) {
     $activeTab = 'leads';
 }
 
@@ -54,6 +59,25 @@ include __DIR__ . '/../admin_header.php';
 <meta name="csrf-token" content="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
 <link rel="stylesheet" href="style.css">
 <link rel="stylesheet" href="../../resources/styles/checkbox.css">
+
+<?php
+// Determine which channel is active. Reddit sub-tabs map to the reddit pane;
+// everything else (including legacy URLs without a tab param) maps to email.
+$redditTabs = ['reddit-threads', 'reddit-settings'];
+$activeChannel = $_GET['channel'] ?? (in_array($activeTab, $redditTabs, true) ? 'reddit' : 'email');
+if (!in_array($activeChannel, ['email', 'reddit'], true)) {
+    $activeChannel = 'email';
+}
+?>
+
+<!-- Channel-level tabs (Email | Reddit) -->
+<div class="channel-tabs">
+    <button class="channel-tab <?php echo $activeChannel === 'email' ? 'active' : ''; ?>" data-channel="email">Email</button>
+    <button class="channel-tab <?php echo $activeChannel === 'reddit' ? 'active' : ''; ?>" data-channel="reddit">Reddit</button>
+</div>
+
+<!-- Email channel -->
+<div class="channel-pane <?php echo $activeChannel === 'email' ? 'active' : ''; ?>" data-channel-pane="email">
 
 <!-- Page-level tabs -->
 <div class="section-tabs">
@@ -163,6 +187,11 @@ include __DIR__ . '/../admin_header.php';
             <p class="text-muted" style="margin:8px 0 0; font-size:13px; text-align:center;">
                 The system picks Canadian-startup queries automatically and keeps searching until it finds enough or your daily SerpAPI quota runs out. Usage today: <span id="serpapiUsage">…</span>.
             </p>
+            <div style="text-align:center; margin-top:10px;">
+                <button class="btn btn-small btn-blue" onclick="showModal('shopifyRejectStatsModal')">
+                    Why candidates get rejected (last 30 days)
+                </button>
+            </div>
         </div>
 
         <div id="shopifyResults" style="display:none; margin-top:16px;">
@@ -227,49 +256,6 @@ try {
 }
 $shopifyRejectedTotal = max(0, $shopifyTotal30d - $shopifyImported30d);
 ?>
-
-<!-- Shopify Rejection Reasons Panel -->
-<div class="panel discovery-panel">
-    <div class="panel-header" onclick="togglePanel('shopifyRejectStatsContent')">
-        <h2><?= svg_icon('bar-chart', 18) ?> Why Shopify candidates get rejected (last 30 days)</h2>
-        <span class="panel-toggle" id="shopifyRejectStatsToggle">&#9660;</span>
-    </div>
-    <div class="panel-content" id="shopifyRejectStatsContent">
-        <?php if ($shopifyTotal30d === 0): ?>
-            <p class="text-muted" style="margin:8px 0; font-size:13px;">No Shopify candidates evaluated in the last 30 days.</p>
-        <?php else: ?>
-            <p class="text-muted" style="margin:0 0 12px; font-size:13px;">
-                Of <?= (int) $shopifyTotal30d ?> candidates evaluated, <?= (int) $shopifyImported30d ?> were imported as leads and <?= (int) $shopifyRejectedTotal ?> were rejected. Use this breakdown to tune the dork pool or evaluator thresholds.
-            </p>
-            <div class="discovery-table-wrapper">
-                <table class="data-table discovery-table">
-                    <thead>
-                        <tr>
-                            <th>Reject reason</th>
-                            <th style="width:90px; text-align:right;">Count</th>
-                            <th style="width:90px; text-align:right;">% of rejects</th>
-                            <th>Sample detail</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($shopifyRejectStats as $row): ?>
-                            <?php
-                                $cnt = (int) $row['cnt'];
-                                $pct = $shopifyRejectedTotal > 0 ? round($cnt / $shopifyRejectedTotal * 100) : 0;
-                            ?>
-                            <tr>
-                                <td><code><?= htmlspecialchars((string) $row['reject_reason']) ?></code></td>
-                                <td style="text-align:right;"><?= $cnt ?></td>
-                                <td style="text-align:right;"><?= $pct ?>%</td>
-                                <td class="text-muted" style="font-size:12px;"><?= htmlspecialchars((string) ($row['sample'] ?? '')) ?></td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-            </div>
-        <?php endif; ?>
-    </div>
-</div>
 
 </div> <!-- /#discovery -->
 
@@ -443,6 +429,32 @@ $shopifyRejectedTotal = max(0, $shopifyTotal30d - $shopifyImported30d);
 <div id="settings" class="tab-content <?php echo $activeTab === 'settings' ? 'active' : ''; ?>">
     <?php settings_tab_render($pdo); ?>
 </div>
+
+</div> <!-- /.channel-pane[data-channel-pane="email"] -->
+
+<!-- Reddit channel -->
+<?php
+// If the URL points to the Reddit channel without a Reddit sub-tab, default to threads.
+if ($activeChannel === 'reddit' && !in_array($activeTab, ['reddit-threads', 'reddit-settings'], true)) {
+    $activeTab = 'reddit-threads';
+}
+?>
+<div class="channel-pane <?php echo $activeChannel === 'reddit' ? 'active' : ''; ?>" data-channel-pane="reddit">
+
+    <!-- Reddit sub-tabs -->
+    <div class="section-tabs">
+        <button class="section-tab <?php echo $activeTab === 'reddit-threads' ? 'active' : ''; ?>" data-tab="reddit-threads">Threads</button>
+        <button class="section-tab <?php echo $activeTab === 'reddit-settings' ? 'active' : ''; ?>" data-tab="reddit-settings">Settings</button>
+    </div>
+
+    <div id="reddit-threads" class="tab-content <?php echo $activeTab === 'reddit-threads' ? 'active' : ''; ?>">
+        <?php reddit_threads_tab_render($pdo); ?>
+    </div>
+
+    <div id="reddit-settings" class="tab-content <?php echo $activeTab === 'reddit-settings' ? 'active' : ''; ?>">
+        <?php reddit_settings_tab_render($pdo); ?>
+    </div>
+</div> <!-- /.channel-pane[data-channel-pane="reddit"] -->
 
 <!-- Lead Detail Modal -->
 <div id="leadDetailModal" class="modal" style="display:none;">
@@ -689,6 +701,146 @@ $shopifyRejectedTotal = max(0, $shopifyTotal30d - $shopifyImported30d);
         <div class="modal-footer">
             <button class="btn btn-blue" onclick="closeBulkSendModal()">Cancel</button>
             <button class="btn btn-blue" id="btnBulkSend" disabled>Send All</button>
+        </div>
+    </div>
+</div>
+
+<!-- Reddit Thread Detail Modal -->
+<div id="redditThreadModal" class="modal" style="display:none;">
+    <div class="modal-content modal-large" style="height:auto; max-height:85vh;">
+        <div class="modal-header">
+            <h3 id="redditThreadTitle">Thread</h3>
+            <button class="modal-close" onclick="closeModal('redditThreadModal')">&times;</button>
+        </div>
+        <div class="modal-body reddit-thread-modal-body">
+            <div class="reddit-thread-meta">
+                <span><strong>Subreddit:</strong> <span id="redditThreadSubreddit"></span></span>
+                <span><strong>AI relevance:</strong> <span id="redditThreadAi"></span></span>
+                <span><strong>Status:</strong> <span id="redditThreadStatus"></span></span>
+                <span><strong>Posted:</strong> <span id="redditThreadPosted"></span></span>
+                <a id="redditThreadUrl" target="_blank" rel="noopener noreferrer">Open on Reddit ↗</a>
+            </div>
+            <div class="reddit-thread-section">
+                <h4>OP body</h4>
+                <pre id="redditThreadBody" class="reddit-thread-body"></pre>
+            </div>
+            <div class="reddit-thread-section">
+                <h4>Why this thread scored that way</h4>
+                <p id="redditThreadReason" class="text-muted"></p>
+            </div>
+            <div class="reddit-thread-section">
+                <h4>Draft</h4>
+                <textarea id="redditDraftBody" rows="10" placeholder="Draft will appear here..."></textarea>
+                <div class="reddit-draft-actions">
+                    <button class="btn btn-small btn-blue" onclick="generatePendingRedditDraft()" id="redditDraftGenerateBtn" style="display:none;">Generate draft</button>
+                    <button class="btn btn-small btn-blue" onclick="saveRedditDraft()">Save draft</button>
+                    <button class="btn btn-small btn-neutral" onclick="openRedditRegenerateFeedback()">Regenerate</button>
+                    <button class="btn btn-small btn-blue" onclick="copyRedditDraft(this)">Copy</button>
+                </div>
+                <div id="redditRegenerateFeedback" class="reddit-regenerate-feedback" style="display:none;">
+                    <label for="redditRegenerateFeedbackText">What should be different about the next draft? (optional)</label>
+                    <textarea id="redditRegenerateFeedbackText" rows="3" placeholder="e.g. too formal, don't mention QuickBooks, lead with the side-hustle angle, drop the disclosure phrasing..."></textarea>
+                    <div class="reddit-regenerate-feedback-actions">
+                        <button class="btn btn-small btn-neutral" onclick="cancelRedditRegenerate()">Cancel</button>
+                        <button class="btn btn-small btn-blue" onclick="submitRedditRegenerate(this)" id="redditRegenerateSubmitBtn">Regenerate</button>
+                    </div>
+                </div>
+            </div>
+            <div class="reddit-thread-section" id="redditReplyStatusSection" style="display:none;">
+                <h4>Posted reply status</h4>
+                <div id="redditReplyStatusBody" class="text-muted"></div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-red" onclick="markRedditNotFit()">Mark not fit</button>
+            <button class="btn btn-neutral" onclick="markRedditSkipped()">Skip</button>
+            <button class="btn btn-blue" onclick="openMarkRedditRepliedModal()">Mark replied…</button>
+        </div>
+    </div>
+</div>
+
+<!-- Mark Replied Modal -->
+<div id="redditMarkRepliedModal" class="modal" style="display:none;">
+    <div class="modal-content" style="max-width:560px; height:auto; max-height:80vh;">
+        <div class="modal-header">
+            <h3>Mark replied</h3>
+            <button class="modal-close" onclick="closeModal('redditMarkRepliedModal')">&times;</button>
+        </div>
+        <div class="modal-body">
+            <p class="text-muted" style="font-size:13px;">After posting your reply on Reddit, paste the comment permalink here so we can track whether it survives auto-removal.</p>
+            <div class="form-group">
+                <label for="redditReplyPermalink">Reddit comment permalink</label>
+                <input type="url" id="redditReplyPermalink" placeholder="https://www.reddit.com/r/.../comments/.../slug/abc123/" required>
+                <p class="form-help">Right-click the timestamp on your comment in Reddit and copy the link.</p>
+            </div>
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" id="redditMentionedProduct" checked>
+                    Mentioned Argo Books in this reply (counts toward post limit)
+                </label>
+            </div>
+            <div id="redditOverrideSection" style="display:none;">
+                <div class="reddit-limit-warning">
+                    <strong>You're at or above your post limit.</strong>
+                    <div id="redditOverrideMsg" style="margin-top:4px;"></div>
+                </div>
+                <label class="checkbox-label">
+                    <input type="checkbox" id="redditOverrideLimit">
+                    I understand — post anyway (significantly increases shadowban risk)
+                </label>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-neutral" onclick="closeModal('redditMarkRepliedModal')">Cancel</button>
+            <button class="btn btn-blue" onclick="confirmMarkRedditReplied()" id="redditConfirmMarkRepliedBtn">Confirm</button>
+        </div>
+    </div>
+</div>
+
+<!-- Shopify Rejection Reasons Modal -->
+<div id="shopifyRejectStatsModal" class="modal" style="display:none;">
+    <div class="modal-content modal-large" style="height:auto; max-height:80vh;">
+        <div class="modal-header">
+            <h3>Why Shopify candidates get rejected (last 30 days)</h3>
+            <button class="modal-close" onclick="closeModal('shopifyRejectStatsModal')">&times;</button>
+        </div>
+        <div class="modal-body">
+            <?php if ($shopifyTotal30d === 0): ?>
+                <p class="text-muted" style="margin:8px 0; font-size:13px;">No Shopify candidates evaluated in the last 30 days.</p>
+            <?php else: ?>
+                <p class="text-muted" style="margin:0 0 12px; font-size:13px;">
+                    Of <?= (int) $shopifyTotal30d ?> candidates evaluated, <?= (int) $shopifyImported30d ?> were imported as leads and <?= (int) $shopifyRejectedTotal ?> were rejected. Use this breakdown to tune the dork pool or evaluator thresholds.
+                </p>
+                <div class="discovery-table-wrapper">
+                    <table class="data-table discovery-table">
+                        <thead>
+                            <tr>
+                                <th>Reject reason</th>
+                                <th style="width:90px; text-align:right;">Count</th>
+                                <th style="width:90px; text-align:right;">% of rejects</th>
+                                <th>Sample detail</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($shopifyRejectStats as $row): ?>
+                                <?php
+                                    $cnt = (int) $row['cnt'];
+                                    $pct = $shopifyRejectedTotal > 0 ? round($cnt / $shopifyRejectedTotal * 100) : 0;
+                                ?>
+                                <tr>
+                                    <td><code><?= htmlspecialchars((string) $row['reject_reason']) ?></code></td>
+                                    <td style="text-align:right;"><?= $cnt ?></td>
+                                    <td style="text-align:right;"><?= $pct ?>%</td>
+                                    <td class="text-muted" style="font-size:12px;"><?= htmlspecialchars((string) ($row['sample'] ?? '')) ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-blue" onclick="closeModal('shopifyRejectStatsModal')">Close</button>
         </div>
     </div>
 </div>

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -1606,3 +1606,509 @@ async function importAllShopifyFits() {
 // Load Shopify status on page load so the usage display is populated
 document.addEventListener('DOMContentLoaded', loadShopifyStatus);
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Reddit outreach
+// ═══════════════════════════════════════════════════════════════════════════
+
+let redditCurrentThread = null; // {id, ...} when the detail modal is open
+
+// ─── Init ───
+document.addEventListener('DOMContentLoaded', function () {
+    // Channel-tab switching (Email | Reddit)
+    document.querySelectorAll('.channel-tab[data-channel]').forEach(btn => {
+        btn.addEventListener('click', function () {
+            const channel = btn.dataset.channel;
+            switchChannel(channel);
+        });
+    });
+
+    // Update safety meter bar colors from data-attributes set server-side
+    updateRedditSafetyMeterColors();
+
+    // If Reddit channel is active on initial load, kick off thread + stats loads
+    if (document.querySelector('.channel-pane[data-channel-pane="reddit"].active')) {
+        loadRedditThreads();
+        loadRedditStats();
+        startRedditProgressPolling();
+    }
+});
+
+function switchChannel(channel) {
+    document.querySelectorAll('.channel-tab').forEach(b => {
+        b.classList.toggle('active', b.dataset.channel === channel);
+    });
+    document.querySelectorAll('.channel-pane').forEach(p => {
+        p.classList.toggle('active', p.dataset.channelPane === channel);
+    });
+
+    // Sync URL
+    try {
+        const url = new URL(window.location.href);
+        url.searchParams.set('channel', channel);
+        if (channel === 'email' && url.searchParams.get('tab') && url.searchParams.get('tab').startsWith('reddit-')) {
+            url.searchParams.set('tab', 'leads');
+        }
+        if (channel === 'reddit' && !['reddit-threads', 'reddit-settings'].includes(url.searchParams.get('tab') || '')) {
+            url.searchParams.set('tab', 'reddit-threads');
+        }
+        history.replaceState({}, '', url.toString());
+    } catch (e) { /* ignore */ }
+
+    // Re-activate the right sub-tab inside the newly-shown channel pane
+    const targetPane = document.querySelector(`.channel-pane[data-channel-pane="${channel}"]`);
+    if (targetPane) {
+        const urlTab = new URLSearchParams(window.location.search).get('tab') || '';
+        const explicit = urlTab ? targetPane.querySelector(`.section-tab[data-tab="${urlTab}"]`) : null;
+        const fallback = targetPane.querySelector('.section-tab.active') || targetPane.querySelector('.section-tab');
+        const sectionTab = explicit || fallback;
+        if (sectionTab && !sectionTab.classList.contains('active')) sectionTab.click();
+    }
+
+    if (channel === 'reddit') {
+        loadRedditThreads();
+        loadRedditStats();
+        startRedditProgressPolling();
+    }
+}
+
+// ─── Safety meter color ───
+
+function updateRedditSafetyMeterColors() {
+    ['redditDailyFill', 'redditWeeklyFill'].forEach(id => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const used = parseInt(el.dataset.used || '0', 10);
+        const limit = parseInt(el.dataset.limit || '0', 10);
+        const pct = limit > 0 ? (used / limit) * 100 : 0;
+        el.style.width = Math.min(100, pct) + '%';
+        el.classList.remove('safety-green', 'safety-yellow', 'safety-red');
+        if (pct >= 100) el.classList.add('safety-red');
+        else if (pct >= 75) el.classList.add('safety-yellow');
+        else el.classList.add('safety-green');
+    });
+}
+
+// ─── Threads list ───
+
+async function loadRedditThreads() {
+    const tbody = document.getElementById('redditThreadsTableBody');
+    if (!tbody) return;
+    tbody.innerHTML = '<tr><td colspan="8" class="empty-state">Loading…</td></tr>';
+
+    const status = document.getElementById('redditFilterStatus')?.value || 'actionable';
+    const subreddit = document.getElementById('redditFilterSubreddit')?.value || '';
+    const source = document.getElementById('redditFilterSource')?.value || '';
+    const days = document.getElementById('redditFilterDays')?.value || '30';
+
+    const data = await api('reddit_get_threads', { params: { status, subreddit, source, days } });
+    if (!data || !data.success) {
+        tbody.innerHTML = '<tr><td colspan="8" class="empty-state">Failed to load threads.</td></tr>';
+        return;
+    }
+
+    if (!data.threads || data.threads.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No threads match this filter.</td></tr>';
+        return;
+    }
+
+    tbody.innerHTML = data.threads.map(t => renderRedditThreadRow(t)).join('');
+}
+
+function renderRedditThreadRow(t) {
+    const ai = t.ai_relevance === null ? '<span class="text-muted">—</span>' : `<span class="reddit-ai-score reddit-ai-${aiBucket(t.ai_relevance)}">${t.ai_relevance}/10</span>`;
+    const statusBadge = redditStatusBadge(t.status);
+    const replyBadge = t.reply_status ? redditReplyStatusBadge(t.reply_status) : '<span class="text-muted">—</span>';
+    const upvotes = t.reply_upvotes !== null && t.reply_upvotes !== undefined ? t.reply_upvotes : '—';
+    const discovered = t.discovered_at ? new Date(t.discovered_at.replace(' ', 'T')).toLocaleString() : '';
+    const title = (t.title || '').length > 100 ? t.title.slice(0, 100) + '…' : (t.title || '');
+
+    return `<tr onclick="openRedditThreadDetail(${t.id})">
+        <td>r/${escapeHtml(t.subreddit)}</td>
+        <td class="reddit-title-cell">${escapeHtml(title)}</td>
+        <td>${ai}</td>
+        <td>${statusBadge}</td>
+        <td>${replyBadge}</td>
+        <td>${upvotes}</td>
+        <td class="text-muted" style="font-size:12px;">${escapeHtml(discovered)}</td>
+        <td class="row-actions" onclick="event.stopPropagation();">
+            <a href="${escapeAttr(t.url)}" target="_blank" rel="noopener noreferrer" class="btn btn-small btn-neutral">View</a>
+        </td>
+    </tr>`;
+}
+
+function aiBucket(n) {
+    if (n >= 8) return 'high';
+    if (n >= 6) return 'mid';
+    return 'low';
+}
+
+function redditStatusBadge(s) {
+    const map = {
+        drafted: ['badge-green', 'Drafted'],
+        drafted_pending: ['badge-yellow', 'Drafted-pending'],
+        replied: ['badge-blue', 'Replied'],
+        skipped: ['badge-gray', 'Skipped'],
+        not_fit: ['badge-gray', 'Not fit'],
+        expired: ['badge-gray', 'Expired'],
+        new: ['badge-yellow', 'New'],
+    };
+    const [cls, label] = map[s] || ['badge-gray', s];
+    return `<span class="badge ${cls}">${escapeHtml(label)}</span>`;
+}
+
+function redditReplyStatusBadge(s) {
+    const map = {
+        pending: ['badge-yellow', 'Checking…'],
+        live: ['badge-green', 'Live'],
+        removed: ['badge-red', 'Removed'],
+        removed_or_shadowbanned: ['badge-red', 'Removed/Shadow'],
+        deleted_by_user: ['badge-gray', 'You deleted'],
+    };
+    const [cls, label] = map[s] || ['badge-gray', s];
+    return `<span class="badge ${cls}">${escapeHtml(label)}</span>`;
+}
+
+// ─── Stats ───
+
+async function loadRedditStats() {
+    const data = await api('reddit_get_stats');
+    if (!data || !data.success) return;
+    const s = data.stats;
+
+    setText('redditStatTotal', s.total);
+    setText('redditStatDrafted', s.drafted);
+    setText('redditStatPending', s.drafted_pending);
+    setText('redditStatReplied7d', s.replied_7d);
+    setText('redditStatSurvival', s.survival_pct === null ? '—' : `${s.survival_pct}% (n=${s.survival_n})`);
+    setText('redditStatAvgUpvotes', s.avg_upvotes === null ? '—' : s.avg_upvotes);
+    setText('redditStatProfileClicks', s.profile_clicks_30d);
+
+    // Safety meter
+    const dailyFill = document.getElementById('redditDailyFill');
+    const weeklyFill = document.getElementById('redditWeeklyFill');
+    if (dailyFill) {
+        dailyFill.dataset.used = s.daily_used;
+        dailyFill.dataset.limit = s.daily_limit;
+    }
+    if (weeklyFill) {
+        weeklyFill.dataset.used = s.weekly_used;
+        weeklyFill.dataset.limit = s.weekly_limit;
+    }
+    setText('redditDailyUsed', s.daily_used);
+    setText('redditDailyLimit', s.daily_limit);
+    setText('redditWeeklyUsed', s.weekly_used);
+    setText('redditWeeklyLimit', s.weekly_limit);
+    updateRedditSafetyMeterColors();
+}
+
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el && value !== undefined && value !== null) el.textContent = String(value);
+}
+
+// ─── Pipeline status ───
+
+let redditProgressPollTimer = null;
+let redditDiscoveryWasRunning = false;
+
+async function loadRedditPipelineStatus() {
+    // Kept for backwards compat — delegates to the progress poller which has
+    // strictly more info.
+    return loadRedditPipelineProgress();
+}
+
+async function loadRedditPipelineProgress() {
+    const data = await api('reddit_pipeline_progress');
+    if (!data || !data.success) return;
+
+    const banner = document.getElementById('redditPipelineBanner');
+    const btn = document.getElementById('redditRunNowBtn');
+    const progress = data.progress || {};
+    const running = !!data.running;
+
+    if (banner) {
+        if (running) {
+            const msg = progress.message || 'Reddit discovery running…';
+            const found = progress.found ?? 0;
+            const drafted = progress.drafted ?? 0;
+            const startedAt = progress.started_at ? new Date(progress.started_at.replace(' ', 'T')) : null;
+            const elapsed = startedAt ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 1000)) : null;
+            const elapsedStr = elapsed === null ? '' : ` · ${elapsed}s elapsed`;
+            const counts = (found || drafted)
+                ? `<span class="reddit-progress-counts">${found} found · ${drafted} drafted${elapsedStr}</span>`
+                : `<span class="reddit-progress-counts">${elapsedStr.replace(/^ · /, '')}</span>`;
+            banner.innerHTML = `<span class="bulk-draft-spinner"></span> <span class="reddit-progress-msg">${escapeHtml(msg)}</span> ${counts}`;
+            banner.style.display = 'flex';
+        } else if (progress.completed && redditDiscoveryWasRunning) {
+            // Just finished — show the summary briefly, then refresh and hide.
+            const msg = progress.error
+                ? `Discovery failed: ${progress.error}`
+                : (progress.message || `Discovery complete. Found ${progress.found ?? 0}, drafted ${progress.drafted ?? 0}.`);
+            banner.innerHTML = `<span class="reddit-progress-msg">${escapeHtml(msg)}</span>`;
+            banner.style.display = 'flex';
+            banner.classList.add(progress.error ? 'banner-error' : 'banner-success');
+            setTimeout(() => {
+                banner.style.display = 'none';
+                banner.classList.remove('banner-success', 'banner-error');
+            }, 6000);
+        } else {
+            banner.style.display = 'none';
+        }
+    }
+
+    if (btn) btn.disabled = running;
+
+    // Stop polling and refresh data when the run ends
+    if (!running && redditProgressPollTimer) {
+        clearInterval(redditProgressPollTimer);
+        redditProgressPollTimer = null;
+        if (redditDiscoveryWasRunning) {
+            loadRedditThreads();
+            loadRedditStats();
+        }
+    }
+    redditDiscoveryWasRunning = running;
+}
+
+function startRedditProgressPolling() {
+    if (redditProgressPollTimer) return;
+    loadRedditPipelineProgress(); // immediate first poll
+    redditProgressPollTimer = setInterval(loadRedditPipelineProgress, 2000);
+}
+
+async function runRedditDiscoveryNow() {
+    if (!confirm('Trigger the Reddit discovery cron now? It will run in the background and pull fresh threads.')) return;
+    const data = await api('reddit_run_now', { method: 'POST' });
+    if (!data || !data.success) {
+        notify(data?.message || 'Failed to start cron');
+        return;
+    }
+    startRedditProgressPolling();
+}
+
+// ─── Thread detail modal ───
+
+async function openRedditThreadDetail(id) {
+    const data = await api('reddit_get_thread', { params: { id } });
+    if (!data || !data.success) {
+        notify(data?.message || 'Failed to load thread');
+        return;
+    }
+    redditCurrentThread = data.thread;
+    fillRedditThreadModal(data.thread);
+    showModal('redditThreadModal');
+}
+
+function fillRedditThreadModal(t) {
+    document.getElementById('redditThreadTitle').textContent = t.title || '(no title)';
+    document.getElementById('redditThreadSubreddit').textContent = 'r/' + (t.subreddit || '');
+    document.getElementById('redditThreadAi').textContent = t.ai_relevance === null ? '—' : `${t.ai_relevance}/10`;
+    document.getElementById('redditThreadStatus').textContent = t.status || '';
+    document.getElementById('redditThreadPosted').textContent = t.posted_at || '';
+    document.getElementById('redditThreadUrl').href = t.url || '#';
+    document.getElementById('redditThreadBody').textContent = t.body || '(link post — no self-text)';
+    document.getElementById('redditThreadReason').textContent = t.ai_relevance_reason || '(no AI reasoning recorded)';
+    document.getElementById('redditDraftBody').value = t.draft_body || '';
+
+    // Show "Generate draft" only for drafted_pending
+    document.getElementById('redditDraftGenerateBtn').style.display = t.status === 'drafted_pending' ? '' : 'none';
+
+    // Reply status section
+    const replySection = document.getElementById('redditReplyStatusSection');
+    const replyBody = document.getElementById('redditReplyStatusBody');
+    if (t.status === 'replied') {
+        replySection.style.display = '';
+        const upvotes = (t.reply_upvotes !== null && t.reply_upvotes !== undefined) ? t.reply_upvotes : '—';
+        const replies = (t.reply_replies_count !== null && t.reply_replies_count !== undefined) ? t.reply_replies_count : '—';
+        replyBody.innerHTML =
+            `Reply status: ${redditReplyStatusBadge(t.reply_status || 'pending')} · ` +
+            `Upvotes: ${upvotes} · Replies: ${replies} · ` +
+            `<a href="${escapeAttr(t.reply_permalink || '#')}" target="_blank" rel="noopener noreferrer">Open your reply ↗</a>`;
+    } else {
+        replySection.style.display = 'none';
+    }
+}
+
+async function saveRedditDraft() {
+    if (!redditCurrentThread) return;
+    const body = document.getElementById('redditDraftBody').value.trim();
+    if (!body) { notify('Draft cannot be empty'); return; }
+    const data = await api('reddit_save_draft', { method: 'POST', body: { id: redditCurrentThread.id, draft_body: body } });
+    if (!data || !data.success) { notify(data?.message || 'Save failed'); return; }
+}
+
+function openRedditRegenerateFeedback() {
+    if (!redditCurrentThread) return;
+    const panel = document.getElementById('redditRegenerateFeedback');
+    const ta = document.getElementById('redditRegenerateFeedbackText');
+    if (!panel || !ta) return;
+    ta.value = '';
+    panel.style.display = 'block';
+    ta.focus();
+}
+
+function cancelRedditRegenerate() {
+    const panel = document.getElementById('redditRegenerateFeedback');
+    if (panel) panel.style.display = 'none';
+}
+
+async function submitRedditRegenerate(btn) {
+    if (!redditCurrentThread) return;
+    const feedback = (document.getElementById('redditRegenerateFeedbackText')?.value || '').trim();
+    if (btn) { btn.disabled = true; btn.textContent = 'Regenerating…'; }
+    const data = await api('reddit_regenerate_draft', {
+        method: 'POST',
+        body: { id: redditCurrentThread.id, feedback },
+    });
+    if (btn) { btn.disabled = false; btn.textContent = 'Regenerate'; }
+    if (!data || !data.success) { notify(data?.message || 'Regeneration failed'); return; }
+    document.getElementById('redditDraftBody').value = data.draft_body;
+    cancelRedditRegenerate();
+}
+
+async function generatePendingRedditDraft() {
+    if (!redditCurrentThread) return;
+    const btn = document.getElementById('redditDraftGenerateBtn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Generating…'; }
+    const data = await api('reddit_generate_pending_draft', { method: 'POST', body: { id: redditCurrentThread.id } });
+    if (btn) { btn.disabled = false; btn.textContent = 'Generate draft'; }
+    if (!data || !data.success) { notify(data?.message || 'Generation failed'); return; }
+    document.getElementById('redditDraftBody').value = data.draft_body;
+    btn.style.display = 'none';
+    loadRedditThreads();
+}
+
+function copyRedditDraft(btn) {
+    const body = document.getElementById('redditDraftBody').value;
+    if (!body) return;
+
+    const copied = () => {
+        const original = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(() => btn.textContent = original, 1000);
+    };
+
+    navigator.clipboard.writeText(body).then(copied).catch(() => {
+        // Fallback for browsers without clipboard API (or insecure contexts)
+        const ta = document.createElement('textarea');
+        ta.value = body;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        copied();
+    });
+}
+
+async function markRedditNotFit() {
+    if (!redditCurrentThread) return;
+    if (!confirm('Mark this thread as not a fit? It will be hidden from the actionable queue.')) return;
+    const data = await api('reddit_mark_not_fit', { method: 'POST', body: { id: redditCurrentThread.id } });
+    if (!data || !data.success) { notify('Failed'); return; }
+    closeModal('redditThreadModal');
+    loadRedditThreads();
+    loadRedditStats();
+}
+
+async function markRedditSkipped() {
+    if (!redditCurrentThread) return;
+    const data = await api('reddit_mark_skipped', { method: 'POST', body: { id: redditCurrentThread.id } });
+    if (!data || !data.success) { notify('Failed'); return; }
+    closeModal('redditThreadModal');
+    loadRedditThreads();
+    loadRedditStats();
+}
+
+// ─── Mark Replied flow ───
+
+function openMarkRedditRepliedModal() {
+    if (!redditCurrentThread) return;
+    document.getElementById('redditReplyPermalink').value = '';
+    document.getElementById('redditMentionedProduct').checked = true;
+    document.getElementById('redditOverrideLimit').checked = false;
+    document.getElementById('redditOverrideSection').style.display = 'none';
+    showModal('redditMarkRepliedModal');
+}
+
+async function confirmMarkRedditReplied() {
+    if (!redditCurrentThread) return;
+    const permalink = document.getElementById('redditReplyPermalink').value.trim();
+    const mentioned = document.getElementById('redditMentionedProduct').checked ? 1 : 0;
+    const override = document.getElementById('redditOverrideLimit').checked ? 1 : 0;
+
+    if (!permalink) { notify('Permalink is required'); return; }
+    if (!/^https?:\/\/(www\.|old\.|new\.)?reddit\.com\/r\/[^\/]+\/comments\/[a-z0-9]+\/[^\/]*\/[a-z0-9]+\/?/i.test(permalink)) {
+        notify('That doesn\'t look like a Reddit comment permalink');
+        return;
+    }
+
+    const btn = document.getElementById('redditConfirmMarkRepliedBtn');
+    btn.disabled = true;
+
+    const data = await api('reddit_mark_replied', {
+        method: 'POST',
+        body: { id: redditCurrentThread.id, permalink, mentioned_product: mentioned, override_limit: override }
+    });
+    btn.disabled = false;
+
+    if (!data || !data.success) {
+        if (data && data.requires_override) {
+            document.getElementById('redditOverrideSection').style.display = '';
+            document.getElementById('redditOverrideMsg').textContent =
+                `Daily: ${data.daily_used}/${data.daily_limit} · Weekly: ${data.weekly_used}/${data.weekly_limit}`;
+            return;
+        }
+        notify(data?.message || 'Failed to mark replied');
+        return;
+    }
+
+    closeModal('redditMarkRepliedModal');
+    closeModal('redditThreadModal');
+    loadRedditThreads();
+    loadRedditStats();
+}
+
+// ─── Settings tab: account info ───
+
+async function loadRedditAccountInfo() {
+    const container = document.getElementById('redditAccountInfo');
+    if (!container) return;
+    container.innerHTML = '<span class="text-muted">Loading…</span>';
+
+    let data;
+    try {
+        data = await api('reddit_get_account_info');
+    } catch (e) {
+        // api() throws on non-200 (e.g. 500 when REDDIT_USERNAME isn't configured).
+        // Show the error inline instead of leaving the spinner stuck.
+        container.innerHTML = `<span class="text-muted" style="color:#c00;">${escapeHtml(e.message || 'Failed to load account info')}</span>`;
+        return;
+    }
+    if (!data || !data.success) {
+        container.innerHTML = `<span class="text-muted" style="color:#c00;">${escapeHtml(data?.message || 'Failed to load account info')}</span>`;
+        return;
+    }
+    const a = data.account;
+    const ageDays = a.account_age_days;
+    const ageStr = ageDays !== null && ageDays !== undefined ? `${ageDays} days old` : 'age unknown';
+    let suggestion = '';
+    if (ageDays !== null && ageDays !== undefined && a.total_karma !== null) {
+        if (ageDays < 30 || a.total_karma < 100) {
+            suggestion = 'Suggested limits at your account maturity: 2/day, 8/week (new/low-karma).';
+        } else {
+            suggestion = 'Suggested limits at your account maturity: 5/day, 15/week (established).';
+        }
+    }
+    container.innerHTML = `
+        <div><strong>u/${escapeHtml(a.username)}</strong> · ${escapeHtml(ageStr)} · karma: ${a.total_karma} (link ${a.link_karma}, comment ${a.comment_karma})</div>
+        ${suggestion ? `<div class="text-muted" style="margin-top:6px;">${escapeHtml(suggestion)}</div>` : ''}
+    `;
+}
+
+// ─── HTML escape helpers (used by Reddit row rendering) ───
+
+function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+function escapeAttr(s) { return escapeHtml(s); }
+

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -1266,3 +1266,501 @@
     border-color: #f87171;
     background: var(--gray-800);
 }
+
+/* ─── Channel tabs (Email | Reddit) ───────────────────────────────────── */
+
+.channel-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+    border-bottom: 2px solid var(--gray-200);
+}
+
+.channel-tab {
+    background: transparent;
+    border: none;
+    padding: 10px 20px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--gray-500);
+    cursor: pointer;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.channel-tab:hover { color: var(--gray-700); }
+
+.channel-tab.active {
+    color: var(--blue-700);
+    border-bottom-color: var(--blue-700);
+}
+
+.channel-pane { display: none; }
+.channel-pane.active { display: block; }
+
+[data-theme="dark"] .channel-tabs { border-bottom-color: var(--gray-700); }
+[data-theme="dark"] .channel-tab { color: var(--gray-400); }
+[data-theme="dark"] .channel-tab:hover { color: var(--gray-200); }
+[data-theme="dark"] .channel-tab.active { color: var(--blue-400, #60a5fa); border-bottom-color: var(--blue-400, #60a5fa); }
+
+/* ─── Generic color badges (used by Reddit + future channels) ─────────── */
+
+.badge-green { background: var(--green-100); color: var(--green-700); }
+.badge-red { background: var(--red-100); color: var(--red-700); }
+.badge-yellow { background: var(--amber-100); color: var(--amber-700); }
+.badge-blue { background: var(--blue-100); color: var(--blue-700); }
+.badge-gray { background: var(--gray-100); color: var(--gray-700); }
+
+[data-theme="dark"] .badge-green { background: rgba(34,197,94,0.18); color: #86efac; }
+[data-theme="dark"] .badge-red { background: rgba(239,68,68,0.18); color: #fca5a5; }
+[data-theme="dark"] .badge-yellow { background: rgba(245,158,11,0.18); color: #fcd34d; }
+[data-theme="dark"] .badge-blue { background: rgba(59,130,246,0.18); color: #93c5fd; }
+[data-theme="dark"] .badge-gray { background: var(--gray-700); color: var(--gray-200); }
+
+/* ─── Reddit progress banner ──────────────────────────────────────────── */
+
+.reddit-progress-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--blue-50, #eff6ff);
+    color: var(--gray-800);
+    border: 1px solid var(--blue-200, #bfdbfe);
+    border-left: 4px solid var(--primary-blue, #3b82f6);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    font-size: 14px;
+}
+
+.reddit-progress-banner .reddit-progress-msg {
+    flex: 1;
+    font-weight: 500;
+}
+
+.reddit-progress-banner .reddit-progress-counts {
+    color: var(--gray-500);
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.reddit-progress-banner.banner-success {
+    background: var(--green-100);
+    color: var(--green-700);
+    border-color: #86efac;
+    border-left-color: #16a34a;
+}
+
+.reddit-progress-banner.banner-error {
+    background: var(--red-100);
+    color: var(--red-700);
+    border-color: #fca5a5;
+    border-left-color: #dc2626;
+}
+
+[data-theme="dark"] .reddit-progress-banner {
+    background: var(--navy-1e3a5f, #1e3a5f);
+    color: var(--gray-100);
+    border-color: var(--gray-700);
+}
+
+[data-theme="dark"] .reddit-progress-banner .reddit-progress-counts {
+    color: var(--gray-400);
+}
+
+[data-theme="dark"] .reddit-progress-banner.banner-success {
+    background: rgba(34,197,94,0.15);
+    color: #86efac;
+}
+
+[data-theme="dark"] .reddit-progress-banner.banner-error {
+    background: rgba(239,68,68,0.15);
+    color: #fca5a5;
+}
+
+/* ─── Reddit dark-mode text legibility ───────────────────────────────────
+   The shared .text-muted and .form-help classes default to gray-400/500
+   which sits at low contrast on the dark theme's near-black backgrounds.
+   Scope a brighter color override to anything inside the Reddit channel
+   pane and the Reddit modals so help text stays readable. */
+
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .text-muted,
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .form-help,
+[data-theme="dark"] #redditThreadModal .text-muted,
+[data-theme="dark"] #redditThreadModal .form-help,
+[data-theme="dark"] #redditMarkRepliedModal .text-muted,
+[data-theme="dark"] #redditMarkRepliedModal .form-help {
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .safety-meter-label,
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .stat-label {
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .stat-value,
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .safety-meter-value {
+    color: var(--gray-100);
+}
+
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .reddit-thread-section h4 {
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] #redditThreadModal .reddit-thread-section h4 {
+    color: var(--gray-300);
+}
+
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .reddit-diagnostics {
+    color: var(--gray-100);
+}
+
+/* ─── Reddit safety meter ─────────────────────────────────────────────── */
+
+.reddit-safety-meter {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+}
+
+.safety-meter-row {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+}
+
+.safety-meter-cell {
+    flex: 1;
+    min-width: 0;
+}
+
+.safety-meter-label {
+    font-size: 12px;
+    color: var(--gray-600);
+    margin-bottom: 4px;
+}
+
+.safety-meter-value {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.safety-meter-divider {
+    color: var(--gray-400);
+    margin: 0 4px;
+}
+
+.safety-meter-bar {
+    height: 8px;
+    background: var(--gray-100);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.safety-meter-fill {
+    height: 100%;
+    width: 0%;
+    transition: width 0.3s, background-color 0.2s;
+}
+
+.safety-meter-fill.safety-green { background: #16a34a; }
+.safety-meter-fill.safety-yellow { background: #eab308; }
+.safety-meter-fill.safety-red { background: #dc2626; }
+
+.safety-meter-help {
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    background: var(--gray-100);
+    color: var(--gray-600);
+    text-align: center;
+    line-height: 22px;
+    font-size: 13px;
+    cursor: help;
+    flex-shrink: 0;
+}
+
+[data-theme="dark"] .reddit-safety-meter { background: var(--gray-800); border-color: var(--gray-700); }
+[data-theme="dark"] .safety-meter-bar { background: var(--gray-700); }
+[data-theme="dark"] .safety-meter-help { background: var(--gray-700); color: var(--gray-300); }
+
+/* ─── Reddit threads table ────────────────────────────────────────────── */
+
+.reddit-table-wrapper {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    overflow-x: auto;
+    margin-top: 12px;
+}
+
+.reddit-table tr { cursor: pointer; }
+.reddit-table tr:hover { background: var(--gray-50, #f9fafb); }
+
+.reddit-title-cell {
+    max-width: 480px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.reddit-ai-score {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.reddit-ai-high { background: var(--green-100); color: var(--green-700); }
+.reddit-ai-mid { background: var(--amber-100); color: var(--amber-700); }
+.reddit-ai-low { background: var(--gray-100); color: var(--gray-600); }
+
+[data-theme="dark"] .reddit-table-wrapper { background: var(--gray-800); border-color: var(--gray-700); }
+[data-theme="dark"] .reddit-table tr:hover { background: var(--gray-700); }
+[data-theme="dark"] .reddit-ai-high { background: rgba(34,197,94,0.18); color: #86efac; }
+[data-theme="dark"] .reddit-ai-mid { background: rgba(245,158,11,0.18); color: #fcd34d; }
+[data-theme="dark"] .reddit-ai-low { background: var(--gray-700); color: var(--gray-300); }
+
+/* ─── Reddit thread detail modal ──────────────────────────────────────── */
+
+.reddit-thread-modal-body { padding: 16px 20px; }
+
+.reddit-thread-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--gray-200);
+    font-size: 13px;
+}
+
+.reddit-thread-meta a { color: var(--blue-700); text-decoration: none; }
+.reddit-thread-meta a:hover { text-decoration: underline; }
+
+.reddit-thread-section { margin-bottom: 16px; }
+.reddit-thread-section h4 { margin: 0 0 6px; font-size: 13px; color: var(--gray-600); font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
+
+.reddit-thread-body {
+    background: var(--gray-50, #f9fafb);
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 13px;
+    white-space: pre-wrap;
+    max-height: 200px;
+    overflow-y: auto;
+    margin: 0;
+}
+
+#redditDraftBody {
+    width: 100%;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 14px;
+    padding: 10px 12px;
+    border: 1px solid var(--gray-300);
+    border-radius: 6px;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+.reddit-draft-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.reddit-regenerate-feedback {
+    margin-top: 12px;
+    padding: 12px;
+    background: var(--gray-50, #f9fafb);
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+}
+
+.reddit-regenerate-feedback label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--gray-700);
+}
+
+.reddit-regenerate-feedback textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--gray-300);
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 13px;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+.reddit-regenerate-feedback-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+}
+
+[data-theme="dark"] .reddit-regenerate-feedback {
+    background: var(--gray-900, #111827);
+    border-color: var(--gray-700);
+}
+
+[data-theme="dark"] .reddit-regenerate-feedback label {
+    color: var(--gray-200);
+}
+
+[data-theme="dark"] .reddit-regenerate-feedback textarea {
+    background: var(--gray-800);
+    border-color: var(--gray-700);
+    color: var(--gray-100);
+}
+
+[data-theme="dark"] .reddit-thread-meta { border-bottom-color: var(--gray-700); }
+[data-theme="dark"] .reddit-thread-meta a { color: var(--blue-400); }
+[data-theme="dark"] .channel-pane[data-channel-pane="reddit"] a:not(.btn):not(.channel-tab):not(.section-tab),
+[data-theme="dark"] #redditThreadModal a:not(.btn),
+[data-theme="dark"] #redditMarkRepliedModal a:not(.btn) { color: var(--blue-400); }
+[data-theme="dark"] .reddit-thread-body { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-200); }
+[data-theme="dark"] #redditDraftBody { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-200); }
+
+/* ─── Mark Replied modal limit warning ────────────────────────────────── */
+
+.reddit-limit-warning {
+    background: var(--red-100);
+    color: var(--red-700);
+    border-left: 4px solid var(--red-500, #ef4444);
+    padding: 10px 12px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    font-size: 13px;
+}
+
+[data-theme="dark"] .reddit-limit-warning { background: rgba(239,68,68,0.15); color: #fca5a5; }
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.checkbox-label input[type="checkbox"] { margin: 0; }
+
+/* ─── Reddit settings tab ─────────────────────────────────────────────── */
+
+.reddit-settings-panel {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    margin-bottom: 16px;
+    overflow: hidden;
+}
+
+.reddit-settings-panel .panel-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--gray-200);
+    background: var(--gray-50, #f9fafb);
+}
+
+.reddit-settings-panel .panel-header h2 {
+    margin: 0;
+    font-size: 15px;
+}
+
+.reddit-settings-panel .panel-content {
+    padding: 16px;
+}
+
+.reddit-add-form {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.reddit-add-form input[type="text"] {
+    flex: 1;
+    min-width: 160px;
+    padding: 6px 10px;
+    border: 1px solid var(--gray-300);
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.reddit-config-table th, .reddit-config-table td {
+    font-size: 13px;
+}
+
+.row-actions form { margin-right: 4px; }
+
+.reddit-tuning-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.form-help {
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: var(--gray-500);
+}
+
+.reddit-diagnostics {
+    font-size: 14px;
+}
+
+.reddit-diagnostics > div { margin-bottom: 4px; }
+
+.reddit-diagnostics-error {
+    margin-top: 8px;
+    padding: 8px 10px;
+    background: var(--red-100);
+    color: var(--red-700);
+    border-radius: 4px;
+}
+
+.reddit-account-info {
+    font-size: 14px;
+}
+
+[data-theme="dark"] .reddit-settings-panel { background: var(--gray-800); border-color: var(--gray-700); }
+[data-theme="dark"] .reddit-settings-panel .panel-header { background: var(--gray-900, #111827); border-bottom-color: var(--gray-700); }
+[data-theme="dark"] .reddit-add-form input[type="text"] { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-100); }
+[data-theme="dark"] .reddit-diagnostics-error { background: rgba(239,68,68,0.15); color: #fca5a5; }
+
+/* ─── Flash messages (for reddit-settings POST-back) ──────────────────── */
+
+.flash-message {
+    padding: 10px 14px;
+    border-radius: 6px;
+    margin-bottom: 16px;
+    font-size: 14px;
+}
+
+.flash-success {
+    background: var(--green-100);
+    color: var(--green-700);
+    border-left: 4px solid #16a34a;
+}
+
+.flash-error {
+    background: var(--red-100);
+    color: var(--red-700);
+    border-left: 4px solid #dc2626;
+}
+
+[data-theme="dark"] .flash-success { background: rgba(34,197,94,0.18); color: #86efac; }
+[data-theme="dark"] .flash-error { background: rgba(239,68,68,0.18); color: #fca5a5; }

--- a/admin/outreach/tabs/reddit-settings.php
+++ b/admin/outreach/tabs/reddit-settings.php
@@ -1,0 +1,468 @@
+<?php
+/**
+ * Reddit Settings sub-tab.
+ *
+ * - Watchlist subreddits CRUD (add/enable/disable/delete)
+ * - Keywords CRUD
+ * - Numeric tuning fields (scoring floors, post limits, auto-disable)
+ * - Reddit account info card (account age, karma)
+ * - Diagnostics card (last run timestamps, error)
+ *
+ * Exposes:
+ *   reddit_settings_tab_handle_post($pdo)
+ *   reddit_settings_tab_render($pdo)
+ */
+
+function reddit_settings_tab_handle_post($pdo)
+{
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'reddit_add_subreddit') {
+        $name = preg_replace('/[^A-Za-z0-9_]/', '', (string) ($_POST['name'] ?? ''));
+        if ($name === '') {
+            $_SESSION['message'] = 'Subreddit name is required.';
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+        }
+        $notes = mb_substr((string) ($_POST['notes'] ?? ''), 0, 255);
+        try {
+            $stmt = $pdo->prepare("INSERT INTO reddit_subreddits (name, enabled, notes) VALUES (?, 1, ?)
+                ON DUPLICATE KEY UPDATE enabled = 1, notes = VALUES(notes)");
+            $stmt->execute([$name, $notes]);
+            $_SESSION['message'] = "Added r/$name to the watchlist.";
+            $_SESSION['message_type'] = 'success';
+        } catch (PDOException $e) {
+            $_SESSION['message'] = 'Could not add subreddit: ' . $e->getMessage();
+            $_SESSION['message_type'] = 'error';
+        }
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_toggle_subreddit') {
+        $id = (int) ($_POST['id'] ?? 0);
+        $stmt = $pdo->prepare("UPDATE reddit_subreddits SET enabled = 1 - enabled WHERE id = ?");
+        $stmt->execute([$id]);
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_reenable_subreddit') {
+        $id = (int) ($_POST['id'] ?? 0);
+        $stmt = $pdo->prepare("UPDATE reddit_subreddits SET enabled = 1, auto_disabled_at = NULL, auto_disabled_reason = NULL WHERE id = ?");
+        $stmt->execute([$id]);
+        $_SESSION['message'] = 'Subreddit re-enabled.';
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_delete_subreddit') {
+        $id = (int) ($_POST['id'] ?? 0);
+        $stmt = $pdo->prepare("DELETE FROM reddit_subreddits WHERE id = ?");
+        $stmt->execute([$id]);
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_add_keyword') {
+        $kw = trim((string) ($_POST['keyword'] ?? ''));
+        if ($kw === '' || mb_strlen($kw) > 120) {
+            $_SESSION['message'] = 'Keyword is required and must be ≤ 120 chars.';
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+        }
+        $notes = mb_substr((string) ($_POST['notes'] ?? ''), 0, 255);
+        try {
+            $stmt = $pdo->prepare("INSERT INTO reddit_keywords (keyword, enabled, notes) VALUES (?, 1, ?)
+                ON DUPLICATE KEY UPDATE enabled = 1, notes = VALUES(notes)");
+            $stmt->execute([$kw, $notes]);
+            $_SESSION['message'] = "Added keyword: $kw";
+            $_SESSION['message_type'] = 'success';
+        } catch (PDOException $e) {
+            $_SESSION['message'] = 'Could not add keyword: ' . $e->getMessage();
+            $_SESSION['message_type'] = 'error';
+        }
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_toggle_keyword') {
+        $id = (int) ($_POST['id'] ?? 0);
+        $stmt = $pdo->prepare("UPDATE reddit_keywords SET enabled = 1 - enabled WHERE id = ?");
+        $stmt->execute([$id]);
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_delete_keyword') {
+        $id = (int) ($_POST['id'] ?? 0);
+        $stmt = $pdo->prepare("DELETE FROM reddit_keywords WHERE id = ?");
+        $stmt->execute([$id]);
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+
+    if ($action === 'reddit_update_tuning') {
+        $rulesFloor = max(0, min(100, (int) ($_POST['rules_score_floor'] ?? 30)));
+        $aiFloor = max(0, min(10, (int) ($_POST['ai_relevance_floor'] ?? 6)));
+        $dailyLimit = max(0, min(50, (int) ($_POST['daily_post_limit'] ?? 3)));
+        $weeklyLimit = max(0, min(200, (int) ($_POST['weekly_post_limit'] ?? 12)));
+        $autoDisableRate = max(0, min(100, (int) ($_POST['auto_disable_removal_rate'] ?? 60)));
+        $autoDisableMin = max(1, min(50, (int) ($_POST['auto_disable_min_replies'] ?? 3)));
+
+        reddit_settings_tab_ensure_singleton($pdo);
+        $stmt = $pdo->prepare("UPDATE reddit_settings SET
+            rules_score_floor = ?,
+            ai_relevance_floor = ?,
+            daily_post_limit = ?,
+            weekly_post_limit = ?,
+            auto_disable_removal_rate = ?,
+            auto_disable_min_replies = ?
+            WHERE id = 1");
+        $stmt->execute([$rulesFloor, $aiFloor, $dailyLimit, $weeklyLimit, $autoDisableRate, $autoDisableMin]);
+        $_SESSION['message'] = 'Tuning saved.';
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?channel=reddit&tab=reddit-settings'); exit;
+    }
+}
+
+function reddit_settings_tab_render($pdo)
+{
+    reddit_settings_tab_ensure_singleton($pdo);
+
+    $subreddits = reddit_settings_tab_fetch_subreddits($pdo);
+    $keywords = reddit_settings_tab_fetch_keywords($pdo);
+    $settings = reddit_settings_tab_fetch_settings($pdo);
+    $diagnostics = reddit_settings_tab_fetch_diagnostics($pdo);
+
+    $csrfToken = $_SESSION['csrf_token'] ?? '';
+    ?>
+
+    <?php if (!empty($_SESSION['message'])): ?>
+        <div class="flash-message flash-<?= htmlspecialchars($_SESSION['message_type'] ?? 'info') ?>">
+            <?= htmlspecialchars($_SESSION['message']) ?>
+        </div>
+        <?php unset($_SESSION['message'], $_SESSION['message_type']); ?>
+    <?php endif; ?>
+
+    <!-- Reddit account info card (loaded on demand) -->
+    <div class="panel reddit-settings-panel">
+        <div class="panel-header">
+            <h2>Reddit account</h2>
+        </div>
+        <div class="panel-content">
+            <div id="redditAccountInfo" class="reddit-account-info">
+                <button class="btn btn-small btn-blue" onclick="loadRedditAccountInfo()">Check account status</button>
+                <span class="text-muted" style="margin-left:8px; font-size:13px;">
+                    Pulls account age + karma from Reddit. Use to decide whether to raise the daily post limit.
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Diagnostics card -->
+    <div class="panel reddit-settings-panel">
+        <div class="panel-header">
+            <h2>Diagnostics</h2>
+        </div>
+        <div class="panel-content">
+            <div class="reddit-diagnostics">
+                <div><strong>Last discovery run:</strong> <?= htmlspecialchars($diagnostics['last_run_at'] ?? 'never') ?></div>
+                <div><strong>Threads found:</strong> <?= (int) ($diagnostics['last_run_threads_found'] ?? 0) ?></div>
+                <div><strong>Threads drafted:</strong> <?= (int) ($diagnostics['last_run_threads_drafted'] ?? 0) ?></div>
+                <div><strong>Last status check:</strong> <?= htmlspecialchars($diagnostics['last_status_check_at'] ?? 'never') ?></div>
+                <?php if (!empty($diagnostics['last_run_error'])): ?>
+                    <div class="reddit-diagnostics-error">
+                        <strong>Last error:</strong> <?= htmlspecialchars($diagnostics['last_run_error']) ?>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tuning fields -->
+    <div class="panel reddit-settings-panel">
+        <div class="panel-header">
+            <h2>Tuning</h2>
+        </div>
+        <div class="panel-content">
+            <form method="post" action="index.php?channel=reddit&tab=reddit-settings">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                <input type="hidden" name="tab" value="reddit-settings">
+                <input type="hidden" name="action" value="reddit_update_tuning">
+
+                <div class="reddit-tuning-grid">
+                    <div class="form-group">
+                        <label for="rulesScoreFloor">Rules score floor (0–100)</label>
+                        <input type="number" id="rulesScoreFloor" name="rules_score_floor"
+                               value="<?= (int) $settings['rules_score_floor'] ?>" min="0" max="100">
+                        <p class="form-help">Threads scoring below this are auto-skipped without an AI call. Default 30.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="aiRelevanceFloor">AI relevance floor (0–10)</label>
+                        <input type="number" id="aiRelevanceFloor" name="ai_relevance_floor"
+                               value="<?= (int) $settings['ai_relevance_floor'] ?>" min="0" max="10">
+                        <p class="form-help">Threads scoring below this don't advance to draft generation. Default 6.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="dailyPostLimit">Daily post limit</label>
+                        <input type="number" id="dailyPostLimit" name="daily_post_limit"
+                               value="<?= (int) $settings['daily_post_limit'] ?>" min="0" max="50">
+                        <p class="form-help">Max product-mentioning replies per rolling 24h. Default 3.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="weeklyPostLimit">Weekly post limit</label>
+                        <input type="number" id="weeklyPostLimit" name="weekly_post_limit"
+                               value="<?= (int) $settings['weekly_post_limit'] ?>" min="0" max="200">
+                        <p class="form-help">Max product-mentioning replies per rolling 7d. Default 12.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="autoDisableRemovalRate">Auto-disable removal rate (%)</label>
+                        <input type="number" id="autoDisableRemovalRate" name="auto_disable_removal_rate"
+                               value="<?= (int) $settings['auto_disable_removal_rate'] ?>" min="0" max="100">
+                        <p class="form-help">If a subreddit's 30-day removal rate is ≥ this, auto-disable it. Default 60.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="autoDisableMinReplies">Auto-disable min replies</label>
+                        <input type="number" id="autoDisableMinReplies" name="auto_disable_min_replies"
+                               value="<?= (int) $settings['auto_disable_min_replies'] ?>" min="1" max="50">
+                        <p class="form-help">Minimum replies in last 30d before the auto-disable rule kicks in. Default 3.</p>
+                    </div>
+                </div>
+
+                <div style="margin-top:12px;">
+                    <button type="submit" class="btn btn-blue">Save tuning</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Subreddit watchlist -->
+    <div class="panel reddit-settings-panel">
+        <div class="panel-header">
+            <h2>Watchlist subreddits</h2>
+        </div>
+        <div class="panel-content">
+            <form method="post" action="index.php?channel=reddit&tab=reddit-settings" class="reddit-add-form">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                <input type="hidden" name="tab" value="reddit-settings">
+                <input type="hidden" name="action" value="reddit_add_subreddit">
+                <input type="text" name="name" placeholder="subreddit name (no r/)" required pattern="[A-Za-z0-9_]+" maxlength="64">
+                <input type="text" name="notes" placeholder="notes (optional)" maxlength="255">
+                <button type="submit" class="btn btn-small btn-blue">Add</button>
+            </form>
+
+            <table class="data-table reddit-config-table">
+                <thead>
+                    <tr>
+                        <th>Subreddit</th>
+                        <th>Enabled</th>
+                        <th>Replies 30d</th>
+                        <th>Removal rate 30d</th>
+                        <th>Notes</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($subreddits)): ?>
+                        <tr><td colspan="6" class="empty-state">No subreddits configured. Add one above.</td></tr>
+                    <?php else: ?>
+                        <?php foreach ($subreddits as $row): ?>
+                            <tr>
+                                <td>r/<?= htmlspecialchars($row['name']) ?></td>
+                                <td>
+                                    <?php if (!empty($row['auto_disabled_at'])): ?>
+                                        <span class="badge badge-red">Auto-disabled</span>
+                                    <?php elseif ((int) $row['enabled'] === 1): ?>
+                                        <span class="badge badge-green">Yes</span>
+                                    <?php else: ?>
+                                        <span class="badge badge-gray">No</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?= (int) ($row['replies_30d'] ?? 0) ?></td>
+                                <td>
+                                    <?php
+                                    $rate = (float) ($row['removal_rate_30d'] ?? 0);
+                                    $rateClass = $rate >= 60 ? 'badge-red' : ($rate >= 30 ? 'badge-yellow' : 'badge-green');
+                                    if (((int) ($row['replies_30d'] ?? 0)) === 0) {
+                                        echo '<span class="text-muted">—</span>';
+                                    } else {
+                                        echo '<span class="badge ' . $rateClass . '">' . number_format($rate, 1) . '%</span>';
+                                    }
+                                    ?>
+                                </td>
+                                <td><?= htmlspecialchars((string) ($row['notes'] ?? '')) ?></td>
+                                <td class="row-actions">
+                                    <?php if (!empty($row['auto_disabled_at'])): ?>
+                                        <form method="post" action="index.php?channel=reddit&tab=reddit-settings" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                            <input type="hidden" name="tab" value="reddit-settings">
+                                            <input type="hidden" name="action" value="reddit_reenable_subreddit">
+                                            <input type="hidden" name="id" value="<?= (int) $row['id'] ?>">
+                                            <button type="submit" class="btn btn-small btn-blue">Re-enable</button>
+                                        </form>
+                                    <?php else: ?>
+                                        <form method="post" action="index.php?channel=reddit&tab=reddit-settings" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                            <input type="hidden" name="tab" value="reddit-settings">
+                                            <input type="hidden" name="action" value="reddit_toggle_subreddit">
+                                            <input type="hidden" name="id" value="<?= (int) $row['id'] ?>">
+                                            <button type="submit" class="btn btn-small btn-neutral">
+                                                <?= (int) $row['enabled'] === 1 ? 'Disable' : 'Enable' ?>
+                                            </button>
+                                        </form>
+                                    <?php endif; ?>
+                                    <form method="post" action="index.php?channel=reddit&tab=reddit-settings" style="display:inline;"
+                                          onsubmit="return confirm('Delete r/<?= htmlspecialchars($row['name']) ?>?');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="tab" value="reddit-settings">
+                                        <input type="hidden" name="action" value="reddit_delete_subreddit">
+                                        <input type="hidden" name="id" value="<?= (int) $row['id'] ?>">
+                                        <button type="submit" class="btn btn-small btn-red">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Keywords -->
+    <div class="panel reddit-settings-panel">
+        <div class="panel-header">
+            <h2>Search keywords</h2>
+        </div>
+        <div class="panel-content">
+            <form method="post" action="index.php?channel=reddit&tab=reddit-settings" class="reddit-add-form">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                <input type="hidden" name="tab" value="reddit-settings">
+                <input type="hidden" name="action" value="reddit_add_keyword">
+                <input type="text" name="keyword" placeholder='keyword or phrase (use quotes for exact)' required maxlength="120">
+                <input type="text" name="notes" placeholder="notes (optional)" maxlength="255">
+                <button type="submit" class="btn btn-small btn-blue">Add</button>
+            </form>
+
+            <table class="data-table reddit-config-table">
+                <thead>
+                    <tr>
+                        <th>Keyword</th>
+                        <th>Enabled</th>
+                        <th>Notes</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($keywords)): ?>
+                        <tr><td colspan="4" class="empty-state">No keywords configured. Add one above.</td></tr>
+                    <?php else: ?>
+                        <?php foreach ($keywords as $row): ?>
+                            <tr>
+                                <td><code><?= htmlspecialchars($row['keyword']) ?></code></td>
+                                <td>
+                                    <?php if ((int) $row['enabled'] === 1): ?>
+                                        <span class="badge badge-green">Yes</span>
+                                    <?php else: ?>
+                                        <span class="badge badge-gray">No</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?= htmlspecialchars((string) ($row['notes'] ?? '')) ?></td>
+                                <td class="row-actions">
+                                    <form method="post" action="index.php?channel=reddit&tab=reddit-settings" style="display:inline;">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="tab" value="reddit-settings">
+                                        <input type="hidden" name="action" value="reddit_toggle_keyword">
+                                        <input type="hidden" name="id" value="<?= (int) $row['id'] ?>">
+                                        <button type="submit" class="btn btn-small btn-neutral">
+                                            <?= (int) $row['enabled'] === 1 ? 'Disable' : 'Enable' ?>
+                                        </button>
+                                    </form>
+                                    <form method="post" action="index.php?channel=reddit&tab=reddit-settings" style="display:inline;"
+                                          onsubmit="return confirm('Delete keyword?');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                                        <input type="hidden" name="tab" value="reddit-settings">
+                                        <input type="hidden" name="action" value="reddit_delete_keyword">
+                                        <input type="hidden" name="id" value="<?= (int) $row['id'] ?>">
+                                        <button type="submit" class="btn btn-small btn-red">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <?php
+}
+
+/**
+ * Insert the singleton settings row if missing. Defaults are spec-aligned.
+ * Tolerates missing table on a fresh install (silent — Phase 1 schema must be run).
+ */
+function reddit_settings_tab_ensure_singleton($pdo): void
+{
+    try {
+        $stmt = $pdo->prepare("INSERT IGNORE INTO reddit_settings
+            (id, rules_score_floor, ai_relevance_floor, daily_post_limit, weekly_post_limit,
+             auto_disable_removal_rate, auto_disable_min_replies)
+            VALUES (1, 30, 6, 3, 12, 60, 3)");
+        $stmt->execute();
+    } catch (PDOException $e) {
+        // Table not created yet; render code will fall back to defaults.
+    }
+}
+
+function reddit_settings_tab_fetch_subreddits($pdo): array
+{
+    try {
+        $stmt = $pdo->prepare("SELECT id, name, enabled, notes, replies_30d, removal_rate_30d, auto_disabled_at, auto_disabled_reason
+                               FROM reddit_subreddits ORDER BY enabled DESC, name ASC");
+        $stmt->execute();
+        return $stmt->fetchAll();
+    } catch (PDOException $e) {
+        return [];
+    }
+}
+
+function reddit_settings_tab_fetch_keywords($pdo): array
+{
+    try {
+        $stmt = $pdo->prepare("SELECT id, keyword, enabled, notes FROM reddit_keywords ORDER BY enabled DESC, keyword ASC");
+        $stmt->execute();
+        return $stmt->fetchAll();
+    } catch (PDOException $e) {
+        return [];
+    }
+}
+
+function reddit_settings_tab_fetch_settings($pdo): array
+{
+    $defaults = [
+        'rules_score_floor' => 30,
+        'ai_relevance_floor' => 6,
+        'daily_post_limit' => 3,
+        'weekly_post_limit' => 12,
+        'auto_disable_removal_rate' => 60,
+        'auto_disable_min_replies' => 3,
+    ];
+    try {
+        $stmt = $pdo->prepare("SELECT rules_score_floor, ai_relevance_floor, daily_post_limit, weekly_post_limit,
+                                      auto_disable_removal_rate, auto_disable_min_replies
+                               FROM reddit_settings WHERE id = 1");
+        $stmt->execute();
+        $row = $stmt->fetch();
+        return $row ? array_merge($defaults, $row) : $defaults;
+    } catch (PDOException $e) {
+        return $defaults;
+    }
+}
+
+function reddit_settings_tab_fetch_diagnostics($pdo): array
+{
+    try {
+        $stmt = $pdo->prepare("SELECT last_run_at, last_run_threads_found, last_run_threads_drafted,
+                                      last_run_error, last_status_check_at
+                               FROM reddit_settings WHERE id = 1");
+        $stmt->execute();
+        return $stmt->fetch() ?: [];
+    } catch (PDOException $e) {
+        return [];
+    }
+}

--- a/admin/outreach/tabs/reddit-threads.php
+++ b/admin/outreach/tabs/reddit-threads.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Reddit Threads sub-tab.
+ *
+ * Renders the discovery queue: stats row, safety meter (daily/weekly post
+ * limits), filters, and a paginated table populated via api.php Reddit
+ * endpoints. Default filter is status IN (drafted, drafted_pending) sorted
+ * by ai_relevance DESC so the actionable queue is front and center.
+ *
+ * Exposes:
+ *   reddit_threads_tab_render($pdo)
+ */
+
+function reddit_threads_tab_render($pdo)
+{
+    // Resolve a few server-side bits we want available at page load. Heavy
+    // data (the threads list) loads via JS from api.php.
+    $limits = reddit_threads_tab_get_post_limits($pdo);
+    $dailyUsed = reddit_threads_tab_count_recent_mentions($pdo, '1 DAY');
+    $weeklyUsed = reddit_threads_tab_count_recent_mentions($pdo, '7 DAY');
+    ?>
+
+    <!-- Pipeline-running / progress banner (live-updated by outreach.js) -->
+    <div id="redditPipelineBanner" class="reddit-progress-banner" style="display:none;"></div>
+
+    <!-- Safety meter -->
+    <div class="reddit-safety-meter" id="redditSafetyMeter">
+        <div class="safety-meter-row">
+            <div class="safety-meter-cell">
+                <div class="safety-meter-label">Today (product mentions)</div>
+                <div class="safety-meter-value">
+                    <span id="redditDailyUsed"><?= (int) $dailyUsed ?></span>
+                    <span class="safety-meter-divider">/</span>
+                    <span id="redditDailyLimit"><?= (int) $limits['daily'] ?></span>
+                </div>
+                <div class="safety-meter-bar">
+                    <div class="safety-meter-fill" id="redditDailyFill" data-used="<?= (int) $dailyUsed ?>" data-limit="<?= (int) $limits['daily'] ?>"></div>
+                </div>
+            </div>
+            <div class="safety-meter-cell">
+                <div class="safety-meter-label">This week (product mentions)</div>
+                <div class="safety-meter-value">
+                    <span id="redditWeeklyUsed"><?= (int) $weeklyUsed ?></span>
+                    <span class="safety-meter-divider">/</span>
+                    <span id="redditWeeklyLimit"><?= (int) $limits['weekly'] ?></span>
+                </div>
+                <div class="safety-meter-bar">
+                    <div class="safety-meter-fill" id="redditWeeklyFill" data-used="<?= (int) $weeklyUsed ?>" data-limit="<?= (int) $limits['weekly'] ?>"></div>
+                </div>
+            </div>
+            <div class="safety-meter-help" title="Heuristic limits to reduce shadowban risk. Counts only replies where you marked 'Mentioned Argo Books'. Tune in Settings as the account ages.">?</div>
+        </div>
+    </div>
+
+    <!-- Secondary stats row -->
+    <div class="stats-row" id="redditStatsRow">
+        <div class="stat-card">
+            <div class="stat-label">Total Threads</div>
+            <div class="stat-value" id="redditStatTotal">0</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Drafted (ready)</div>
+            <div class="stat-value stat-new" id="redditStatDrafted">0</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Drafted-pending</div>
+            <div class="stat-value stat-pending" id="redditStatPending">0</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Replied (7d)</div>
+            <div class="stat-value" id="redditStatReplied7d">0</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Reply Survival</div>
+            <div class="stat-value" id="redditStatSurvival">—</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Avg Upvotes / Reply</div>
+            <div class="stat-value" id="redditStatAvgUpvotes">—</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Profile-Link Clicks (30d)</div>
+            <div class="stat-value" id="redditStatProfileClicks">0</div>
+        </div>
+    </div>
+
+    <!-- Filters + Run Now -->
+    <div class="filters-bar">
+        <div class="filters-container">
+            <div class="filters-row">
+                <div class="filter-group">
+                    <label for="redditFilterStatus">Status</label>
+                    <select id="redditFilterStatus" onchange="loadRedditThreads()">
+                        <option value="actionable">Actionable (drafted)</option>
+                        <option value="all">All</option>
+                        <option value="drafted">Drafted</option>
+                        <option value="drafted_pending">Drafted-pending</option>
+                        <option value="replied">Replied</option>
+                        <option value="reply_removed">Reply Removed</option>
+                        <option value="skipped">Skipped</option>
+                        <option value="not_fit">Not Fit</option>
+                        <option value="expired">Expired</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="redditFilterSubreddit">Subreddit</label>
+                    <select id="redditFilterSubreddit" onchange="loadRedditThreads()">
+                        <option value="">All</option>
+                        <?php foreach (reddit_threads_tab_list_subreddits($pdo) as $sub): ?>
+                            <option value="<?= htmlspecialchars($sub) ?>">r/<?= htmlspecialchars($sub) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="redditFilterSource">Discovery</label>
+                    <select id="redditFilterSource" onchange="loadRedditThreads()">
+                        <option value="">Any</option>
+                        <option value="watchlist">Watchlist</option>
+                        <option value="keyword">Keyword</option>
+                        <option value="both">Both</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="redditFilterDays">Discovered</label>
+                    <select id="redditFilterDays" onchange="loadRedditThreads()">
+                        <option value="7">Last 7 days</option>
+                        <option value="14">Last 14 days</option>
+                        <option value="30" selected>Last 30 days</option>
+                        <option value="0">All time</option>
+                    </select>
+                </div>
+                <div class="filter-group form-group-btn">
+                    <button class="btn btn-blue" onclick="runRedditDiscoveryNow()" id="redditRunNowBtn">Run discovery now</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Threads table -->
+    <div class="reddit-table-wrapper">
+        <table class="data-table reddit-table">
+            <thead>
+                <tr>
+                    <th>Subreddit</th>
+                    <th>Title</th>
+                    <th>AI</th>
+                    <th>Status</th>
+                    <th>Reply</th>
+                    <th>Upvotes</th>
+                    <th>Discovered</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody id="redditThreadsTableBody">
+                <tr><td colspan="8" class="empty-state">Loading…</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <?php
+}
+
+/**
+ * Read post-limit settings from `reddit_settings`. Falls back to spec defaults
+ * if the row hasn't been created yet (fresh install before Phase 2 schema ran).
+ */
+function reddit_threads_tab_get_post_limits($pdo): array
+{
+    $defaults = ['daily' => 3, 'weekly' => 12];
+    try {
+        $stmt = $pdo->prepare("SELECT daily_post_limit, weekly_post_limit FROM reddit_settings WHERE id = 1");
+        $stmt->execute();
+        $row = $stmt->fetch();
+        if (!$row) return $defaults;
+        return [
+            'daily' => (int) ($row['daily_post_limit'] ?? $defaults['daily']),
+            'weekly' => (int) ($row['weekly_post_limit'] ?? $defaults['weekly']),
+        ];
+    } catch (PDOException $e) {
+        return $defaults;
+    }
+}
+
+/**
+ * Count product-mentioning replies posted in the given rolling window
+ * (e.g. '1 DAY', '7 DAY'). Used to render the safety meter.
+ */
+function reddit_threads_tab_count_recent_mentions($pdo, string $interval): int
+{
+    try {
+        $sql = "SELECT COUNT(*) FROM reddit_threads
+                WHERE status = 'replied'
+                  AND mentioned_product = 1
+                  AND reply_posted_at > DATE_SUB(NOW(), INTERVAL $interval)";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute();
+        return (int) $stmt->fetchColumn();
+    } catch (PDOException $e) {
+        return 0;
+    }
+}
+
+/**
+ * Distinct subreddits seen in the threads table, for the filter dropdown.
+ */
+function reddit_threads_tab_list_subreddits($pdo): array
+{
+    try {
+        $stmt = $pdo->prepare("SELECT DISTINCT subreddit FROM reddit_threads ORDER BY subreddit ASC");
+        $stmt->execute();
+        return array_map(fn($r) => $r['subreddit'], $stmt->fetchAll());
+    } catch (PDOException $e) {
+        return [];
+    }
+}

--- a/admin/referral-links/index.php
+++ b/admin/referral-links/index.php
@@ -407,6 +407,54 @@ function get_funnel_per_source(?string $period_start, string $environment): arra
 }
 
 /**
+ * Top landing pages by distinct-visitor count, for the All-traffic funnel
+ * breakdown. Trailing query/hash strings are stripped server-side via a
+ * SUBSTRING_INDEX so `/?ref=foo` and `/` collapse into the same bucket.
+ */
+function get_landing_page_breakdown(?string $period_start, string $environment): array
+{
+    global $pdo;
+
+    $where = ['environment = ?', "event_type = 'landing'"];
+    $params = [$environment];
+    if ($period_start !== null) {
+        $where[] = 'created_at >= ?';
+        $params[] = $period_start;
+    }
+    $where_sql = implode(' AND ', $where);
+
+    $sql = "
+        SELECT
+            SUBSTRING_INDEX(SUBSTRING_INDEX(page_url, '?', 1), '#', 1) AS clean_path,
+            COUNT(DISTINCT visitor_id) AS visitors
+        FROM referral_events
+        WHERE $where_sql
+        GROUP BY clean_path
+        ORDER BY visitors DESC";
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    return $stmt->fetchAll();
+}
+
+/**
+ * Map a request path to a human-readable label for the landing-pages chart.
+ * Anything we don't recognise falls back to the raw path.
+ */
+function friendly_landing_label(?string $path): string
+{
+    $p = strtolower(trim((string)$path));
+    if ($p === '' || $p === '/' || $p === '/index.php') return 'Home';
+    if ($p === '/downloads/' || $p === '/downloads') return 'Downloads page';
+
+    // /compare/argo-books-vs-<competitor>/  →  "<Competitor> comparison"
+    if (preg_match('#^/compare/argo-books-vs-([a-z0-9-]+)/?$#', $p, $m)) {
+        return ucfirst($m[1]) . ' comparison';
+    }
+    return $path;
+}
+
+/**
  * All ad-spend rows for the Spend tab, sorted newest period first.
  */
 function get_campaign_spend_rows(): array
@@ -663,6 +711,32 @@ include __DIR__ . '/../admin_header.php';
         $funnel_counts = get_funnel_stage_counts($funnel_period_start_dt, $funnel_source_filter ?: null);
         $per_source = get_funnel_per_source($funnel_period_start_dt, current_environment());
 
+        // Landing-page breakdown: only meaningful for "All traffic" since a
+        // specific tracked source usually points at a single destination page.
+        $landing_breakdown = [];
+        $landing_chart_labels = [];
+        $landing_chart_counts = [];
+        if ($funnel_source_filter === '') {
+            $rows = get_landing_page_breakdown($funnel_period_start_dt, current_environment());
+            // Cap at top 7; collapse the long tail into "Other" so the pie stays readable.
+            $top = array_slice($rows, 0, 7);
+            $rest = array_slice($rows, 7);
+            $other_total = array_sum(array_map(fn($r) => (int)$r['visitors'], $rest));
+            foreach ($top as $r) {
+                $landing_breakdown[] = [
+                    'label'    => friendly_landing_label($r['clean_path']),
+                    'visitors' => (int)$r['visitors'],
+                ];
+            }
+            if ($other_total > 0) {
+                $landing_breakdown[] = ['label' => 'Other', 'visitors' => $other_total];
+            }
+            foreach ($landing_breakdown as $r) {
+                $landing_chart_labels[] = $r['label'];
+                $landing_chart_counts[] = $r['visitors'];
+            }
+        }
+
         // Compute aggregate totals + CAC/LTV for the hero cards
         $total_spend = 0.0;
         $total_revenue = 0.0;
@@ -846,6 +920,29 @@ include __DIR__ . '/../admin_header.php';
                 <?php endif; ?>
             <?php endforeach; ?>
         </div>
+
+        <?php if (!empty($landing_breakdown)): ?>
+            <div class="landing-breakdown">
+                <h3>Where landings come from</h3>
+                <div class="landing-breakdown-body">
+                    <div class="landing-breakdown-chart">
+                        <canvas id="landingPagesChart"></canvas>
+                    </div>
+                    <ul class="landing-breakdown-list">
+                        <?php $total_landings = array_sum($landing_chart_counts); ?>
+                        <?php foreach ($landing_breakdown as $i => $row):
+                            $pct = $total_landings > 0 ? round(($row['visitors'] / $total_landings) * 100, 1) : 0;
+                        ?>
+                            <li>
+                                <span class="swatch" data-swatch-idx="<?php echo $i; ?>"></span>
+                                <span class="lbl"><?php echo htmlspecialchars($row['label']); ?></span>
+                                <span class="pct"><?php echo $pct; ?>%</span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            </div>
+        <?php endif; ?>
     </div>
 
     <!-- Comparison table -->
@@ -1477,6 +1574,62 @@ include __DIR__ . '/../admin_header.php';
             sessionStorage.setItem('scrollPosition', window.scrollY);
         });
     });
+
+    // Landing-page breakdown doughnut (only rendered on All-traffic funnel).
+    (function () {
+        const canvas = document.getElementById('landingPagesChart');
+        if (!canvas || typeof Chart === 'undefined') return;
+
+        const labels = <?php echo json_encode($landing_chart_labels, JSON_UNESCAPED_SLASHES); ?>;
+        const counts = <?php echo json_encode($landing_chart_counts); ?>;
+        if (!labels.length) return;
+
+        // Reuse the palette other admin charts use so themes stay consistent.
+        const palette = [
+            'rgba(59, 130, 246, 0.85)',   // blue
+            'rgba(139, 92, 246, 0.85)',   // purple
+            'rgba(16, 185, 129, 0.85)',   // emerald
+            'rgba(245, 158, 11, 0.85)',   // amber
+            'rgba(239, 68, 68, 0.85)',    // red
+            'rgba(14, 165, 233, 0.85)',   // sky
+            'rgba(168, 85, 247, 0.85)',   // violet
+            'rgba(107, 114, 128, 0.85)',  // gray (Other)
+        ];
+        const colors = labels.map((_, i) => palette[i % palette.length]);
+
+        // Color the inline list swatches to match the chart slices.
+        document.querySelectorAll('.landing-breakdown-list .swatch').forEach(el => {
+            const idx = parseInt(el.getAttribute('data-swatch-idx'), 10);
+            if (!Number.isNaN(idx) && colors[idx]) {
+                el.style.backgroundColor = colors[idx];
+            }
+        });
+
+        new Chart(canvas, {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{ data: counts, backgroundColor: colors, borderWidth: 0 }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                cutout: '55%',
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: function (ctx) {
+                                const total = ctx.dataset.data.reduce((a, b) => a + b, 0);
+                                const pct = total > 0 ? ((ctx.parsed / total) * 100).toFixed(1) : 0;
+                                return ctx.label + ': ' + ctx.parsed + ' (' + pct + '%)';
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    })();
 </script>
 <script src="../section-tabs.js"></script>
 

--- a/admin/referral-links/index.php
+++ b/admin/referral-links/index.php
@@ -423,6 +423,8 @@ function get_landing_page_breakdown(?string $period_start, string $environment):
     }
     $where_sql = implode(' AND ', $where);
 
+    // LIMIT keeps the result small even on a large referral_events table —
+    // the caller only renders the top few in the chart anyway.
     $sql = "
         SELECT
             SUBSTRING_INDEX(SUBSTRING_INDEX(page_url, '?', 1), '#', 1) AS clean_path,
@@ -430,7 +432,8 @@ function get_landing_page_breakdown(?string $period_start, string $environment):
         FROM referral_events
         WHERE $where_sql
         GROUP BY clean_path
-        ORDER BY visitors DESC";
+        ORDER BY visitors DESC
+        LIMIT 20";
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
@@ -447,9 +450,11 @@ function friendly_landing_label(?string $path): string
     if ($p === '' || $p === '/' || $p === '/index.php') return 'Home';
     if ($p === '/downloads/' || $p === '/downloads') return 'Downloads page';
 
-    // /compare/argo-books-vs-<competitor>/  →  "<Competitor> comparison"
+    // /compare/argo-books-vs-<competitor>/  →  "<Competitor> Comparison".
+    // Convert hyphens to spaces and title-case so multi-word slugs render
+    // properly ("quickbooks-online" → "Quickbooks Online comparison").
     if (preg_match('#^/compare/argo-books-vs-([a-z0-9-]+)/?$#', $p, $m)) {
-        return ucfirst($m[1]) . ' comparison';
+        return ucwords(str_replace('-', ' ', $m[1])) . ' comparison';
     }
     return $path;
 }

--- a/admin/referral-links/style.css
+++ b/admin/referral-links/style.css
@@ -662,6 +662,78 @@ code {
     font-size: 15px;
 }
 
+/* Landing-page breakdown chart (rendered under the funnel on All traffic). */
+.landing-breakdown {
+    margin-top: 28px;
+    padding-top: 24px;
+    border-top: 1px solid var(--gray-border);
+}
+
+[data-theme="dark"] .landing-breakdown {
+    border-top-color: var(--gray-700);
+}
+
+.landing-breakdown h3 {
+    margin: 0 0 16px 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--gray-600);
+}
+
+[data-theme="dark"] .landing-breakdown h3 {
+    color: var(--gray-300);
+}
+
+.landing-breakdown-body {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 32px;
+    flex-wrap: wrap;
+}
+
+.landing-breakdown-chart {
+    position: relative;
+    width: 240px;
+    height: 240px;
+    flex: 0 0 240px;
+}
+
+.landing-breakdown-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    min-width: 240px;
+    max-width: 420px;
+}
+
+.landing-breakdown-list li {
+    display: grid;
+    grid-template-columns: 14px 1fr auto;
+    gap: 10px;
+    align-items: center;
+    padding: 6px 0;
+    font-size: 14px;
+}
+
+.landing-breakdown-list .swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    background: var(--gray-400);
+}
+
+.landing-breakdown-list .pct {
+    font-variant-numeric: tabular-nums;
+    color: var(--gray-700);
+    font-weight: 600;
+}
+
+[data-theme="dark"] .landing-breakdown-list .pct {
+    color: var(--gray-200);
+}
+
 /* Mobile responsive */
 @media (max-width: 768px) {
     .funnel-row {
@@ -673,5 +745,9 @@ code {
     }
     .funnel-count {
         text-align: left;
+    }
+    .landing-breakdown-chart {
+        width: 200px;
+        height: 200px;
     }
 }

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -35,7 +35,7 @@ const OUTREACH_CATEGORY_POOL = [
     'tanning salons', 'nail salons', 'barber shops', 'optical stores',
     'hearing aid clinics', 'home inspectors', 'appraisers',
     'property management', 'storage facilities', 'glass repair',
-    'fencing contractors', 'concrete contractors', 'paving contractors', 
+    'fencing contractors', 'concrete contractors', 'paving contractors',
     'tree services', 'snow removal', 'pool services', 'septic services',
     'garage door repair', 'security companies', 'staffing agencies',
     'travel agencies', 'event venues', 'food trucks',

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -34,10 +34,9 @@ const OUTREACH_CATEGORY_POOL = [
     'upholstery services', 'tailors', 'dry cleaners', 'spas',
     'tanning salons', 'nail salons', 'barber shops', 'optical stores',
     'hearing aid clinics', 'home inspectors', 'appraisers',
-    'property management', 'storage facilities', 'courier services',
-    'towing services', 'glass repair', 'fencing contractors',
-    'concrete contractors', 'paving contractors', 'tree services',
-    'snow removal', 'pool services', 'septic services',
+    'property management', 'storage facilities', 'glass repair',
+    'fencing contractors', 'concrete contractors', 'paving contractors', 
+    'tree services', 'snow removal', 'pool services', 'septic services',
     'garage door repair', 'security companies', 'staffing agencies',
     'travel agencies', 'event venues', 'food trucks',
 ];

--- a/cron/lib/reddit_helpers.php
+++ b/cron/lib/reddit_helpers.php
@@ -1,0 +1,898 @@
+<?php
+/**
+ * Shared helpers for the Reddit outreach channel.
+ *
+ * - OAuth client (script-app password grant, token cached in reddit_settings)
+ * - Reddit API wrappers (subreddit /new, global /search, thread comments, /api/info)
+ * - Rules-based pre-filter scoring
+ * - Neutral AI relevance check (Gemini)
+ * - Voice-doc-driven draft generation (Gemini)
+ *
+ * Used by:
+ *   cron/reddit_monitor.php       — daily discovery + draft pipeline
+ *   cron/reddit_status_check.php  — every-2h posted-reply status check
+ *   admin/outreach/api.php        — admin actions (run now, regenerate, on-demand draft)
+ *
+ * No DB writes here; callers orchestrate persistence.
+ */
+
+if (defined('REDDIT_HELPERS_LOADED')) return;
+define('REDDIT_HELPERS_LOADED', true);
+
+require_once __DIR__ . '/outreach_helpers.php'; // for call_gemini()
+require_once __DIR__ . '/reddit_voice.php';
+
+const REDDIT_USER_AGENT_PREFIX = 'argobooks-outreach/1.0 by /u/';
+const REDDIT_API_BASE_OAUTH = 'https://oauth.reddit.com';
+const REDDIT_API_BASE_PUBLIC = 'https://www.reddit.com';
+const REDDIT_TOKEN_URL = 'https://www.reddit.com/api/v1/access_token';
+const REDDIT_API_CALL_SLEEP_US = 600000; // 0.6s between calls — stay polite
+
+/**
+ * True when full OAuth credentials are configured. When false, the helpers
+ * fall back to Reddit's public JSON endpoints (no app, no auth, lower rate
+ * limits but plenty for our volume). Lets you flip to OAuth later just by
+ * filling in the REDDIT_* env vars — no code change needed.
+ */
+function reddit_oauth_configured(): bool
+{
+    return !empty($_ENV['REDDIT_CLIENT_ID'])
+        && !empty($_ENV['REDDIT_CLIENT_SECRET'])
+        && !empty($_ENV['REDDIT_USERNAME'])
+        && !empty($_ENV['REDDIT_PASSWORD']);
+}
+
+/**
+ * User-Agent string for outbound Reddit requests. Reddit asks for a
+ * descriptive UA on all traffic — we include the configured username if set,
+ * otherwise a generic suffix for unauthenticated calls.
+ */
+function reddit_user_agent(): string
+{
+    $username = $_ENV['REDDIT_USERNAME'] ?? 'anonymous';
+    return REDDIT_USER_AGENT_PREFIX . $username;
+}
+
+// ─── Logging ───
+
+function reddit_log(string $message): void
+{
+    $sanitized = preg_replace('/[\r\n]+/', ' ', $message);
+    @error_log('[reddit][' . date('Y-m-d H:i:s') . '] ' . $sanitized);
+}
+
+// ─── Live progress (file-backed) ───
+// The discovery cron writes JSON to a small progress file at each milestone.
+// The admin Threads tab polls it via api.php?action=reddit_pipeline_progress
+// so the founder sees what step the cron is on (instead of staring at a
+// "running…" banner with no detail).
+
+function reddit_progress_file_path(): string
+{
+    return __DIR__ . '/../logs/reddit_monitor_progress.json';
+}
+
+function reddit_progress_write(array $update): void
+{
+    $path = reddit_progress_file_path();
+    $dir = dirname($path);
+    if (!is_dir($dir)) @mkdir($dir, 0755, true);
+
+    $current = reddit_progress_read();
+    $merged = array_merge($current, $update, ['updated_at' => date('Y-m-d H:i:s')]);
+    @file_put_contents($path, json_encode($merged), LOCK_EX);
+}
+
+function reddit_progress_read(): array
+{
+    $path = reddit_progress_file_path();
+    if (!file_exists($path)) return [];
+    $raw = @file_get_contents($path);
+    if (!$raw) return [];
+    $data = json_decode($raw, true);
+    return is_array($data) ? $data : [];
+}
+
+function reddit_progress_reset(array $initial = []): void
+{
+    $base = [
+        'message' => '',
+        'found' => 0,
+        'drafted' => 0,
+        'started_at' => date('Y-m-d H:i:s'),
+        'completed' => false,
+    ];
+    $merged = array_merge($base, $initial, ['updated_at' => date('Y-m-d H:i:s')]);
+    @file_put_contents(reddit_progress_file_path(), json_encode($merged), LOCK_EX);
+}
+
+// ─── OAuth ───
+
+/**
+ * Returns a valid OAuth access token, refreshing if missing or expired.
+ * Token is stored encrypted via portal_encrypt() in reddit_settings.
+ * Returns null on auth failure (logs the error).
+ */
+function reddit_get_access_token($pdo): ?string
+{
+    $clientId = $_ENV['REDDIT_CLIENT_ID'] ?? '';
+    $clientSecret = $_ENV['REDDIT_CLIENT_SECRET'] ?? '';
+    $username = $_ENV['REDDIT_USERNAME'] ?? '';
+    $password = $_ENV['REDDIT_PASSWORD'] ?? '';
+
+    if ($clientId === '' || $clientSecret === '' || $username === '' || $password === '') {
+        reddit_log('Missing Reddit OAuth env vars; cannot authenticate.');
+        return null;
+    }
+
+    // Cached token?
+    $stmt = $pdo->prepare("SELECT access_token, access_token_expires_at FROM reddit_settings WHERE id = 1");
+    $stmt->execute();
+    $row = $stmt->fetch();
+
+    if ($row && !empty($row['access_token']) && !empty($row['access_token_expires_at'])
+        && strtotime($row['access_token_expires_at']) > (time() + 60)) {
+        try {
+            $decrypted = portal_decrypt($row['access_token']);
+            if ($decrypted !== '') {
+                return $decrypted;
+            }
+        } catch (Throwable $e) {
+            // Stale or corrupt cipher (e.g. encryption key rotated). Fall through to refresh.
+            reddit_log('Cached token decrypt failed; refreshing: ' . $e->getMessage());
+        }
+    }
+
+    // Refresh
+    $ch = curl_init(REDDIT_TOKEN_URL);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => http_build_query([
+            'grant_type' => 'password',
+            'username' => $username,
+            'password' => $password,
+        ]),
+        CURLOPT_HTTPHEADER => [
+            'User-Agent: ' . REDDIT_USER_AGENT_PREFIX . $username,
+        ],
+        CURLOPT_USERPWD => $clientId . ':' . $clientSecret,
+        CURLOPT_TIMEOUT => 20,
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($response === false || $httpCode !== 200) {
+        reddit_log("Token refresh failed (HTTP $httpCode): " . substr((string) $response, 0, 200));
+        return null;
+    }
+
+    $data = json_decode($response, true);
+    $token = $data['access_token'] ?? null;
+    $expiresIn = (int) ($data['expires_in'] ?? 3600);
+    if (!$token) {
+        reddit_log('Token refresh returned no access_token.');
+        return null;
+    }
+
+    $encrypted = portal_encrypt($token);
+    $expiresAt = date('Y-m-d H:i:s', time() + $expiresIn);
+    $upd = $pdo->prepare("UPDATE reddit_settings SET access_token = ?, access_token_expires_at = ? WHERE id = 1");
+    $upd->execute([$encrypted, $expiresAt]);
+
+    return $token;
+}
+
+/**
+ * GET against the Reddit API. Dispatches to OAuth when credentials are
+ * configured, otherwise falls back to Reddit's public JSON endpoints (no
+ * app, no auth required). The path is the same in both modes — the helper
+ * handles the base URL difference and the `.json` suffix for public mode.
+ *
+ * Returns decoded JSON array on success, null on failure (logs).
+ */
+function reddit_api_get($pdo, string $path, array $query = []): ?array
+{
+    if (reddit_oauth_configured()) {
+        return reddit_api_get_oauth($pdo, $path, $query);
+    }
+    return reddit_api_get_public($path, $query);
+}
+
+/**
+ * Authenticated GET via the OAuth endpoint. Sleeps REDDIT_API_CALL_SLEEP_US
+ * after each call to stay polite under any rate limit.
+ */
+function reddit_api_get_oauth($pdo, string $path, array $query = []): ?array
+{
+    $token = reddit_get_access_token($pdo);
+    if ($token === null) return null;
+
+    $url = REDDIT_API_BASE_OAUTH . $path;
+    if (!empty($query)) {
+        $url .= (strpos($url, '?') === false ? '?' : '&') . http_build_query($query);
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $token,
+            'User-Agent: ' . reddit_user_agent(),
+        ],
+        CURLOPT_TIMEOUT => 30,
+    ]);
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    usleep(REDDIT_API_CALL_SLEEP_US);
+
+    if ($response === false) {
+        reddit_log("API call failed: $path");
+        return null;
+    }
+    if ($httpCode === 401) {
+        // Token may have been revoked; clear cache so next call refreshes.
+        $upd = $pdo->prepare("UPDATE reddit_settings SET access_token = NULL, access_token_expires_at = NULL WHERE id = 1");
+        $upd->execute();
+        reddit_log("API call 401 ($path) — cleared cached token.");
+        return null;
+    }
+    if ($httpCode !== 200) {
+        reddit_log("API call HTTP $httpCode ($path): " . substr((string) $response, 0, 200));
+        return null;
+    }
+    $data = json_decode($response, true);
+    if (!is_array($data)) {
+        reddit_log("API call returned non-JSON ($path).");
+        return null;
+    }
+    return $data;
+}
+
+/**
+ * Unauthenticated GET via Reddit's public endpoints.
+ *
+ * Reddit's JSON endpoints (`.json` suffix) are aggressively IP-blocked for
+ * datacenter / shared-hosting traffic, which returns 403 even with a
+ * descriptive User-Agent. RSS / Atom endpoints (`.rss` suffix) are typically
+ * less restricted because Reddit doesn't want to break legitimate RSS readers.
+ *
+ * Strategy: discovery-shaped paths (subreddit listings, search, thread
+ * comments) try `.rss` and parse the Atom feed back into Reddit's JSON shape
+ * so downstream code doesn't care which format we got. Endpoints with no RSS
+ * equivalent (`/api/info`, `/user/X/about`) keep using `.json` and will
+ * silently 403 from blocked IPs — those features (reply-status check, account
+ * info card) require OAuth to work.
+ *
+ * Fill in the REDDIT_* OAuth env vars to upgrade automatically.
+ */
+function reddit_api_get_public(string $path, array $query = []): ?array
+{
+    if (reddit_path_supports_rss($path)) {
+        $result = reddit_api_get_public_rss($path, $query);
+        if ($result !== null) {
+            return $result;
+        }
+        // Fall through to JSON only if RSS *didn't* return a parseable feed
+        // (rare — usually it's blocked or it's parseable, no in-between).
+    }
+    return reddit_api_get_public_json($path, $query);
+}
+
+/**
+ * Endpoints that Reddit serves over RSS/Atom AND that our parser knows how
+ * to handle. Comments listings (`/r/X/comments/Y`) also have RSS but a
+ * different shape (mix of post + comments) that the current parser doesn't
+ * convert — so they fall through to JSON, which will 403 from blocked IPs.
+ * Net effect: AI relevance + draft generation runs without top-comments
+ * context, which is a soft signal loss but doesn't break the flow.
+ */
+function reddit_path_supports_rss(string $path): bool
+{
+    return (bool) preg_match('#^/r/[^/]+/new$|^/search$#', $path);
+}
+
+/**
+ * JSON-flavoured fetch (legacy path; still used by /api/info and user-about).
+ */
+function reddit_api_get_public_json(string $path, array $query = []): ?array
+{
+    if (!str_ends_with($path, '.json')) {
+        $path .= '.json';
+    }
+
+    $url = REDDIT_API_BASE_PUBLIC . $path;
+    if (!empty($query)) {
+        $url .= (strpos($url, '?') === false ? '?' : '&') . http_build_query($query);
+    }
+
+    $response = reddit_http_get($url, ['Accept: application/json']);
+    if ($response === null) return null;
+
+    $data = json_decode($response['body'], true);
+    if (!is_array($data)) {
+        reddit_log("Public JSON returned non-JSON ($path).");
+        return null;
+    }
+    return $data;
+}
+
+/**
+ * RSS-flavoured fetch — same endpoints, `.rss` suffix, parsed back into
+ * Reddit's JSON listing shape so callers don't care.
+ */
+function reddit_api_get_public_rss(string $path, array $query = []): ?array
+{
+    $rssPath = $path . '.rss';
+    $url = REDDIT_API_BASE_PUBLIC . $rssPath;
+    if (!empty($query)) {
+        $url .= (strpos($url, '?') === false ? '?' : '&') . http_build_query($query);
+    }
+
+    $response = reddit_http_get($url, ['Accept: application/atom+xml, application/rss+xml, text/xml']);
+    if ($response === null) return null;
+
+    return reddit_parse_atom_to_listing($response['body'], $rssPath);
+}
+
+/**
+ * Low-level HTTP GET against Reddit with our standard headers + rate-limit
+ * sleep. Returns ['body' => string, 'http_code' => int] on success, null on
+ * 403/429/network failure (with the failure logged so we can see it).
+ */
+function reddit_http_get(string $url, array $extraHeaders = []): ?array
+{
+    $headers = array_merge(['User-Agent: ' . reddit_user_agent()], $extraHeaders);
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS => 3,
+    ]);
+    $body = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    usleep(REDDIT_API_CALL_SLEEP_US);
+
+    if ($body === false) {
+        reddit_log("HTTP request failed: $url");
+        return null;
+    }
+    if ($httpCode === 429) {
+        reddit_log("Rate-limited (429) on $url");
+        return null;
+    }
+    if ($httpCode === 403) {
+        reddit_log("403 on $url — Reddit blocks unauthenticated traffic from this IP. Fill in REDDIT_* OAuth env vars to upgrade.");
+        return null;
+    }
+    if ($httpCode !== 200) {
+        reddit_log("HTTP $httpCode ($url): " . substr((string) $body, 0, 200));
+        return null;
+    }
+    return ['body' => $body, 'http_code' => $httpCode];
+}
+
+/**
+ * Parse a Reddit Atom feed into the same shape Reddit's JSON listing returns,
+ * so downstream code (reddit_normalize_post, score, etc.) works unchanged.
+ *
+ * Returns null on parse failure. Missing fields default sensibly:
+ *   - score and num_comments default to 0 (RSS doesn't expose these)
+ *   - is_self defaults to true (RSS doesn't distinguish; we treat as self-post
+ *     and use the HTML content as the body)
+ *   - stickied defaults to false
+ */
+function reddit_parse_atom_to_listing(string $xml, string $sourcePath): ?array
+{
+    $prev = libxml_use_internal_errors(true);
+    $feed = simplexml_load_string($xml);
+    libxml_use_internal_errors($prev);
+    if ($feed === false) {
+        reddit_log("Atom parse failed for $sourcePath");
+        return null;
+    }
+
+    $children = [];
+    foreach ($feed->entry ?? [] as $entry) {
+        // The full id is like "t3_xxxxxx"; strip the prefix for the bare id field
+        $fullId = (string) ($entry->id ?? '');
+        if (!preg_match('/t3_([a-z0-9]+)/', $fullId, $m)) continue;
+        $id = $m[1];
+
+        // <category term="smallbusiness" label="r/smallbusiness"/>
+        $subreddit = '';
+        foreach ($entry->category ?? [] as $cat) {
+            $term = (string) $cat['term'];
+            if ($term !== '') { $subreddit = $term; break; }
+        }
+
+        // <link href="https://www.reddit.com/r/.../comments/.../slug/"/>
+        $permalinkAbs = '';
+        foreach ($entry->link ?? [] as $link) {
+            $href = (string) $link['href'];
+            if ($href !== '') { $permalinkAbs = $href; break; }
+        }
+        // reddit_normalize_post expects post['permalink'] to be the relative path
+        $permalinkRel = '';
+        if (preg_match('#https?://[^/]+(/.*)$#', $permalinkAbs, $m)) {
+            $permalinkRel = $m[1];
+        }
+
+        // <author><name>/u/username</name></author>
+        $author = '';
+        if (isset($entry->author->name)) {
+            $author = ltrim((string) $entry->author->name, '/');
+            if (strpos($author, 'u/') === 0) $author = substr($author, 2);
+        }
+
+        $createdUtc = strtotime((string) ($entry->published ?? $entry->updated ?? ''));
+        if ($createdUtc === false) $createdUtc = time();
+
+        // <content type="html"> — Reddit wraps the body in HTML. Decode entities,
+        // strip tags, collapse whitespace to a reasonable plaintext body.
+        $contentHtml = (string) ($entry->content ?? '');
+        $body = trim(preg_replace('/\s+/', ' ', strip_tags(html_entity_decode($contentHtml, ENT_QUOTES | ENT_HTML5))));
+
+        $title = (string) ($entry->title ?? '');
+
+        $children[] = [
+            'kind' => 't3',
+            'data' => [
+                'id' => $id,
+                'subreddit' => $subreddit,
+                'title' => $title,
+                'selftext' => $body,
+                'permalink' => $permalinkRel,
+                'url' => $permalinkAbs,
+                'author' => $author ?: null,
+                'score' => 0,
+                'num_comments' => 0,
+                'created_utc' => $createdUtc,
+                'is_self' => true,
+                'stickied' => false,
+            ],
+        ];
+    }
+
+    return [
+        'data' => [
+            'children' => $children,
+            'after' => null,
+            'before' => null,
+        ],
+    ];
+}
+
+// ─── Discovery: fetch + normalize ───
+
+/**
+ * Fetch the latest posts from a single subreddit. Returns an array of
+ * normalized thread rows ready for scoring + insertion.
+ */
+function reddit_fetch_subreddit_new($pdo, string $subreddit, int $limit = 50, int $hoursBack = 24): array
+{
+    $data = reddit_api_get($pdo, "/r/$subreddit/new", ['limit' => $limit]);
+    if (!$data || !isset($data['data']['children'])) return [];
+
+    $cutoff = time() - ($hoursBack * 3600);
+    $out = [];
+    foreach ($data['data']['children'] as $child) {
+        $post = $child['data'] ?? [];
+        if (empty($post['id']) || empty($post['created_utc'])) continue;
+        if ((int) $post['created_utc'] < $cutoff) continue;
+        if (!empty($post['stickied'])) continue;
+        $out[] = reddit_normalize_post($post, 'watchlist');
+    }
+    return $out;
+}
+
+/**
+ * Run Reddit's global search for a keyword and return normalized threads.
+ */
+function reddit_fetch_search($pdo, string $keyword, int $limit = 50, string $timeRange = 'day'): array
+{
+    $data = reddit_api_get($pdo, '/search', [
+        'q' => $keyword,
+        't' => $timeRange,
+        'sort' => 'new',
+        'restrict_sr' => 'false',
+        'limit' => $limit,
+        'type' => 'link',
+    ]);
+    if (!$data || !isset($data['data']['children'])) return [];
+
+    $out = [];
+    foreach ($data['data']['children'] as $child) {
+        $post = $child['data'] ?? [];
+        if (empty($post['id'])) continue;
+        if (!empty($post['stickied'])) continue;
+        $normalized = reddit_normalize_post($post, 'keyword');
+        $normalized['matched_keywords'] = [$keyword];
+        $out[] = $normalized;
+    }
+    return $out;
+}
+
+/**
+ * Top-level comments on a thread, used as context for AI relevance + draft.
+ * Returns a plain array of comment bodies (strings).
+ */
+function reddit_fetch_top_comments($pdo, string $subreddit, string $postId36, int $limit = 10): array
+{
+    // The comments endpoint has no RSS parser shape and 403s from blocked
+    // IPs in unauth mode — skip the request entirely and let the AI score
+    // from title + body only. Restored automatically once OAuth is set up.
+    if (!reddit_oauth_configured()) {
+        return [];
+    }
+
+    $data = reddit_api_get($pdo, "/r/$subreddit/comments/$postId36", [
+        'limit' => $limit,
+        'depth' => 1,
+        'sort' => 'top',
+    ]);
+    if (!is_array($data) || count($data) < 2) return [];
+
+    $listing = $data[1]['data']['children'] ?? [];
+    $out = [];
+    foreach ($listing as $child) {
+        if (($child['kind'] ?? '') !== 't1') continue;
+        $body = $child['data']['body'] ?? '';
+        if ($body === '' || $body === '[deleted]' || $body === '[removed]') continue;
+        $out[] = $body;
+        if (count($out) >= $limit) break;
+    }
+    return $out;
+}
+
+/**
+ * Check a posted comment's current state via /api/info. Returns one of
+ * 'live', 'removed', 'removed_or_shadowbanned', 'deleted_by_user', or null
+ * (on API failure). Also returns upvotes and reply count if observable.
+ */
+function reddit_check_comment_status($pdo, string $commentId36): array
+{
+    $fullName = 't1_' . $commentId36;
+    $data = reddit_api_get($pdo, '/api/info', ['id' => $fullName]);
+    if ($data === null) {
+        return ['status' => null, 'upvotes' => null, 'replies' => null];
+    }
+    $children = $data['data']['children'] ?? [];
+    if (empty($children)) {
+        // API returned 200 but no comment — removed by mod or shadowbanned.
+        return ['status' => 'removed_or_shadowbanned', 'upvotes' => null, 'replies' => null];
+    }
+    $c = $children[0]['data'] ?? [];
+    $body = $c['body'] ?? '';
+    $upvotes = isset($c['ups']) ? (int) $c['ups'] : null;
+    // num_replies is not always present on comments; fall back to 0.
+    $replies = isset($c['num_replies']) ? (int) $c['num_replies'] : 0;
+
+    if ($body === '[removed]') {
+        return ['status' => 'removed', 'upvotes' => $upvotes, 'replies' => $replies];
+    }
+    if ($body === '[deleted]') {
+        return ['status' => 'deleted_by_user', 'upvotes' => $upvotes, 'replies' => $replies];
+    }
+    return ['status' => 'live', 'upvotes' => $upvotes, 'replies' => $replies];
+}
+
+/**
+ * Fetch the founder's Reddit account info (age + karma). Used by admin
+ * Settings to suggest post limits.
+ */
+function reddit_fetch_account_about($pdo): ?array
+{
+    $username = $_ENV['REDDIT_USERNAME'] ?? '';
+    if ($username === '') return null;
+    $data = reddit_api_get($pdo, "/user/$username/about");
+    if (!$data || !isset($data['data'])) return null;
+    $d = $data['data'];
+    return [
+        'username' => $username,
+        'created_utc' => (int) ($d['created_utc'] ?? 0),
+        'total_karma' => (int) ($d['total_karma'] ?? 0),
+        'link_karma' => (int) ($d['link_karma'] ?? 0),
+        'comment_karma' => (int) ($d['comment_karma'] ?? 0),
+    ];
+}
+
+/**
+ * Reshape a Reddit API post object into our DB row shape (subset; caller
+ * fills in scoring fields after).
+ */
+function reddit_normalize_post(array $post, string $defaultSource): array
+{
+    $isSelf = !empty($post['is_self']);
+    return [
+        'reddit_id' => $post['id'],
+        'subreddit' => $post['subreddit'] ?? '',
+        'title' => mb_substr((string) ($post['title'] ?? ''), 0, 500),
+        'body' => $isSelf ? (string) ($post['selftext'] ?? '') : null,
+        'url' => 'https://www.reddit.com' . ($post['permalink'] ?? ''),
+        'author' => $post['author'] ?? null,
+        'author_karma' => null, // Filled lazily if needed
+        'post_score' => (int) ($post['score'] ?? 0),
+        'comment_count' => (int) ($post['num_comments'] ?? 0),
+        'posted_at' => date('Y-m-d H:i:s', (int) ($post['created_utc'] ?? time())),
+        'discovery_source' => $defaultSource,
+        'matched_keywords' => [],
+    ];
+}
+
+// ─── Rules-based scoring ───
+
+/**
+ * Score a normalized thread 0–100. See spec for the breakdown.
+ * Watchlist-source threads get a bigger subreddit-relevance bonus than
+ * keyword-only threads. Multi-source ('both') gets a small extra boost.
+ */
+function reddit_score_thread(array $thread, array $context = []): int
+{
+    $now = time();
+    $postedAt = strtotime($thread['posted_at'] ?? 'now');
+    $hoursOld = max(0, ($now - $postedAt) / 3600);
+
+    // Recency 0-30: linear decay over 24h
+    $recency = max(0, 30 - (int) round($hoursOld * (30 / 24)));
+
+    // Comment sweet-spot 0-20
+    $n = (int) ($thread['comment_count'] ?? 0);
+    if ($n === 0) $comments = 5;
+    elseif ($n <= 20) $comments = 20;
+    elseif ($n <= 50) $comments = 10;
+    else $comments = 0;
+
+    // Subreddit relevance 0-20
+    $source = $thread['discovery_source'] ?? 'keyword';
+    if ($source === 'both') $subRel = 25;
+    elseif ($source === 'watchlist') $subRel = 20;
+    else $subRel = 5;
+
+    // Keyword match strength 0-20
+    $kwHits = is_array($thread['matched_keywords'] ?? null) ? count($thread['matched_keywords']) : 0;
+    if ($kwHits >= 2) $kwScore = 20;
+    elseif ($kwHits === 1) $kwScore = 10;
+    else $kwScore = 5;
+
+    // OP karma sanity 0-10 (defaults to 5 if unknown)
+    $karma = $thread['author_karma'] ?? null;
+    if ($karma === null) $karmaScore = 5;
+    elseif ($karma >= 50) $karmaScore = 10;
+    elseif ($karma >= 10) $karmaScore = 5;
+    else $karmaScore = 0;
+
+    $total = $recency + $comments + $subRel + $kwScore + $karmaScore;
+    return max(0, min(100, $total));
+}
+
+// ─── AI relevance (neutral framing) ───
+
+/**
+ * Ask Gemini to score software-recommendation intent on a 0–10 scale.
+ * Neutral prompt — does NOT ask "should the founder reply?" since that
+ * biases toward yes-answers. Caller decides whether to reply.
+ *
+ * Returns ['score' => int 0-10, 'reason' => string] on success,
+ * or ['score' => null, 'reason' => '<error>'] on failure.
+ */
+function reddit_ai_relevance(array $thread, array $topComments, $pdo = null): array
+{
+    $systemPrompt = <<<'SYS'
+You are evaluating a Reddit thread for software-recommendation intent. Be conservative — most threads do NOT qualify.
+
+A thread qualifies (score 7+) only if ALL of the following are true:
+- The OP is actively looking for, or open to switching, bookkeeping / accounting / invoicing software
+- The OP describes a real problem in their own words (not a generic "what do you guys use" karma-farming post)
+- The thread is not already saturated with software recommendations (look at the top comments — if 3+ commenters already recommended QuickBooks, Wave, FreshBooks, etc., the conversation is done)
+- The OP appears to be a real person running a small business, freelancing, or doing a side hustle (not a corporate procurement question or a student homework post)
+
+A thread does NOT qualify (score ≤4) if:
+- It's a question about tax filing, accounting concepts, or bookkeeping methodology (not software)
+- It's a "best of" / "favorite tool" karma post with no specific problem
+- It's a complaint thread with no openness to alternatives
+- It's about an industry too large for Argo Books (enterprise, mid-market with employees, multi-entity)
+
+Score 5–6 for borderline cases — relevant but ambiguous fit.
+
+Return JSON only: {"relevance": <0-10 integer>, "reason": "<one sentence>"}
+
+Do NOT consider whether any specific product is a good fit. Do NOT recommend a reply. Just score software-recommendation intent.
+SYS;
+
+    $commentsBlock = empty($topComments)
+        ? '(no comments yet)'
+        : implode("\n---\n", array_map(fn($c) => mb_substr($c, 0, 500), $topComments));
+
+    $userPrompt = "Subreddit: r/" . ($thread['subreddit'] ?? '')
+        . "\nTitle: " . ($thread['title'] ?? '')
+        . "\nBody: " . (empty($thread['body']) ? '(link post, no body)' : mb_substr((string) $thread['body'], 0, 2000))
+        . "\nComment count: " . (int) ($thread['comment_count'] ?? 0)
+        . "\nTop 10 comments:\n" . $commentsBlock;
+
+    // Few-shot learning: include recent founder-labeled threads so the AI
+    // gradually calibrates to this specific founder's taste. Only triggers
+    // when there's a meaningful sample (3+ of each label) to avoid noise
+    // from a tiny set of early labels.
+    if ($pdo !== null) {
+        $examples = reddit_fetch_label_examples($pdo);
+        if (!empty($examples['negatives']) && count($examples['negatives']) >= 3) {
+            $userPrompt .= "\n\n--- Examples the founder REJECTED as not a fit (treat similar threads as 4 or lower) ---";
+            foreach ($examples['negatives'] as $ex) {
+                $userPrompt .= "\n- r/{$ex['subreddit']} | {$ex['title']}";
+                if (!empty($ex['ai_relevance_reason'])) {
+                    $userPrompt .= " | AI thought: {$ex['ai_relevance_reason']}";
+                }
+            }
+        }
+        if (!empty($examples['positives']) && count($examples['positives']) >= 3) {
+            $userPrompt .= "\n\n--- Examples the founder ACCEPTED (drafted or replied — treat similar threads as 7+) ---";
+            foreach ($examples['positives'] as $ex) {
+                $userPrompt .= "\n- r/{$ex['subreddit']} | {$ex['title']}";
+            }
+        }
+    }
+
+    $resp = call_gemini($systemPrompt, $userPrompt);
+    if (!empty($resp['error'])) {
+        return ['score' => null, 'reason' => 'gemini_error: ' . $resp['error']];
+    }
+    $content = $resp['content'] ?? '';
+    $parsed = reddit_extract_json($content);
+    if (!is_array($parsed) || !isset($parsed['relevance'])) {
+        return ['score' => null, 'reason' => 'invalid_json'];
+    }
+    $score = (int) $parsed['relevance'];
+    $score = max(0, min(10, $score));
+    $reason = mb_substr((string) ($parsed['reason'] ?? ''), 0, 500);
+    return ['score' => $score, 'reason' => $reason];
+}
+
+/**
+ * Pull the most recent founder-labeled threads to use as few-shot examples
+ * in the AI relevance prompt. Negatives = explicit 'not_fit' labels.
+ * Positives = threads the founder actually drafted/replied on (the strongest
+ * 'yes this is a fit' signal we have). Capped to a few of each so the prompt
+ * doesn't balloon.
+ *
+ * Returns ['negatives' => [...], 'positives' => [...]]. Each row is a small
+ * dict of subreddit/title/ai_relevance_reason — small enough to fit a dozen
+ * in the prompt without significantly bumping token cost.
+ */
+function reddit_fetch_label_examples($pdo, int $limitEach = 5): array
+{
+    $out = ['negatives' => [], 'positives' => []];
+    try {
+        $negStmt = $pdo->prepare("
+            SELECT subreddit, title, ai_relevance_reason
+            FROM reddit_threads
+            WHERE status = 'not_fit'
+            ORDER BY status_updated_at DESC
+            LIMIT $limitEach
+        ");
+        $negStmt->execute();
+        $out['negatives'] = $negStmt->fetchAll() ?: [];
+
+        $posStmt = $pdo->prepare("
+            SELECT subreddit, title
+            FROM reddit_threads
+            WHERE status IN ('replied', 'drafted')
+              AND draft_body IS NOT NULL
+              AND draft_body != ''
+            ORDER BY status_updated_at DESC
+            LIMIT $limitEach
+        ");
+        $posStmt->execute();
+        $out['positives'] = $posStmt->fetchAll() ?: [];
+    } catch (PDOException $e) {
+        // Schema not ready or table empty — just return empties; AI runs without examples.
+    }
+    return $out;
+}
+
+// ─── Draft generation ───
+
+/**
+ * Generate a Reddit reply draft for a thread. Uses REDDIT_VOICE_DOC as the
+ * system instruction. Returns ['body' => string] on success or
+ * ['error' => string] on failure.
+ */
+function reddit_generate_draft(array $thread, array $topComments, array $regenContext = []): array
+{
+    $systemPrompt = REDDIT_VOICE_DOC . "\n\n# Output rules for this task\n"
+        . "You are drafting a Reddit reply for the founder to copy-paste manually. "
+        . "Follow the voice rules strictly. Output ONLY the reply text — no preamble, no explanation, "
+        . "no markdown formatting unless natural for Reddit. Do not include a URL. "
+        . "Do not include disclosure unless mentioning Argo Books. Keep it short: 2–4 short paragraphs at most.";
+
+    $commentsBlock = empty($topComments)
+        ? '(no comments yet)'
+        : implode("\n---\n", array_map(fn($c) => mb_substr($c, 0, 400), $topComments));
+
+    $userPrompt = "Subreddit: r/" . ($thread['subreddit'] ?? '')
+        . "\nThread title: " . ($thread['title'] ?? '')
+        . "\nBody: " . (empty($thread['body']) ? '(link post, no body)' : mb_substr((string) $thread['body'], 0, 2000))
+        . "\nTop comments (for context — don't repeat what others already said):\n" . $commentsBlock;
+
+    // Regeneration context: when the founder rejected a previous draft, show
+    // the AI what was wrong with it so the next version actually addresses
+    // their feedback instead of producing a randomly-varied near-duplicate.
+    $previousDraft = trim((string) ($regenContext['previous_draft'] ?? ''));
+    $feedback = trim((string) ($regenContext['feedback'] ?? ''));
+    if ($previousDraft !== '' || $feedback !== '') {
+        $userPrompt .= "\n\n--- This is a regeneration request ---";
+        if ($previousDraft !== '') {
+            $userPrompt .= "\nPrevious draft you produced (the founder rejected this):\n"
+                . mb_substr($previousDraft, 0, 2000);
+        }
+        if ($feedback !== '') {
+            $userPrompt .= "\n\nFounder feedback on what to change:\n" . mb_substr($feedback, 0, 2000);
+            $userPrompt .= "\n\nWrite a new reply that ACTUALLY addresses the feedback — not a cosmetic variation. If the feedback contradicts the voice doc, prefer the feedback.";
+        } else {
+            $userPrompt .= "\n\nWrite a meaningfully different reply (different angle or framing — not just reworded). Don't repeat the previous draft's structure.";
+        }
+    }
+
+    $userPrompt .= "\n\nWrite the reply now.";
+
+    $resp = call_gemini($systemPrompt, $userPrompt);
+    if (!empty($resp['error'])) {
+        return ['error' => $resp['error']];
+    }
+    $body = trim((string) ($resp['content'] ?? ''));
+    if ($body === '') {
+        return ['error' => 'empty_draft'];
+    }
+    // Defensive cleanup: strip em-dashes the voice doc bans, just in case.
+    $body = str_replace(['—', '–'], '-', $body);
+    return ['body' => $body];
+}
+
+// ─── Utility ───
+
+/**
+ * Best-effort extraction of a JSON object from a string that may include
+ * Markdown code fences or surrounding prose. Gemini sometimes wraps JSON
+ * in ```json ... ``` despite instruction to return only JSON.
+ */
+function reddit_extract_json(string $s): ?array
+{
+    $s = trim($s);
+    if ($s === '') return null;
+
+    // Strip code fences
+    if (preg_match('/```(?:json)?\s*(\{.*\})\s*```/s', $s, $m)) {
+        $s = $m[1];
+    } else {
+        // Find the first {...} block
+        $start = strpos($s, '{');
+        $end = strrpos($s, '}');
+        if ($start !== false && $end !== false && $end > $start) {
+            $s = substr($s, $start, $end - $start + 1);
+        }
+    }
+
+    $parsed = json_decode($s, true);
+    return is_array($parsed) ? $parsed : null;
+}
+
+/**
+ * Extract the t1_xxxxxx comment ID from a Reddit permalink. Accepts both
+ * /r/.../comments/<post_id>/<slug>/<comment_id> and the bare-comment form.
+ * Returns null if the URL is malformed.
+ */
+function reddit_extract_comment_id_from_permalink(string $url): ?string
+{
+    if (!preg_match('#reddit\.com/r/[^/]+/comments/[a-z0-9]+/[^/]*/([a-z0-9]+)/?#i', $url, $m)) {
+        return null;
+    }
+    return $m[1];
+}

--- a/cron/lib/reddit_helpers.php
+++ b/cron/lib/reddit_helpers.php
@@ -573,8 +573,17 @@ function reddit_check_comment_status($pdo, string $commentId36): array
     $c = $children[0]['data'] ?? [];
     $body = $c['body'] ?? '';
     $upvotes = isset($c['ups']) ? (int) $c['ups'] : null;
-    // num_replies is not always present on comments; fall back to 0.
-    $replies = isset($c['num_replies']) ? (int) $c['num_replies'] : 0;
+    // Reddit comment objects expose replies via a `replies` Listing (or empty
+    // string when there are none). There's no `num_replies` scalar — we have
+    // to count children in the Listing when one is returned. /api/info often
+    // doesn't expand the replies tree (it returns ""), in which case we
+    // record null rather than misleadingly logging 0.
+    $replies = null;
+    if (isset($c['replies']) && is_array($c['replies'])) {
+        $replies = count($c['replies']['data']['children'] ?? []);
+    } elseif (isset($c['replies']) && $c['replies'] === '') {
+        $replies = 0;
+    }
 
     if ($body === '[removed]') {
         return ['status' => 'removed', 'upvotes' => $upvotes, 'replies' => $replies];

--- a/cron/lib/reddit_voice.php
+++ b/cron/lib/reddit_voice.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Reddit reply voice doc.
+ *
+ * Hand-edited PHP string constant — change directly in this file when tuning.
+ * Loaded by reddit_helpers.php during draft generation and prepended as
+ * system instruction to Gemini.
+ *
+ * Edit the constant body, commit, deploy. No admin UI controls this on purpose;
+ * editing it should be intentional and reviewable.
+ */
+
+if (defined('REDDIT_VOICE_LOADED')) return;
+define('REDDIT_VOICE_LOADED', true);
+
+const REDDIT_VOICE_DOC = <<<'VOICE'
+# Reddit Voice Guide — Argo Books
+
+## Persona
+I'm a solo developer in Saskatchewan, Canada. I got frustrated with QuickBooks (too complex, too expensive for tiny businesses) and Wave (bank feeds break constantly), so I built my own bookkeeping/accounting app called Argo Books. I'm not a marketing team — just one person shipping software.
+
+## Argo Books context (for replies)
+- Free tier covers basic bookkeeping, invoicing, expense tracking
+- Premium adds advanced features (predictive analytics, multi-user, etc.)
+- Canadian-built, works internationally
+- Desktop app + web version
+- Target user: side hustlers, freelancers, sole proprietors, very small businesses that find QuickBooks overkill
+- Differentiators vs competitors:
+  - Cheaper than QuickBooks
+  - More reliable than Wave (especially around bank feeds, anecdotally)
+  - Simpler than Xero (which is built for accountants, not owners)
+  - Actually owned by a real person who reads emails, not a corporation
+
+## Voice rules
+
+Do:
+- Short sentences. Vary length deliberately.
+- Always use contractions (I'm, don't, it's, can't, you're)
+- Sometimes start sentences with lowercase ("yeah," "honestly," "ngl,") when it fits
+- Be direct. Lead with the useful thing, no preamble.
+- One mild typo or "ngl" / "tbh" / "imo" per few posts is fine
+- Mention specific competitors by name when relevant (QuickBooks, Wave, FreshBooks, Xero)
+- It's okay to admit limits ("I haven't tried X but heard it's good")
+
+Don't:
+- No headers (##), no bullet lists in replies, no bold
+- No em-dashes (—) — use regular hyphens (-) or commas/periods. Em-dashes are the #1 AI tell.
+- No "Great question!" / "Hope this helps!" / "Feel free to..." / "Let me know if..."
+- No "Here's a breakdown" / "Several things to consider" / "It's important to note"
+- Don't restate the person's question back to them
+- Don't end every comment by mentioning Argo (looks like a bot)
+- No exclamation marks at the end of sentences (rarely natural)
+- No structured 3-point answers when one sentence works
+
+## Length
+- Default: 2–4 short paragraphs (3–6 sentences each, max)
+- Sometimes a one-liner is perfect — use it
+- Never write a wall of text. If the answer needs that much, link to a blog post instead.
+
+## Mentioning Argo Books
+
+When to mention:
+- They directly ask for software recommendations
+- They're explicitly describing a pain Argo solves (spreadsheets, hate QuickBooks, side-hustle bookkeeping)
+- The thread is specifically about alternatives to QuickBooks/Wave/FreshBooks
+
+When NOT to mention:
+- Tangentially related thread (e.g. tax advice, business registration)
+- 3+ other comments already pitching products (saturated, you'll be ignored)
+- Brand-new account with <50 karma (build trust first)
+- The question is about something Argo doesn't actually do well
+
+Disclosure phrasing (pick one, vary):
+- "(disclosure: I built one of these so I'm biased)"
+- "ngl I built one of these, so grain of salt"
+- "biased here since I'm the dev, but..."
+
+Put disclosure BEFORE the mention, not after. Don't include a URL — just say "Argo Books" by name. Let them Google it.
+
+## Honesty
+- Don't claim personal experience with tools you haven't actually used. If you haven't used Wave, say "I've heard" or "people complain about" instead of "in my experience."
+- If a competitor genuinely fits the OP's case better than Argo, say so.
+
+## Examples
+
+Good (sounds human, would not get auto-flagged):
+
+> yeah quickbooks is overkill for one person. wave is free which is nice but I've seen people complain about bank feed sync issues. honestly got frustrated enough that I built my own thing (disclosure: it's called argo books, so obviously biased). also heard akaunting is solid if you want self-hosted.
+
+> the gst thing depends on revenue. you only have to register once you hit 30k in a rolling 12-month period in canada. below that you can just track receipts in a spreadsheet, no need for software yet.
+
+> tried freshbooks for like a month and the pricing tiers drove me nuts — wait, scratch that, no em-dashes — the pricing tiers drove me nuts, they nickel-and-dime you for stuff that should be standard. wish there was a middle ground tbh.
+
+Bad (AI-flavored, do NOT write like this):
+
+> Great question! There are several factors to consider when choosing accounting software for your small business. Some popular options include QuickBooks, FreshBooks, and Wave — each with its own strengths and weaknesses. I'd recommend trying a few free trials to see which fits best. Hope this helps!
+
+> That's a really common challenge for new freelancers. Here are a few things to keep in mind:
+> 1. Track your expenses from day one
+> 2. Separate personal and business finances
+> 3. Set aside money for taxes quarterly
+> Let me know if you have any other questions!
+
+(Both are obvious AI: headers, lists, bolded openings, hedging, no opinion, no specifics, no personal experience.)
+VOICE;

--- a/cron/reddit_monitor.php
+++ b/cron/reddit_monitor.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Reddit discovery cron.
+ *
+ * Runs daily at 8am (and manually via admin "Run discovery now").
+ *
+ * Pipeline:
+ *   1. Pull last 24h from each enabled watchlist subreddit
+ *   2. Run global Reddit search for each enabled keyword (t=day)
+ *   3. Dedup by reddit_id (a thread hitting both sources gets discovery_source=both)
+ *   4. Score each new thread (rules-based 0-100)
+ *   5. Threads scoring < rules_score_floor → status='skipped'
+ *   6. For passing threads: fetch top comments, run AI relevance check
+ *   7. Threads with ai_relevance < ai_relevance_floor → status='skipped'
+ *   8. Threads with ai_relevance ≥ 8 → pre-generate draft, status='drafted'
+ *   9. Threads with ai_relevance 6-7 → status='drafted_pending' (on-demand draft)
+ *  10. Auto-expire `drafted`/`drafted_pending` threads older than 3 days
+ *  11. Update reddit_settings diagnostics
+ *
+ * Manual flags:
+ *   --dry-run    Log what would happen without writing drafts or status changes
+ *   --verbose    Print each step's progress to stdout
+ */
+
+set_time_limit(900); // 15 min max
+
+// Allow execution from CLI/cron OR from an admin web request that has already
+// authenticated and detached the response (sets REDDIT_MONITOR_INLINE).
+if (!defined('REDDIT_MONITOR_INLINE') && php_sapi_name() !== 'cli' && !empty($_SERVER['REMOTE_ADDR'])) {
+    http_response_code(403);
+    die('Access denied. CLI/cron only.');
+}
+
+// Skip duplicate bootstrap when included from admin/outreach/api.php — the
+// autoloader, env vars, and DB connection are already in scope. Loading
+// Dotenv twice is safe (immutable) but cheaper to skip.
+if (!defined('REDDIT_MONITOR_INLINE')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+    $dotenv->load();
+    require_once __DIR__ . '/../db_connect.php';
+}
+require_once __DIR__ . '/lib/outreach_helpers.php';
+require_once __DIR__ . '/lib/reddit_helpers.php';
+
+// ─── Lock file ───
+
+$lockDir = __DIR__ . '/logs';
+if (!is_dir($lockDir)) mkdir($lockDir, 0755, true);
+$lockFile = $lockDir . '/reddit_monitor.lock';
+$lockFp = fopen($lockFile, 'c');
+if (!$lockFp || !flock($lockFp, LOCK_EX | LOCK_NB)) {
+    echo "Reddit monitor already running. Exiting.\n";
+    exit(0);
+}
+
+// ─── Args ───
+
+$args = array_slice($argv ?? [], 1);
+$dryRun = in_array('--dry-run', $args, true);
+$verbose = in_array('--verbose', $args, true);
+
+function rmon_say($msg) {
+    global $verbose;
+    if ($verbose) echo "[reddit_monitor] $msg\n";
+    reddit_log($msg);
+}
+
+// ─── Pipeline state ───
+
+$startedAt = date('Y-m-d H:i:s');
+$threadsFound = 0;
+$threadsDrafted = 0;
+$lastError = null;
+
+reddit_progress_reset([
+    'message' => 'Starting discovery…',
+    'started_at' => $startedAt,
+]);
+
+try {
+    // Ensure singleton row + read floors
+    $pdo->exec("INSERT IGNORE INTO reddit_settings (id) VALUES (1)");
+    $cfg = $pdo->query("SELECT rules_score_floor, ai_relevance_floor FROM reddit_settings WHERE id = 1")->fetch();
+    $rulesFloor = (int) ($cfg['rules_score_floor'] ?? 30);
+    $aiFloor = (int) ($cfg['ai_relevance_floor'] ?? 6);
+
+    // ─── Step 1+2: Discovery ───
+
+    $subs = $pdo->query("SELECT name FROM reddit_subreddits WHERE enabled = 1 AND auto_disabled_at IS NULL")
+                ->fetchAll(PDO::FETCH_COLUMN);
+    $keywords = $pdo->query("SELECT keyword FROM reddit_keywords WHERE enabled = 1")->fetchAll(PDO::FETCH_COLUMN);
+
+    rmon_say("Discovery: " . count($subs) . " subreddits, " . count($keywords) . " keywords");
+
+    $discovered = []; // keyed by reddit_id
+
+    foreach ($subs as $i => $sub) {
+        reddit_progress_write(['message' => "Pulling r/$sub (" . ($i + 1) . '/' . count($subs) . ')…']);
+        $threads = reddit_fetch_subreddit_new($pdo, $sub);
+        rmon_say("  r/$sub → " . count($threads) . " threads");
+        foreach ($threads as $t) {
+            $rid = $t['reddit_id'];
+            $discovered[$rid] = $t;
+        }
+    }
+
+    foreach ($keywords as $i => $kw) {
+        reddit_progress_write(['message' => "Searching \"$kw\" (" . ($i + 1) . '/' . count($keywords) . ')…']);
+        $threads = reddit_fetch_search($pdo, $kw);
+        rmon_say("  keyword \"$kw\" → " . count($threads) . " threads");
+        foreach ($threads as $t) {
+            $rid = $t['reddit_id'];
+            if (isset($discovered[$rid])) {
+                // Already from watchlist — upgrade to 'both' and append keyword
+                $discovered[$rid]['discovery_source'] = 'both';
+                $existing = $discovered[$rid]['matched_keywords'] ?? [];
+                $discovered[$rid]['matched_keywords'] = array_values(array_unique(array_merge($existing, [$kw])));
+            } else {
+                // Keyword-only thread; check if subreddit IS in watchlist
+                $inWatchlist = in_array($t['subreddit'], $subs, true);
+                $t['discovery_source'] = $inWatchlist ? 'both' : 'keyword';
+                $discovered[$rid] = $t;
+            }
+        }
+    }
+
+    rmon_say("Discovery total (deduplicated): " . count($discovered) . " threads");
+    $threadsFound = count($discovered);
+    reddit_progress_write(['found' => $threadsFound, 'message' => "Found $threadsFound threads, scoring…"]);
+
+    // ─── Step 3-9: Score, AI relevance, draft (skip already-seen reddit_ids) ───
+
+    $existingStmt = $pdo->prepare("SELECT 1 FROM reddit_threads WHERE reddit_id = ?");
+    $insertStmt = $pdo->prepare("
+        INSERT INTO reddit_threads
+        (reddit_id, subreddit, title, body, url, author, post_score, comment_count,
+         posted_at, discovery_source, matched_keywords, rules_score, ai_relevance,
+         ai_relevance_reason, draft_body, draft_generated_at, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ");
+
+    $processed = 0;
+    $totalToProcess = count($discovered);
+
+    foreach ($discovered as $rid => $t) {
+        $processed++;
+        $existingStmt->execute([$rid]);
+        if ($existingStmt->fetchColumn()) continue; // already discovered earlier
+
+        $rulesScore = reddit_score_thread($t);
+
+        if ($rulesScore < $rulesFloor) {
+            // Below rules floor → store as skipped, no AI call
+            if (!$dryRun) {
+                $insertStmt->execute([
+                    $t['reddit_id'], $t['subreddit'], $t['title'], $t['body'], $t['url'],
+                    $t['author'], $t['post_score'], $t['comment_count'], $t['posted_at'],
+                    $t['discovery_source'], json_encode($t['matched_keywords']),
+                    $rulesScore, null, null, null, null, 'skipped',
+                ]);
+            }
+            rmon_say("  $rid skipped (rules_score=$rulesScore < $rulesFloor)");
+            continue;
+        }
+
+        // Fetch top comments for relevance context
+        $comments = reddit_fetch_top_comments($pdo, $t['subreddit'], $rid);
+
+        reddit_progress_write(['message' => "AI scoring thread $processed/$totalToProcess (r/{$t['subreddit']})…"]);
+
+        // AI relevance (passes $pdo so it can include the founder's recent
+        // not_fit / replied labels as few-shot examples in the prompt).
+        $rel = reddit_ai_relevance($t, $comments, $pdo);
+        $aiScore = $rel['score'];
+        $aiReason = $rel['reason'];
+
+        if ($aiScore === null) {
+            rmon_say("  $rid AI relevance failed: $aiReason — storing as new");
+            // Persist so we don't re-process; status='new' lets retry on next run
+            if (!$dryRun) {
+                $insertStmt->execute([
+                    $t['reddit_id'], $t['subreddit'], $t['title'], $t['body'], $t['url'],
+                    $t['author'], $t['post_score'], $t['comment_count'], $t['posted_at'],
+                    $t['discovery_source'], json_encode($t['matched_keywords']),
+                    $rulesScore, null, null, null, null, 'new',
+                ]);
+            }
+            continue;
+        }
+
+        if ($aiScore < $aiFloor) {
+            if (!$dryRun) {
+                $insertStmt->execute([
+                    $t['reddit_id'], $t['subreddit'], $t['title'], $t['body'], $t['url'],
+                    $t['author'], $t['post_score'], $t['comment_count'], $t['posted_at'],
+                    $t['discovery_source'], json_encode($t['matched_keywords']),
+                    $rulesScore, $aiScore, $aiReason, null, null, 'skipped',
+                ]);
+            }
+            rmon_say("  $rid skipped (ai_relevance=$aiScore < $aiFloor)");
+            continue;
+        }
+
+        // Passes both floors
+        $draftBody = null;
+        $draftGeneratedAt = null;
+        $status = 'drafted_pending';
+
+        if ($aiScore >= 8) {
+            reddit_progress_write(['message' => "Generating draft for r/{$t['subreddit']} (relevance $aiScore)…"]);
+            $draft = reddit_generate_draft($t, $comments);
+            if (!empty($draft['body'])) {
+                $draftBody = $draft['body'];
+                $draftGeneratedAt = date('Y-m-d H:i:s');
+                $status = 'drafted';
+                $threadsDrafted++;
+                reddit_progress_write(['drafted' => $threadsDrafted]);
+                rmon_say("  $rid pre-drafted (ai_relevance=$aiScore)");
+            } else {
+                rmon_say("  $rid draft generation failed: " . ($draft['error'] ?? 'unknown') . ' — keeping as drafted_pending');
+            }
+        } else {
+            rmon_say("  $rid drafted_pending (ai_relevance=$aiScore, will draft on demand)");
+        }
+
+        if (!$dryRun) {
+            $insertStmt->execute([
+                $t['reddit_id'], $t['subreddit'], $t['title'], $t['body'], $t['url'],
+                $t['author'], $t['post_score'], $t['comment_count'], $t['posted_at'],
+                $t['discovery_source'], json_encode($t['matched_keywords']),
+                $rulesScore, $aiScore, $aiReason, $draftBody, $draftGeneratedAt, $status,
+            ]);
+        }
+    }
+
+    // ─── Step 10: Auto-expire stale drafts (> 3 days) ───
+
+    if (!$dryRun) {
+        $expired = $pdo->exec("
+            UPDATE reddit_threads
+            SET status = 'expired'
+            WHERE status IN ('drafted', 'drafted_pending', 'new')
+              AND discovered_at < DATE_SUB(NOW(), INTERVAL 3 DAY)
+        ");
+        if ($expired > 0) rmon_say("Auto-expired $expired stale drafts");
+    }
+
+    // ─── Step 11: Update diagnostics ───
+
+    if (!$dryRun) {
+        $upd = $pdo->prepare("
+            UPDATE reddit_settings
+            SET last_run_at = ?, last_run_threads_found = ?, last_run_threads_drafted = ?, last_run_error = NULL
+            WHERE id = 1
+        ");
+        $upd->execute([$startedAt, $threadsFound, $threadsDrafted]);
+    }
+
+    rmon_say("Done. found=$threadsFound drafted=$threadsDrafted");
+    reddit_progress_write([
+        'message' => "Done. Found $threadsFound threads, pre-drafted $threadsDrafted.",
+        'completed' => true,
+        'found' => $threadsFound,
+        'drafted' => $threadsDrafted,
+    ]);
+    echo "Reddit monitor complete: $threadsFound threads found, $threadsDrafted pre-drafted.\n";
+} catch (Throwable $e) {
+    $lastError = $e->getMessage();
+    reddit_log("Reddit monitor crashed: $lastError");
+    reddit_progress_write([
+        'message' => 'Crashed: ' . $lastError,
+        'completed' => true,
+        'error' => $lastError,
+    ]);
+    if (!$dryRun) {
+        $upd = $pdo->prepare("UPDATE reddit_settings SET last_run_at = ?, last_run_error = ? WHERE id = 1");
+        $upd->execute([$startedAt, $lastError]);
+    }
+    echo "Reddit monitor FAILED: $lastError\n";
+    exit(1);
+} finally {
+    flock($lockFp, LOCK_UN);
+    fclose($lockFp);
+}

--- a/cron/reddit_monitor.php
+++ b/cron/reddit_monitor.php
@@ -14,7 +14,8 @@
  *   7. Threads with ai_relevance < ai_relevance_floor → status='skipped'
  *   8. Threads with ai_relevance ≥ 8 → pre-generate draft, status='drafted'
  *   9. Threads with ai_relevance 6-7 → status='drafted_pending' (on-demand draft)
- *  10. Auto-expire `drafted`/`drafted_pending` threads older than 3 days
+ *  10. Auto-expire `new`, `drafted`, and `drafted_pending` threads older than 3 days
+ *      (including `new` catches AI-failure retries that never got reprocessed)
  *  11. Update reddit_settings diagnostics
  *
  * Manual flags:

--- a/cron/reddit_status_check.php
+++ b/cron/reddit_status_check.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Reddit posted-reply status checker.
+ *
+ * Runs every 2 hours. For each thread with status='replied', re-checks the
+ * posted comment via Reddit API on a staggered schedule (30min / 2h / 6h /
+ * 24h / 72h after posting), classifies reply_status, captures engagement
+ * (upvotes + replies), then rolls up per-subreddit removal stats and
+ * applies the auto-disable rule.
+ *
+ * Idempotent — safe to run on any schedule. Each row tracks its own
+ * check_count + last_checked_at so we never over-check.
+ */
+
+set_time_limit(600);
+
+if (php_sapi_name() !== 'cli' && !empty($_SERVER['REMOTE_ADDR'])) {
+    http_response_code(403);
+    die('Access denied. CLI/cron only.');
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->load();
+
+require_once __DIR__ . '/../db_connect.php';
+require_once __DIR__ . '/lib/outreach_helpers.php';
+require_once __DIR__ . '/lib/reddit_helpers.php';
+
+// ─── Lock file ───
+
+$lockDir = __DIR__ . '/logs';
+if (!is_dir($lockDir)) mkdir($lockDir, 0755, true);
+$lockFile = $lockDir . '/reddit_status_check.lock';
+$lockFp = fopen($lockFile, 'c');
+if (!$lockFp || !flock($lockFp, LOCK_EX | LOCK_NB)) {
+    echo "Reddit status check already running. Exiting.\n";
+    exit(0);
+}
+
+// Schedule (in seconds since reply_posted_at) for checks 1..5
+const CHECK_OFFSETS_SEC = [1800, 7200, 21600, 86400, 259200];
+
+$startedAt = date('Y-m-d H:i:s');
+$updated = 0;
+$lastError = null;
+
+try {
+    // Find candidates: replied, comment id known, check_count < 5
+    // Filter to those whose next scheduled check has passed.
+    $stmt = $pdo->query("
+        SELECT id, subreddit, reply_comment_id, reply_posted_at, reply_status_check_count, reply_status
+        FROM reddit_threads
+        WHERE status = 'replied'
+          AND reply_comment_id IS NOT NULL
+          AND reply_status_check_count < 5
+          AND (reply_status IS NULL OR reply_status NOT IN ('deleted_by_user'))
+    ");
+    $candidates = $stmt->fetchAll();
+
+    $now = time();
+    foreach ($candidates as $row) {
+        $count = (int) $row['reply_status_check_count'];
+        $postedAt = strtotime($row['reply_posted_at']);
+        if ($count >= 5 || !$postedAt) continue;
+
+        $offset = CHECK_OFFSETS_SEC[$count] ?? null;
+        if ($offset === null) continue;
+        if (($now - $postedAt) < $offset) continue; // not yet time for next check
+
+        $result = reddit_check_comment_status($pdo, $row['reply_comment_id']);
+        $status = $result['status']; // 'live' | 'removed' | 'removed_or_shadowbanned' | 'deleted_by_user' | null
+
+        if ($status === null) {
+            // API failed; don't increment count so we retry next run.
+            reddit_log("Status check: API failure for thread {$row['id']} (comment {$row['reply_comment_id']})");
+            continue;
+        }
+
+        $upd = $pdo->prepare("
+            UPDATE reddit_threads
+            SET reply_status = ?,
+                reply_status_checked_at = NOW(),
+                reply_status_check_count = reply_status_check_count + 1,
+                reply_upvotes = ?,
+                reply_replies_count = ?
+            WHERE id = ?
+        ");
+        $upd->execute([
+            $status,
+            $result['upvotes'],
+            $result['replies'],
+            $row['id'],
+        ]);
+        $updated++;
+    }
+
+    // ─── Roll up per-subreddit removal rates ───
+
+    $rollup = $pdo->query("
+        SELECT subreddit,
+               COUNT(*) AS total,
+               SUM(CASE WHEN reply_status IN ('removed', 'removed_or_shadowbanned') THEN 1 ELSE 0 END) AS removed
+        FROM reddit_threads
+        WHERE status = 'replied'
+          AND reply_status_check_count >= 1
+          AND reply_posted_at > DATE_SUB(NOW(), INTERVAL 30 DAY)
+        GROUP BY subreddit
+    ")->fetchAll();
+
+    // Reset all subreddits to zero so subs with no recent replies show 0/0
+    $pdo->exec("UPDATE reddit_subreddits SET replies_30d = 0, removal_rate_30d = 0.00");
+
+    $rollupStmt = $pdo->prepare("
+        UPDATE reddit_subreddits
+        SET replies_30d = ?, removal_rate_30d = ?
+        WHERE name = ?
+    ");
+    foreach ($rollup as $r) {
+        $total = (int) $r['total'];
+        $removed = (int) $r['removed'];
+        $rate = $total > 0 ? round(($removed / $total) * 100, 2) : 0.0;
+        $rollupStmt->execute([$total, $rate, $r['subreddit']]);
+    }
+
+    // ─── Auto-disable rule ───
+
+    $cfg = $pdo->query("SELECT auto_disable_removal_rate, auto_disable_min_replies FROM reddit_settings WHERE id = 1")->fetch();
+    $threshold = (int) ($cfg['auto_disable_removal_rate'] ?? 60);
+    $minReplies = (int) ($cfg['auto_disable_min_replies'] ?? 3);
+
+    $disableStmt = $pdo->prepare("
+        UPDATE reddit_subreddits
+        SET auto_disabled_at = NOW(),
+            auto_disabled_reason = 'high_removal_rate'
+        WHERE enabled = 1
+          AND auto_disabled_at IS NULL
+          AND replies_30d >= ?
+          AND removal_rate_30d >= ?
+    ");
+    $disableStmt->execute([$minReplies, $threshold]);
+    $disabledCount = $disableStmt->rowCount();
+    if ($disabledCount > 0) {
+        reddit_log("Auto-disabled $disabledCount subreddit(s) for high removal rate.");
+    }
+
+    // ─── Diagnostics ───
+
+    $upd = $pdo->prepare("UPDATE reddit_settings SET last_status_check_at = ? WHERE id = 1");
+    $upd->execute([$startedAt]);
+
+    echo "Reddit status check complete: $updated reply rows updated, " . count($rollup) . " subreddits rolled up.\n";
+} catch (Throwable $e) {
+    $lastError = $e->getMessage();
+    reddit_log("Status check crashed: $lastError");
+    echo "Reddit status check FAILED: $lastError\n";
+    exit(1);
+} finally {
+    flock($lockFp, LOCK_UN);
+    fclose($lockFp);
+}

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -1073,3 +1073,150 @@ CREATE TABLE IF NOT EXISTS campaign_spend (
     INDEX idx_period (period_start),
     FOREIGN KEY (source_code) REFERENCES referral_links(source_code) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ─── Reddit outreach channel ───
+-- Threads discovered by the daily cron + the founder's manual reply tracking.
+-- Manual posting only (no auto-posting); permalink is required to mark a
+-- thread `replied`, which feeds the status-check cron's worklist.
+CREATE TABLE IF NOT EXISTS reddit_threads (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    reddit_id VARCHAR(20) NOT NULL UNIQUE COMMENT 'Reddit t3_xxxxxx ID',
+    subreddit VARCHAR(64) NOT NULL,
+    title VARCHAR(500) NOT NULL,
+    body TEXT DEFAULT NULL,
+    url VARCHAR(500) NOT NULL,
+    author VARCHAR(64) DEFAULT NULL,
+    author_karma INT DEFAULT NULL,
+    post_score INT DEFAULT 0,
+    comment_count INT DEFAULT 0,
+    posted_at DATETIME DEFAULT NULL,
+    discovered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    discovery_source ENUM('watchlist','keyword','both') NOT NULL DEFAULT 'watchlist',
+    matched_keywords JSON DEFAULT NULL,
+    rules_score INT DEFAULT 0,
+    ai_relevance TINYINT DEFAULT NULL COMMENT '0-10 or NULL if not checked',
+    ai_relevance_reason VARCHAR(500) DEFAULT NULL,
+    draft_body TEXT DEFAULT NULL,
+    draft_generated_at DATETIME DEFAULT NULL,
+    status ENUM('new','drafted','drafted_pending','replied','skipped','not_fit','expired') NOT NULL DEFAULT 'new',
+    status_updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    mentioned_product TINYINT(1) DEFAULT 0 COMMENT 'Set when marking replied — counts toward post-limit',
+    reply_permalink VARCHAR(500) DEFAULT NULL,
+    reply_comment_id VARCHAR(20) DEFAULT NULL COMMENT 'Extracted t1_xxxxxx from permalink',
+    reply_posted_at DATETIME DEFAULT NULL,
+    reply_status ENUM('pending','live','removed','removed_or_shadowbanned','deleted_by_user') DEFAULT NULL,
+    reply_status_checked_at DATETIME DEFAULT NULL,
+    reply_status_check_count TINYINT DEFAULT 0,
+    reply_upvotes INT DEFAULT NULL,
+    reply_replies_count INT DEFAULT NULL,
+    override_limit TINYINT(1) DEFAULT 0 COMMENT 'Founder explicitly went over the post-limit cap',
+    notes TEXT DEFAULT NULL,
+    INDEX idx_status (status),
+    INDEX idx_discovered (discovered_at),
+    INDEX idx_relevance_status (ai_relevance, status),
+    INDEX idx_reply_status (reply_status),
+    INDEX idx_subreddit (subreddit),
+    INDEX idx_reply_posted (reply_posted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Watchlist of subreddits polled daily. Per-subreddit removal-rate stats
+-- are rolled up by the status-check cron and used by the auto-disable rule.
+CREATE TABLE IF NOT EXISTS reddit_subreddits (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(64) NOT NULL UNIQUE,
+    enabled TINYINT(1) NOT NULL DEFAULT 1,
+    notes VARCHAR(255) DEFAULT NULL,
+    replies_30d INT NOT NULL DEFAULT 0,
+    removal_rate_30d DECIMAL(5,2) NOT NULL DEFAULT 0.00,
+    auto_disabled_at DATETIME DEFAULT NULL,
+    auto_disabled_reason VARCHAR(120) DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Search terms run against Reddit's global search each day. Use quoted
+-- phrases for exact matching (e.g. "quickbooks alternative").
+CREATE TABLE IF NOT EXISTS reddit_keywords (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    keyword VARCHAR(120) NOT NULL UNIQUE,
+    enabled TINYINT(1) NOT NULL DEFAULT 1,
+    notes VARCHAR(255) DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Singleton settings row (id=1 enforced). Holds OAuth token cache,
+-- diagnostics, and tunable thresholds.
+CREATE TABLE IF NOT EXISTS reddit_settings (
+    id TINYINT PRIMARY KEY,
+    access_token VARCHAR(255) DEFAULT NULL COMMENT 'Encrypted via portal_encrypt()',
+    access_token_expires_at DATETIME DEFAULT NULL,
+    last_run_at DATETIME DEFAULT NULL,
+    last_run_threads_found INT DEFAULT 0,
+    last_run_threads_drafted INT DEFAULT 0,
+    last_run_error TEXT DEFAULT NULL,
+    last_status_check_at DATETIME DEFAULT NULL,
+    rules_score_floor TINYINT NOT NULL DEFAULT 30,
+    ai_relevance_floor TINYINT NOT NULL DEFAULT 6,
+    daily_post_limit TINYINT NOT NULL DEFAULT 3,
+    weekly_post_limit TINYINT NOT NULL DEFAULT 12,
+    auto_disable_removal_rate TINYINT NOT NULL DEFAULT 60,
+    auto_disable_min_replies TINYINT NOT NULL DEFAULT 3
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed the singleton row and a starter watchlist + keyword pool. Idempotent
+-- via INSERT IGNORE so re-running the schema is safe.
+INSERT IGNORE INTO reddit_settings (id) VALUES (1);
+
+INSERT IGNORE INTO reddit_subreddits (name, notes) VALUES
+    ('smallbusiness', 'general small-business owners'),
+    ('EtsySellers', 'Etsy shop owners — high product-mention tolerance'),
+    ('Flipping', 'resellers and flippers'),
+    ('freelance', 'freelancers'),
+    ('sidehustle', 'side-hustle starters'),
+    ('juststart', 'brand-new entrepreneurs'),
+    ('Bookkeeping', 'small and heavily moderated — tune carefully'),
+    ('Entrepreneur', 'huge but bans self-promo aggressively'),
+    ('PersonalFinanceCanada', 'Canadian audience'),
+    ('ecommerce', 'general ecommerce — inventory + invoicing pain'),
+    ('shopify', 'Shopify store owners'),
+    ('Reselling', 'resellers — inventory + receipt tracking'),
+    ('Landlord', 'landlords — rental income tracking'),
+    ('realestateinvesting', 'real estate investors — rental bookkeeping'),
+    ('sweatystartup', 'service-business owners'),
+    ('microsaas', 'indie SaaS founders — invoicing + subscription accounting'),
+    ('graphic_design', 'designers — invoicing pain'),
+    ('AmazonSeller', 'Amazon sellers — inventory + fees tracking');
+
+INSERT IGNORE INTO reddit_keywords (keyword, notes) VALUES
+    ('bookkeeping software', 'broad intent'),
+    ('quickbooks alternative', 'switch-intent'),
+    ('freshbooks alternative', 'switch-intent'),
+    ('wave accounting', 'often switch-intent from Wave bugs'),
+    ('freelancer taxes canada', 'Canadian freelancer pain'),
+    ('etsy bookkeeping', 'Etsy seller pain'),
+    ('side hustle taxes', 'side-hustler tax confusion'),
+    ('small business spreadsheet bookkeeping', 'spreadsheet-to-software transition'),
+    -- Receipt scanning
+    ('receipt scanning app', 'AI receipt scan'),
+    ('scan receipts for taxes', 'AI receipt scan'),
+    ('digitize receipts', 'AI receipt scan'),
+    ('track expenses receipts', 'expenses + receipts'),
+    -- Invoicing
+    ('invoice software for freelancers', 'invoicing'),
+    ('send invoices online', 'invoicing'),
+    ('best invoicing software', 'invoicing'),
+    ('invoice template app', 'invoicing'),
+    -- Rental / landlords
+    ('rental property bookkeeping', 'rental'),
+    ('landlord accounting software', 'rental'),
+    ('track rental income', 'rental'),
+    -- Inventory
+    ('small business inventory software', 'inventory'),
+    ('inventory tracking spreadsheet', 'inventory — spreadsheet pain'),
+    ('ecommerce inventory tracking', 'inventory — ecommerce'),
+    -- Customer / supplier
+    ('small business CRM', 'customer mgmt'),
+    ('track customers spreadsheet', 'customer mgmt — spreadsheet pain'),
+    ('vendor tracking software', 'supplier mgmt'),
+    -- General SMB / self-employed
+    ('self-employed accounting', 'self-employed broad intent'),
+    ('sole proprietor taxes', 'sole proprietor pain');

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -1102,7 +1102,7 @@ CREATE TABLE IF NOT EXISTS reddit_threads (
     status_updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     mentioned_product TINYINT(1) DEFAULT 0 COMMENT 'Set when marking replied — counts toward post-limit',
     reply_permalink VARCHAR(500) DEFAULT NULL,
-    reply_comment_id VARCHAR(20) DEFAULT NULL COMMENT 'Extracted t1_xxxxxx from permalink',
+    reply_comment_id VARCHAR(20) DEFAULT NULL COMMENT 'Base36 comment id (no t1_ prefix) extracted from the permalink; the t1_ prefix is prepended at query time',
     reply_posted_at DATETIME DEFAULT NULL,
     reply_status ENUM('pending','live','removed','removed_or_shadowbanned','deleted_by_user') DEFAULT NULL,
     reply_status_checked_at DATETIME DEFAULT NULL,

--- a/read-me/Cron jobs.md
+++ b/read-me/Cron jobs.md
@@ -249,7 +249,7 @@ Manual posting only — the cron does NOT post anything to Reddit. Drafts are re
 
 ### Environment Variables
 
-Default mode is **unauthenticated** — the cron uses Reddit's public JSON endpoints (no app, no OAuth, no policy gate). Fill in the `REDDIT_*` vars later to upgrade to OAuth without code changes.
+Default mode is **unauthenticated** — no app, no OAuth, no policy gate. Fill in the `REDDIT_*` vars later to upgrade to OAuth without code changes.
 
 | Variable | Required | Description |
 |---|---|---|
@@ -259,7 +259,9 @@ Default mode is **unauthenticated** — the cron uses Reddit's public JSON endpo
 | `REDDIT_USERNAME` | optional | Reddit account that will post. If set without the OAuth pair, used purely as the User-Agent identifier and for the admin "your account stats" card. |
 | `REDDIT_PASSWORD` | optional | Account password. Required only for OAuth mode. |
 
-The cron uses OAuth automatically when all four `REDDIT_*` vars are set; otherwise it falls back to public JSON endpoints. The public endpoint path is slightly less durable — Reddit can throttle/block unauthenticated reads at any time — but works fine at our volume.
+**Endpoint behaviour (unauth mode):** Reddit's JSON endpoints are aggressively IP-blocked from datacenter hosts (returns 403). To work around this, the helpers fetch discovery-shaped paths (`/r/X/new`, `/search`) via Reddit's RSS feed at the `.rss` suffix and parse the Atom XML back into the JSON listing shape — those endpoints are typically not IP-blocked. Endpoints with no RSS counterpart (`/api/info`, `/user/X/about`) still go to JSON and will silently 403 from blocked IPs, meaning the **reply-status check** and **account-info card** require OAuth to function. Discovery + drafting work either way.
+
+When all four `REDDIT_*` vars are set, the helpers switch to OAuth (`oauth.reddit.com`) and all endpoints work normally. No code change required.
 
 Per-channel tuning (scoring floors, post limits, auto-disable thresholds, subreddit / keyword lists) lives in the database and is editable in the admin UI under **Outreach → Reddit → Settings**.
 

--- a/read-me/Cron jobs.md
+++ b/read-me/Cron jobs.md
@@ -223,3 +223,79 @@ Queries Stripe for refund requests stuck in `processing` for more than 30 minute
 ### What It Does
 
 Refreshes `refund_velocity_baselines` per company so the established-account hard-block tier (≥ 50% of trailing 30-day revenue) has accurate inputs. If baselines drift out of date, the refund safety check fires too often or not enough — see the [Hard-Block Response Procedure](procedures/Refund%20block%20response%20procedure.md) for symptoms.
+
+---
+
+## 9. Reddit Discovery
+
+**Script:** `cron/reddit_monitor.php`
+**Schedule:** Daily at 8:00 AM
+
+```bash
+0 8 * * * /usr/bin/php /home/argorobots/public_html/cron/reddit_monitor.php
+```
+
+### What It Does
+
+1. Pulls fresh threads (last 24h) from each enabled watchlist subreddit
+2. Runs global Reddit search for each enabled keyword
+3. Deduplicates by thread ID and applies rules-based scoring
+4. Runs a neutral AI relevance check (Gemini) on threads above the rules floor
+5. Pre-generates a draft reply for threads scoring ≥ 8 on AI relevance
+6. Marks borderline (6–7) threads as `drafted_pending` for on-demand drafting in the admin UI
+7. Auto-expires drafted threads older than 3 days
+
+Manual posting only — the cron does NOT post anything to Reddit. Drafts are reviewed and copy-pasted manually by the founder.
+
+### Environment Variables
+
+Default mode is **unauthenticated** — the cron uses Reddit's public JSON endpoints (no app, no OAuth, no policy gate). Fill in the `REDDIT_*` vars later to upgrade to OAuth without code changes.
+
+| Variable | Required | Description |
+|---|---|---|
+| `GEMINI_API_KEY` | yes | Reused from the email pipeline for AI relevance + draft generation |
+| `REDDIT_CLIENT_ID` | optional | From a personal-use script app at https://www.reddit.com/prefs/apps/. Required only for OAuth mode. |
+| `REDDIT_CLIENT_SECRET` | optional | App secret. Required only for OAuth mode. |
+| `REDDIT_USERNAME` | optional | Reddit account that will post. If set without the OAuth pair, used purely as the User-Agent identifier and for the admin "your account stats" card. |
+| `REDDIT_PASSWORD` | optional | Account password. Required only for OAuth mode. |
+
+The cron uses OAuth automatically when all four `REDDIT_*` vars are set; otherwise it falls back to public JSON endpoints. The public endpoint path is slightly less durable — Reddit can throttle/block unauthenticated reads at any time — but works fine at our volume.
+
+Per-channel tuning (scoring floors, post limits, auto-disable thresholds, subreddit / keyword lists) lives in the database and is editable in the admin UI under **Outreach → Reddit → Settings**.
+
+### CLI Flags
+
+```bash
+php reddit_monitor.php             # Full pipeline
+php reddit_monitor.php --dry-run   # Log what would happen; don't write threads/drafts
+php reddit_monitor.php --verbose   # Stream progress to stdout
+```
+
+### Logs
+
+A lock file (`/cron/logs/reddit_monitor.lock`) prevents overlapping runs.
+
+### Manual Trigger
+
+The admin Reddit → Threads tab has a **"Run discovery now"** button that triggers this cron in the background.
+
+---
+
+## 10. Reddit Status Check
+
+**Script:** `cron/reddit_status_check.php`
+**Schedule:** Every 2 hours
+
+```bash
+0 */2 * * * /usr/bin/php /home/argorobots/public_html/cron/reddit_status_check.php
+```
+
+### What It Does
+
+For each thread marked `replied`, re-checks the posted Reddit comment via the Reddit API on a staggered schedule (30min / 2h / 6h / 24h / 72h after posting). Classifies the reply as `live`, `removed`, `removed_or_shadowbanned`, or `deleted_by_user`, captures upvote + reply engagement, and rolls up per-subreddit removal rates. Applies the auto-disable rule: any subreddit with ≥ N replies in the last 30 days and ≥ X% removal rate is automatically removed from the watchlist (N and X configurable in admin Settings).
+
+Idempotent — each row tracks its own check count and last-checked timestamp; the cron never over-checks. After 5 checks, a reply's status is treated as final and dropped from the worklist.
+
+### Logs
+
+A lock file (`/cron/logs/reddit_status_check.lock`) prevents overlapping runs.

--- a/statistics.php
+++ b/statistics.php
@@ -130,7 +130,28 @@ function track_event($event_type, $event_data = '')
  */
 function track_page_view($page)
 {
-    return track_event('page_view', $page);
+    $result = track_event('page_view', $page);
+    // Also emit a separate 'reddit_referrer' event if this visit came from
+    // a Reddit URL. Used by the admin Reddit dashboard to count profile-link
+    // clicks (the only Reddit traffic browsers expose a referrer for).
+    track_reddit_referrer_if_present($page);
+    return $result;
+}
+
+/**
+ * If the inbound request carries a reddit.com Referer header, emit a
+ * 'reddit_referrer' statistics event. Called from track_page_view().
+ * Same one-per-IP-per-day dedup behaviour as track_event() since it
+ * piggybacks on that function.
+ */
+function track_reddit_referrer_if_present($page)
+{
+    $referrer = $_SERVER['HTTP_REFERER'] ?? '';
+    if ($referrer === '') return;
+    if (!preg_match('#^https?://(www\.|old\.|new\.|m\.|i\.)?reddit\.com/?#i', $referrer)) return;
+    // event_data carries the inbound page + a hash of the referrer so we can
+    // see roughly where they landed; we don't store the full referring URL.
+    track_event('reddit_referrer', $page);
 }
 
 /**

--- a/statistics.php
+++ b/statistics.php
@@ -149,8 +149,9 @@ function track_reddit_referrer_if_present($page)
     $referrer = $_SERVER['HTTP_REFERER'] ?? '';
     if ($referrer === '') return;
     if (!preg_match('#^https?://(www\.|old\.|new\.|m\.|i\.)?reddit\.com/?#i', $referrer)) return;
-    // event_data carries the inbound page + a hash of the referrer so we can
-    // see roughly where they landed; we don't store the full referring URL.
+    // event_data is the inbound page (the landing URL the Reddit visitor hit).
+    // We deliberately don't store the referrer itself, since it adds little
+    // beyond "reddit.com" and risks logging tracking params from share links.
     track_event('reddit_referrer', $page);
 }
 


### PR DESCRIPTION
## Summary

- Adds a Reddit outreach channel alongside the existing email outreach: new Email | Reddit channel-tab split in `admin/outreach/`, with all five existing email sub-tabs preserved.
- Reddit pipeline runs daily (and on-demand) — pulls subreddit /new + keyword searches via Reddit's public RSS endpoints (auto-upgrades to OAuth when env vars are configured), runs a neutral AI relevance check (Gemini), and hybrid-drafts replies (pre-drafts high-confidence threads, defers borderline ones to on-demand).
- Manual-posting only by design: Mark Replied modal requires the comment permalink, then an every-2h status-check cron classifies survival (live / removed / shadowbanned / deleted) and rolls up per-subreddit removal rates with auto-disable.
- Daily/weekly post-limit safety meter, live progress banner with current-step polling, regenerate-with-feedback flow, and few-shot learning that folds the founder's recent `not_fit` / `replied` labels into the AI relevance prompt.
- Includes one unrelated commit: `feat(admin/referral-links): landing-page breakdown in funnel` (committed separately).

## Required manual steps after merge

1. **Run the new schema** in HeidiSQL — four new tables (`reddit_threads`, `reddit_subreddits`, `reddit_keywords`, `reddit_settings`). All `CREATE TABLE IF NOT EXISTS` + `INSERT IGNORE`, so safe to re-run.
2. **Configure cron** on the server:
   ```cron
   0 8 * * *   /usr/bin/php /home/argorobots/public_html/cron/reddit_monitor.php
   0 */2 * * * /usr/bin/php /home/argorobots/public_html/cron/reddit_status_check.php
   ```
3. **Set `REDDIT_USERNAME` in .env** (account name only). The other `REDDIT_*` vars are optional — if blank, the system uses Reddit's public RSS endpoints (no app/OAuth needed). When the Reddit account has aged enough to clear the Responsible Builder Policy gate, fill them in and the code automatically upgrades to OAuth.
4. **Put `https://argorobots.com` in the Reddit profile bio** — the only path where browser referrer headers identify Reddit-sourced visits.

## Test plan

- [ ] Schema runs cleanly on the local dev DB (idempotent)
- [ ] Admin → Outreach loads with no regressions on existing Email tabs (Discovery / Leads / A-B Tests / Follow-ups / Settings)
- [ ] Reddit channel tab + sub-tabs render
- [ ] Reddit → Settings: subreddit + keyword CRUD works (add / toggle / delete)
- [ ] Reddit → Threads: "Run discovery now" shows the live progress banner, polling updates every 2s, threads populate when done
- [ ] Thread detail modal: draft renders, edit + save works, regenerate (with and without feedback) works, copy button shows "Copied" feedback
- [ ] Mark Replied modal: rejects invalid permalinks, requires the override checkbox when at the daily/weekly limit
- [ ] Status-check cron classifies a posted reply within 30 min of marking it replied
- [ ] Dark mode: all Reddit-pane text is readable; links are blue-400 (not blue-700)

🤖 Generated with [Claude Code](https://claude.com/claude-code)