### PR TITLE
Serve source survey options from config JSON

### DIFF
--- a/api/survey-options.php
+++ b/api/survey-options.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Source Survey Options Endpoint
+ *
+ * GET /api/survey-options.php
+ *
+ * Returns the option list shown in the desktop app's post-onboarding
+ * "Where did you hear about Argo Books?" survey. Options are defined in
+ * config/survey-options.json so a new option (e.g. a new platform) can be
+ * added without releasing a new app version.
+ *
+ * The app falls back to a bundled default list when this endpoint is
+ * unreachable or returns a non-2xx.
+ *
+ * Response (200):
+ *   {
+ *     "options": [
+ *       { "key": "google", "label": "Google" },
+ *       ...
+ *       { "key": "other", "label": "Other", "freeform": true }
+ *     ]
+ *   }
+ */
+
+header('Content-Type: application/json');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+require_once __DIR__ . '/../config/survey_options.php';
+
+// Allow brief client/proxy caching; option changes propagate within minutes.
+header('Cache-Control: public, max-age=300');
+echo json_encode(['options' => get_survey_options()]);

--- a/api/survey-options.php
+++ b/api/survey-options.php
@@ -32,6 +32,15 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'GET') {
 
 require_once __DIR__ . '/../config/survey_options.php';
 
+$options = get_survey_options();
+if ($options === null) {
+    // JSON missing/malformed. Return an error (not a partial list) so the app
+    // falls back to its own bundled default list, the single offline fallback.
+    http_response_code(500);
+    echo json_encode(['error' => 'Options unavailable']);
+    exit;
+}
+
 // Allow brief client/proxy caching; option changes propagate within minutes.
 header('Cache-Control: public, max-age=300');
-echo json_encode(['options' => get_survey_options()]);
+echo json_encode(['options' => $options]);

--- a/api/track-app-event.php
+++ b/api/track-app-event.php
@@ -73,7 +73,16 @@ if ($event_type === 'signup_survey') {
     // reads), so adding a survey option needs only that one file edit.
     require_once __DIR__ . '/../config/survey_options.php';
     $allowed = get_survey_option_keys();
-    if (!in_array($answer, $allowed, true)) {
+    if ($allowed === null) {
+        // The options JSON is unavailable (broken deploy). The app is serving its
+        // own bundled fallback list, so validate leniently rather than rejecting
+        // every answer and silently losing survey responses during the outage.
+        if (!preg_match('/^[a-z]{3,30}$/', $answer)) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Invalid answer']);
+            exit;
+        }
+    } elseif (!in_array($answer, $allowed, true)) {
         http_response_code(400);
         echo json_encode(['success' => false, 'error' => 'Invalid answer']);
         exit;
@@ -86,9 +95,14 @@ if ($event_type === 'signup_survey') {
 
     // Freeform text accompanies any option flagged freeform in the JSON (today
     // just "other"). Trim, cap at 200 chars, strip control characters so it
-    // stores cleanly. Ignore for non-freeform answers.
+    // stores cleanly. Ignore for non-freeform answers. When the JSON is
+    // unavailable, fall back to the conventional "other" freeform key.
+    $freeform_keys = get_survey_freeform_keys();
+    $is_freeform = $freeform_keys === null
+        ? ($answer === 'other')
+        : in_array($answer, $freeform_keys, true);
     $other_text = null;
-    if (in_array($answer, get_survey_freeform_keys(), true)) {
+    if ($is_freeform) {
         $raw_other = trim((string)($data['other_text'] ?? ''));
         if ($raw_other === '') {
             http_response_code(400);

--- a/api/track-app-event.php
+++ b/api/track-app-event.php
@@ -77,7 +77,8 @@ if ($event_type === 'signup_survey') {
         // The options JSON is unavailable (broken deploy). The app is serving its
         // own bundled fallback list, so validate leniently rather than rejecting
         // every answer and silently losing survey responses during the outage.
-        if (!preg_match('/^[a-z]{3,30}$/', $answer)) {
+        // Use the same key format as the JSON path so degraded mode stays consistent.
+        if (!preg_match(SURVEY_KEY_PATTERN, $answer)) {
             http_response_code(400);
             echo json_encode(['success' => false, 'error' => 'Invalid answer']);
             exit;

--- a/api/track-app-event.php
+++ b/api/track-app-event.php
@@ -69,7 +69,10 @@ if (!preg_match('/^[a-z]{3,8}$/', $platform)) {
 // funnel's source of truth).
 if ($event_type === 'signup_survey') {
     $answer = strtolower((string)($data['answer'] ?? ''));
-    $allowed = ['google', 'bing', 'youtube', 'reddit', 'friend', 'email', 'other'];
+    // Valid answers come from config/survey-options.json (same source the app
+    // reads), so adding a survey option needs only that one file edit.
+    require_once __DIR__ . '/../config/survey_options.php';
+    $allowed = get_survey_option_keys();
     if (!in_array($answer, $allowed, true)) {
         http_response_code(400);
         echo json_encode(['success' => false, 'error' => 'Invalid answer']);
@@ -81,10 +84,11 @@ if ($event_type === 'signup_survey') {
         exit;
     }
 
-    // Freeform text accompanies the "other" answer. Trim, cap at 200 chars,
-    // strip control characters so it stores cleanly. Ignore for non-other answers.
+    // Freeform text accompanies any option flagged freeform in the JSON (today
+    // just "other"). Trim, cap at 200 chars, strip control characters so it
+    // stores cleanly. Ignore for non-freeform answers.
     $other_text = null;
-    if ($answer === 'other') {
+    if (in_array($answer, get_survey_freeform_keys(), true)) {
         $raw_other = trim((string)($data['other_text'] ?? ''));
         if ($raw_other === '') {
             http_response_code(400);

--- a/config/survey-options.json
+++ b/config/survey-options.json
@@ -1,0 +1,13 @@
+{
+    "options": [
+        { "key": "google",      "label": "Google" },
+        { "key": "bing",        "label": "Bing" },
+        { "key": "youtube",     "label": "YouTube" },
+        { "key": "reddit",      "label": "Reddit" },
+        { "key": "friend",      "label": "A friend" },
+        { "key": "email",       "label": "Email" },
+        { "key": "capterra",    "label": "Capterra" },
+        { "key": "producthunt", "label": "Product Hunt" },
+        { "key": "other",       "label": "Other", "freeform": true }
+    ]
+}

--- a/config/survey_options.php
+++ b/config/survey_options.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Source Survey Options Configuration
+ *
+ * Single source of truth for the desktop app's post-onboarding
+ * "Where did you hear about Argo Books?" survey options. Both the app-facing
+ * endpoint (api/survey-options.php) and the answer receiver
+ * (api/track-app-event.php) read from here, so adding/removing an option is a
+ * single edit to config/survey-options.json with no other code changes.
+ *
+ * Options live in config/survey-options.json (data, no PHP). This file provides
+ * accessors with a hardcoded fallback so the survey keeps working if the JSON
+ * is missing or malformed.
+ */
+
+/**
+ * Default options, used when survey-options.json cannot be read or parsed.
+ * Keys must stay in sync with the app's bundled SourceSurveyOptionsService.DefaultOptions.
+ *
+ * @return array<int, array{key:string,label:string,freeform?:bool}>
+ */
+function _survey_default_options() {
+    return [
+        ['key' => 'google',      'label' => 'Google'],
+        ['key' => 'bing',        'label' => 'Bing'],
+        ['key' => 'youtube',     'label' => 'YouTube'],
+        ['key' => 'reddit',      'label' => 'Reddit'],
+        ['key' => 'friend',      'label' => 'A friend'],
+        ['key' => 'email',       'label' => 'Email'],
+        ['key' => 'capterra',    'label' => 'Capterra'],
+        ['key' => 'producthunt', 'label' => 'Product Hunt'],
+        ['key' => 'other',       'label' => 'Other', 'freeform' => true],
+    ];
+}
+
+/**
+ * Returns the survey options as an array of {key, label, freeform?} maps.
+ * Reads config/survey-options.json; falls back to defaults on any failure.
+ * Result is cached per request.
+ *
+ * @return array<int, array{key:string,label:string,freeform?:bool}>
+ */
+function get_survey_options() {
+    static $options = null;
+    if ($options !== null) {
+        return $options;
+    }
+
+    $options = _survey_default_options();
+
+    $json = @file_get_contents(__DIR__ . '/survey-options.json');
+    if ($json !== false) {
+        $data = json_decode($json, true);
+        if (is_array($data) && isset($data['options']) && is_array($data['options'])) {
+            $parsed = [];
+            foreach ($data['options'] as $o) {
+                if (!is_array($o) || empty($o['key']) || !isset($o['label'])) {
+                    continue;
+                }
+                $entry = ['key' => (string)$o['key'], 'label' => (string)$o['label']];
+                if (!empty($o['freeform'])) {
+                    $entry['freeform'] = true;
+                }
+                $parsed[] = $entry;
+            }
+            if (count($parsed) > 0) {
+                $options = $parsed;
+            }
+        }
+    }
+
+    return $options;
+}
+
+/**
+ * Returns the set of valid answer keys (lowercased) for server-side validation.
+ *
+ * @return string[]
+ */
+function get_survey_option_keys() {
+    $keys = [];
+    foreach (get_survey_options() as $o) {
+        $keys[] = strtolower($o['key']);
+    }
+    return $keys;
+}
+
+/**
+ * Returns the set of option keys (lowercased) that carry freeform text.
+ *
+ * @return string[]
+ */
+function get_survey_freeform_keys() {
+    $keys = [];
+    foreach (get_survey_options() as $o) {
+        if (!empty($o['freeform'])) {
+            $keys[] = strtolower($o['key']);
+        }
+    }
+    return $keys;
+}

--- a/config/survey_options.php
+++ b/config/survey_options.php
@@ -8,45 +8,26 @@
  * (api/track-app-event.php) read from here, so adding/removing an option is a
  * single edit to config/survey-options.json with no other code changes.
  *
- * Options live in config/survey-options.json (data, no PHP). This file provides
- * accessors with a hardcoded fallback so the survey keeps working if the JSON
- * is missing or malformed.
+ * There is intentionally NO hardcoded fallback list here. The desktop app ships
+ * its own bundled default list and uses it whenever this endpoint is unreachable
+ * or returns a non-2xx, so the app is the single source of the offline fallback.
+ * If the JSON cannot be read, accessors return null and callers degrade
+ * accordingly (the options endpoint 500s; the receiver validates leniently).
  */
 
 /**
- * Default options, used when survey-options.json cannot be read or parsed.
- * Keys must stay in sync with the app's bundled SourceSurveyOptionsService.DefaultOptions.
+ * Returns the survey options as an array of {key, label, freeform?} maps, or
+ * null if config/survey-options.json is missing/malformed. Cached per request.
  *
- * @return array<int, array{key:string,label:string,freeform?:bool}>
- */
-function _survey_default_options() {
-    return [
-        ['key' => 'google',      'label' => 'Google'],
-        ['key' => 'bing',        'label' => 'Bing'],
-        ['key' => 'youtube',     'label' => 'YouTube'],
-        ['key' => 'reddit',      'label' => 'Reddit'],
-        ['key' => 'friend',      'label' => 'A friend'],
-        ['key' => 'email',       'label' => 'Email'],
-        ['key' => 'capterra',    'label' => 'Capterra'],
-        ['key' => 'producthunt', 'label' => 'Product Hunt'],
-        ['key' => 'other',       'label' => 'Other', 'freeform' => true],
-    ];
-}
-
-/**
- * Returns the survey options as an array of {key, label, freeform?} maps.
- * Reads config/survey-options.json; falls back to defaults on any failure.
- * Result is cached per request.
- *
- * @return array<int, array{key:string,label:string,freeform?:bool}>
+ * @return array<int, array{key:string,label:string,freeform?:bool}>|null
  */
 function get_survey_options() {
-    static $options = null;
-    if ($options !== null) {
+    static $options = false; // false = not yet computed (null is a valid result)
+    if ($options !== false) {
         return $options;
     }
 
-    $options = _survey_default_options();
+    $options = null;
 
     $json = @file_get_contents(__DIR__ . '/survey-options.json');
     if ($json !== false) {
@@ -73,26 +54,35 @@ function get_survey_options() {
 }
 
 /**
- * Returns the set of valid answer keys (lowercased) for server-side validation.
+ * Returns the valid answer keys (lowercased), or null if options are unavailable.
  *
- * @return string[]
+ * @return string[]|null
  */
 function get_survey_option_keys() {
+    $opts = get_survey_options();
+    if ($opts === null) {
+        return null;
+    }
     $keys = [];
-    foreach (get_survey_options() as $o) {
+    foreach ($opts as $o) {
         $keys[] = strtolower($o['key']);
     }
     return $keys;
 }
 
 /**
- * Returns the set of option keys (lowercased) that carry freeform text.
+ * Returns the option keys (lowercased) that carry freeform text, or null if
+ * options are unavailable.
  *
- * @return string[]
+ * @return string[]|null
  */
 function get_survey_freeform_keys() {
+    $opts = get_survey_options();
+    if ($opts === null) {
+        return null;
+    }
     $keys = [];
-    foreach (get_survey_options() as $o) {
+    foreach ($opts as $o) {
         if (!empty($o['freeform'])) {
             $keys[] = strtolower($o['key']);
         }

--- a/config/survey_options.php
+++ b/config/survey_options.php
@@ -16,6 +16,13 @@
  */
 
 /**
+ * Allowed format for an option key, shared by JSON parsing and the receiver's
+ * degraded-mode validation so both stay consistent. Lowercase letters, digits,
+ * underscores and hyphens; 2-40 chars.
+ */
+const SURVEY_KEY_PATTERN = '/^[a-z0-9_-]{2,40}$/';
+
+/**
  * Returns the survey options as an array of {key, label, freeform?} maps, or
  * null if config/survey-options.json is missing/malformed. Cached per request.
  *
@@ -30,24 +37,42 @@ function get_survey_options() {
     $options = null;
 
     $json = @file_get_contents(__DIR__ . '/survey-options.json');
-    if ($json !== false) {
-        $data = json_decode($json, true);
-        if (is_array($data) && isset($data['options']) && is_array($data['options'])) {
-            $parsed = [];
-            foreach ($data['options'] as $o) {
-                if (!is_array($o) || empty($o['key']) || !isset($o['label'])) {
-                    continue;
-                }
-                $entry = ['key' => (string)$o['key'], 'label' => (string)$o['label']];
-                if (!empty($o['freeform'])) {
-                    $entry['freeform'] = true;
-                }
-                $parsed[] = $entry;
-            }
-            if (count($parsed) > 0) {
-                $options = $parsed;
-            }
+    if ($json === false) {
+        // Log so a broken deploy (missing JSON) is noticeable rather than silently
+        // degrading to the app's bundled defaults + lenient server validation.
+        error_log('survey_options: unable to read config/survey-options.json');
+        return $options;
+    }
+
+    $data = json_decode($json, true);
+    if (!is_array($data) || !isset($data['options']) || !is_array($data['options'])) {
+        error_log('survey_options: config/survey-options.json is missing or malformed');
+        return $options;
+    }
+
+    $parsed = [];
+    foreach ($data['options'] as $o) {
+        if (!is_array($o) || empty($o['key']) || !isset($o['label'])) {
+            continue;
         }
+        // Normalize and validate the key so a config typo fails fast (and visibly)
+        // instead of producing a key the app can never match.
+        $key = strtolower(trim((string)$o['key']));
+        if (!preg_match(SURVEY_KEY_PATTERN, $key)) {
+            error_log('survey_options: skipping option with invalid key: ' . json_encode($o['key']));
+            continue;
+        }
+        $entry = ['key' => $key, 'label' => (string)$o['label']];
+        if (!empty($o['freeform'])) {
+            $entry['freeform'] = true;
+        }
+        $parsed[] = $entry;
+    }
+
+    if (count($parsed) > 0) {
+        $options = $parsed;
+    } else {
+        error_log('survey_options: config/survey-options.json contained no valid options');
     }
 
     return $options;


### PR DESCRIPTION
## Summary
The desktop app's post-onboarding source survey options were hardcoded in the app, and `track-app-event.php` validated submitted answers against a hardcoded whitelist here. Adding an option (e.g. a newly launched platform) therefore needed both an app release and a server code edit. This makes the option list a single editable JSON file that drives both display and validation.

## Changes
- Add `config/survey-options.json`: the editable option list (current 7 options plus Capterra and Product Hunt). **Editing this file is the entire workflow for adding/removing a survey option.**
- Add `config/survey_options.php`: shared accessor (`get_survey_options`, `get_survey_option_keys`, `get_survey_freeform_keys`). It carries **no** hardcoded fallback list: on a missing/malformed JSON the accessors return null and log via `error_log`. Keys are normalized and validated against a shared `SURVEY_KEY_PATTERN`.
- Add `GET /api/survey-options.php`: returns the list for the app to fetch; returns HTTP 500 if the JSON is unavailable so the app falls back to its own bundled defaults (the single source of the offline fallback).
- `track-app-event.php`: validate the submitted answer and detect freeform options from the JSON. When the JSON is unavailable it validates leniently using the same `SURVEY_KEY_PATTERN` and treats `other` as freeform, so submissions are still recorded during an outage.

## Notes
- Pairs with the desktop PR (ArgoRobots/Argo-Books-Avalonia#374).
- No DB schema change: `source_survey_answer` is already free text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)