### PR TITLE
ci(deploy): include all commits in incremental deploy diff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,32 +21,64 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # Full history so we can diff against the previous branch tip even
+          # when a push contains many commits. fetch-depth: 2 was only enough
+          # to diff the single most recent commit, silently dropping earlier
+          # commits in the same push from the incremental deploy.
+          fetch-depth: 0
 
       # Compute mode + composer_changed up front so later steps can short-circuit.
       # Pure git diff — no composer or PHP needed yet.
+      #
+      # Diff base resolution:
+      #   - workflow_dispatch + full_deploy=true  → full mirror
+      #   - push event with valid before-SHA      → BASE=before-SHA (covers ALL
+      #     commits in the push, not just the latest one)
+      #   - push event with zero before-SHA       → first push to branch, full
+      #   - push event with unreachable before    → force-push, full (safe)
+      #   - workflow_dispatch + full_deploy=false → BASE=HEAD~1 (legacy behavior)
+      #   - anything else / HEAD~1 missing        → full
       - name: Determine changed files
         id: changes
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           FULL_DEPLOY="${{ github.event.inputs.full_deploy }}"
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          BASE=""
 
           if [ "$FULL_DEPLOY" = "true" ]; then
-            echo "mode=full" >> "$GITHUB_OUTPUT"
-            echo "composer_changed=true" >> "$GITHUB_OUTPUT"
-          elif ! git rev-parse HEAD~1 >/dev/null 2>&1; then
-            echo "First commit detected, doing full deploy"
+            echo "Full deploy forced via workflow_dispatch input"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "$ZERO_SHA" ]; then
+              echo "First push to branch (no before-SHA), doing full deploy"
+            elif ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+              echo "before-SHA $BEFORE_SHA not reachable (force-push?), doing full deploy"
+            else
+              BASE="$BEFORE_SHA"
+              echo "Incremental diff from $BASE..HEAD (covers all commits in this push)"
+            fi
+          elif git rev-parse HEAD~1 >/dev/null 2>&1; then
+            BASE="HEAD~1"
+            echo "Manual dispatch (full_deploy=false), incremental from HEAD~1"
+          else
+            echo "First commit / unable to determine range, doing full deploy"
+          fi
+
+          if [ -z "$BASE" ]; then
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "composer_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mode=incremental" >> "$GITHUB_OUTPUT"
 
             # Files that were added, copied, modified, or renamed
-            git diff --name-only --diff-filter=ACMR HEAD~1 HEAD > /tmp/changed_files.txt || true
+            git diff --name-only --diff-filter=ACMR "$BASE" HEAD > /tmp/changed_files.txt || true
             # Files that were deleted
-            git diff --name-only --diff-filter=D HEAD~1 HEAD > /tmp/deleted_files.txt || true
+            git diff --name-only --diff-filter=D "$BASE" HEAD > /tmp/deleted_files.txt || true
 
             # Check if composer files changed (need to rebuild + re-upload vendor/)
-            if git diff --name-only HEAD~1 HEAD | grep -qE '^composer\.(json|lock)$'; then
+            if git diff --name-only "$BASE" HEAD | grep -qE '^composer\.(json|lock)$'; then
               echo "composer_changed=true" >> "$GITHUB_OUTPUT"
             else
               echo "composer_changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Switch incremental deploy diff from `HEAD~1..HEAD` to `github.event.before..HEAD` so a push containing multiple commits deploys **all** changed files, not just the last commit's
- Bump `actions/checkout` `fetch-depth` from 2 to 0 so the older commits in a multi-commit push are reachable for the diff
- Falls back to a full deploy when the before-SHA is missing (first push to a branch) or unreachable (force-push), and preserves the existing `HEAD~1` behavior for `workflow_dispatch + full_deploy=false`

## Why

When you push multiple commits at once, GitHub fires a single `push` event. The old workflow only diffed the most recent commit against its parent, so files changed in any earlier commit of the same push were silently skipped by the incremental upload. Demonstrated locally with the 3 commits just landed on main: old logic = 2 files, new logic = 12 files.

## Test plan

- [ ] Merge this PR. Workflow runs against this single commit — should hit the `push event with valid before-SHA` path and incrementally deploy `.github/workflows/deploy.yml` (which is excluded server-side, so effectively nothing). Confirm "Determine changed files" step prints `Incremental diff from <SHA>..HEAD (covers all commits in this push)`.
- [ ] After merge, manually run the workflow with `full_deploy=true` once to backfill any files that were dropped from the previous (buggy) multi-commit push of `eed86273..382dadab`.
- [ ] Next time multiple commits are pushed together, confirm the deploy log lists files from every commit in the push, not just the last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)