### PR TITLE
Load .env in pricing API so price overrides apply

### DIFF
--- a/api/pricing/plans.php
+++ b/api/pricing/plans.php
@@ -9,6 +9,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
+// Load environment variables so price overrides (PREMIUM_MONTHLY_PRICE, etc.) are
+// applied. get_pricing_config() reads $_ENV, which is only populated once the .env
+// is loaded; without this the endpoint silently serves the default prices.
+require_once __DIR__ . '/../../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->safeLoad();
+
 require_once __DIR__ . '/../../config/pricing.php';
 
 $pricing = get_pricing_config();


### PR DESCRIPTION
api/pricing/plans.php read pricing via get_pricing_config(), which pulls values from $_ENV, but the endpoint never loaded the .env file (unlike track-app-event.php, exchange-rates.php, and the pricing web page via db_connect.php). With $_ENV unpopulated, _pricing_parse_env() fell back to the $10 default, so the app's upgrade modal showed $10 even when PREMIUM_MONTHLY_PRICE was set to 15. Load the environment before reading the config, matching the other endpoints.