### PR TITLE
Desktop crash reporting + data-logs reorg

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -53,6 +53,10 @@ Deny from all
     RewriteRule ^database/ - [F,L]
     RewriteRule ^vendor/ - [F,L]
     RewriteRule ^cron/logs/ - [F,L]
+    # Stored telemetry + crash reports are read only by the authenticated admin
+    # pages (via the filesystem), never served as static files. The endpoints
+    # write here over the filesystem too, so blocking web access is safe.
+    RewriteRule ^admin/data-logs/ - [F,L]
 </IfModule>
 
 # Prevent directory listing
@@ -278,6 +282,9 @@ php_value upload_max_filesize 10M
 
     # Telemetry data upload
     RewriteRule ^api/data/upload/?$ api/data/upload.php [L,QSA]
+
+    # Desktop app crash reports
+    RewriteRule ^api/data/crash/?$ api/data/crash.php [L,QSA]
 
     # --- Avalonia (cross-platform) download routes ---
 

--- a/admin/app-stats/index.php
+++ b/admin/app-stats/index.php
@@ -12,7 +12,10 @@ if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== tru
 $page_title = "Argo Books Statistics";
 $page_description = "View and analyze anonymous user data with geo-location insights from the Argo Books application";
 
-$dataDir = '../data-logs/';
+// Telemetry files now live in data-logs/telemetry/. The legacy data-logs/ root
+// is still read during the transition so files not yet moved keep showing.
+$dataDir = '../data-logs/telemetry/';
+$legacyDataDir = '../data-logs/';
 $errorMessage = '';
 
 // Tier filter: 'all' (default), 'free', 'premium'
@@ -145,11 +148,24 @@ function processEvent($event, $sourceFile, $sessionMeta = []) {
     }
 }
 
-if (!is_dir($dataDir)) {
+$dataDirs = array_values(array_filter([$dataDir, $legacyDataDir], 'is_dir'));
+if (empty($dataDirs)) {
     $errorMessage = "Directory 'data-logs/' does not exist.";
 } else {
-    $dataFiles = glob($dataDir . '*.json');
-    if (!$dataFiles || count($dataFiles) === 0) {
+    // Read from both the new telemetry/ folder and the legacy root, de-duping by
+    // filename so a file present in both places is only counted once.
+    $dataFiles = [];
+    $seenNames = [];
+    foreach ($dataDirs as $dir) {
+        foreach (glob($dir . '*.json') ?: [] as $f) {
+            $name = basename($f);
+            if (!isset($seenNames[$name])) {
+                $seenNames[$name] = true;
+                $dataFiles[] = $f;
+            }
+        }
+    }
+    if (count($dataFiles) === 0) {
         $errorMessage = "No anonymous data files found.";
     } else {
         // Sort files by modification time (newest first) for file info display
@@ -514,7 +530,7 @@ include __DIR__ . '/../admin_header.php';
         <div class="no-data">
             <h3>No Data Available</h3>
             <p><?= htmlspecialchars($errorMessage) ?></p>
-            <p><small>Make sure the data directory exists and contains valid JSON files at: <code>admin/data-logs/</code></small></p>
+            <p><small>Make sure the data directory exists and contains valid JSON files at: <code>admin/data-logs/telemetry/</code></small></p>
         </div>
     <?php elseif (!$currentViewHasData): ?>
         <div class="no-data">
@@ -523,7 +539,7 @@ include __DIR__ . '/../admin_header.php';
                 <p>No <?= htmlspecialchars($tierFilter) ?>-tier data has been collected yet. Switch to a different tier above.</p>
             <?php else: ?>
                 <p>No anonymous data has been collected yet. Data will appear here once users start using the application and uploading their analytics.</p>
-                <p><small>Data files are automatically uploaded to: <code>admin/data-logs/</code></small></p>
+                <p><small>Data files are automatically uploaded to: <code>admin/data-logs/telemetry/</code></small></p>
             <?php endif; ?>
         </div>
     <?php else: ?>
@@ -555,6 +571,7 @@ include __DIR__ . '/../admin_header.php';
                 <button class="section-tab" data-tab="errors">Errors</button>
                 <button class="section-tab" data-tab="usage">Usage</button>
                 <button class="section-tab" data-tab="api">API Usage</button>
+                <button class="section-tab" data-tab="crashes">Crashes</button>
             </div>
 
             <!-- Active Users Tab -->
@@ -873,6 +890,11 @@ include __DIR__ . '/../admin_header.php';
                         <canvas id="aiImportDurationByTypeChart"></canvas>
                     </div>
                 </div>
+            </div>
+
+            <!-- Crashes Tab -->
+            <div id="crashes" class="tab-content">
+                <?php include __DIR__ . '/../crashes-tab.php'; ?>
             </div>
 
         </div>

--- a/admin/crashes-tab.php
+++ b/admin/crashes-tab.php
@@ -1,0 +1,222 @@
+<?php
+// Crash Reports tab body, included by admin/app-stats/index.php inside the
+// #crashes tab. Admin auth + page chrome are handled by the host page; this
+// just reads desktop crash reports from admin/data-logs/crashes/ and renders
+// them grouped by exception signature. Reuses .stats-grid / .stat-card /
+// .section-title from the host page's styles.
+
+$crashDir = __DIR__ . '/data-logs/crashes';
+$crashFiles = is_dir($crashDir) ? (glob($crashDir . '/argo_crash_*.json') ?: []) : [];
+
+$crashGroups = [];
+$crashTotal = 0;
+$crashVersions = [];
+$crashDevices = [];
+
+foreach ($crashFiles as $crashFile) {
+    $raw = @file_get_contents($crashFile);
+    if ($raw === false) {
+        continue;
+    }
+    $data = json_decode($raw, true);
+    if (!is_array($data) || empty($data['crashes']) || !is_array($data['crashes'])) {
+        continue;
+    }
+
+    $meta = [
+        'appVersion' => (string) ($data['appVersion'] ?? 'unknown'),
+        'platform'   => (string) ($data['platform'] ?? 'Unknown'),
+        'country'    => $data['countryCode'] ?? null,
+        'authId'     => $data['authId'] ?? null,
+        'receivedAt' => $data['receivedAt'] ?? null,
+    ];
+    $crashVersions[$meta['appVersion']] = true;
+
+    foreach ($data['crashes'] as $c) {
+        if (!is_array($c)) {
+            continue;
+        }
+        $crashTotal++;
+        if ($meta['authId']) {
+            $crashDevices[$meta['authId']] = true;
+        }
+
+        $type = (string) ($c['exceptionType'] ?? 'UnknownException');
+        $source = (string) ($c['source'] ?? '');
+        $sig = $type . '|' . $source;
+        $ts = $c['timestamp'] ?? $meta['receivedAt'];
+
+        if (!isset($crashGroups[$sig])) {
+            $crashGroups[$sig] = [
+                'type' => $type, 'source' => $source, 'count' => 0,
+                'platforms' => [], 'versions' => [], 'devices' => [],
+                'first' => null, 'last' => null,
+                'sample' => null, 'sampleMeta' => [], 'sampleTs' => '', 'occurrences' => [],
+            ];
+        }
+
+        $crashGroups[$sig]['count']++;
+        $crashGroups[$sig]['platforms'][$meta['platform']] = true;
+        $crashGroups[$sig]['versions'][$meta['appVersion']] = true;
+        if ($meta['authId']) {
+            $crashGroups[$sig]['devices'][$meta['authId']] = true;
+        }
+        if ($ts !== null) {
+            if ($crashGroups[$sig]['first'] === null || $ts < $crashGroups[$sig]['first']) {
+                $crashGroups[$sig]['first'] = $ts;
+            }
+            if ($crashGroups[$sig]['last'] === null || $ts > $crashGroups[$sig]['last']) {
+                $crashGroups[$sig]['last'] = $ts;
+            }
+        }
+        if ($crashGroups[$sig]['sample'] === null || (string) $ts >= $crashGroups[$sig]['sampleTs']) {
+            $crashGroups[$sig]['sample'] = $c;
+            $crashGroups[$sig]['sampleMeta'] = $meta;
+            $crashGroups[$sig]['sampleTs'] = (string) $ts;
+        }
+        if (count($crashGroups[$sig]['occurrences']) < 30) {
+            $crashGroups[$sig]['occurrences'][] = [
+                'ts' => $ts, 'platform' => $meta['platform'],
+                'version' => $meta['appVersion'], 'country' => $meta['country'],
+            ];
+        }
+    }
+}
+
+uasort($crashGroups, fn ($a, $b) => $b['count'] <=> $a['count']);
+
+if (!function_exists('crash_fmt')) {
+    function crash_fmt(?string $ts): string
+    {
+        if (!$ts) {
+            return '-';
+        }
+        $t = strtotime($ts);
+        return $t ? date('M j, Y g:i A', $t) : htmlspecialchars($ts);
+    }
+}
+?>
+<style>
+.crash-group {
+    border: 1px solid var(--border-color); border-radius: 12px;
+    margin-bottom: 1rem; background: var(--background-color); overflow: hidden;
+}
+.crash-group > summary {
+    list-style: none; cursor: pointer; padding: 1rem 1.25rem;
+    display: flex; align-items: center; gap: 1rem;
+}
+.crash-group > summary::-webkit-details-marker { display: none; }
+.crash-group > summary:hover { background: var(--hover-color, rgba(127,127,127,0.06)); }
+.crash-count {
+    flex: 0 0 auto; min-width: 2.5rem; text-align: center;
+    font-weight: 700; font-size: 1.1rem; color: #fff;
+    background: var(--danger-color, #e5484d); border-radius: 8px; padding: 0.35rem 0.6rem;
+}
+.crash-sig { flex: 1 1 auto; min-width: 0; }
+.crash-sig .type { font-weight: 600; color: var(--text-color); word-break: break-all; }
+.crash-sig .loc { font-family: monospace; font-size: 0.85rem; color: var(--text-muted); margin-top: 0.15rem; }
+.crash-tags { flex: 0 0 auto; text-align: right; font-size: 0.78rem; color: var(--text-muted); }
+.crash-detail { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--border-color); }
+.crash-detail h4 { margin: 1.25rem 0 0.5rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); }
+.crash-detail pre {
+    background: var(--code-bg, rgba(127,127,127,0.08)); border: 1px solid var(--border-color);
+    border-radius: 8px; padding: 0.85rem 1rem; overflow-x: auto;
+    font-size: 0.82rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+}
+.crash-detail .msg { color: var(--text-color); }
+.breadcrumbs { list-style: none; margin: 0; padding: 0; font-family: monospace; font-size: 0.8rem; }
+.breadcrumbs li { padding: 0.2rem 0; border-bottom: 1px dashed var(--border-color); color: var(--text-muted); }
+.occ-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.occ-table th, .occ-table td { text-align: left; padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--border-color); }
+.occ-table th { color: var(--text-muted); font-weight: 600; }
+.crash-empty { text-align: center; padding: 3rem 1rem; color: var(--text-muted); }
+.crash-empty .big { font-size: 1.2rem; color: var(--text-color); margin-bottom: 0.5rem; }
+</style>
+
+<h2 class="section-title">Crash Reports</h2>
+<p style="color: var(--text-muted); margin-top: -0.5rem; margin-bottom: 1.5rem;">
+    Unhandled exceptions reported by the desktop app, grouped by where they happened.
+</p>
+
+<div class="stats-grid">
+    <div class="stat-card"><h3>Total Crashes</h3><div class="value"><?= number_format($crashTotal) ?></div></div>
+    <div class="stat-card"><h3>Distinct Crashes</h3><div class="value"><?= number_format(count($crashGroups)) ?></div></div>
+    <div class="stat-card"><h3>Affected Devices</h3><div class="value"><?= number_format(count($crashDevices)) ?></div></div>
+    <div class="stat-card"><h3>App Versions</h3><div class="value"><?= number_format(count($crashVersions)) ?></div></div>
+</div>
+
+<?php if (count($crashGroups) === 0): ?>
+    <div class="crash-empty">
+        <div class="big">No crashes reported &#127881;</div>
+        <div>Either nothing has crashed, or no reports have arrived yet.</div>
+    </div>
+<?php else: ?>
+    <?php foreach ($crashGroups as $g):
+        $sample = $g['sample'] ?? [];
+        $sampleMeta = $g['sampleMeta'] ?? [];
+    ?>
+    <details class="crash-group">
+        <summary>
+            <span class="crash-count"><?= number_format($g['count']) ?></span>
+            <span class="crash-sig">
+                <div class="type"><?= htmlspecialchars($g['type']) ?></div>
+                <?php if ($g['source'] !== ''): ?><div class="loc"><?= htmlspecialchars($g['source']) ?></div><?php endif; ?>
+            </span>
+            <span class="crash-tags">
+                <span><?= htmlspecialchars(implode(', ', array_keys($g['versions']))) ?></span><br>
+                <span><?= htmlspecialchars(implode(', ', array_keys($g['platforms']))) ?> &middot; <?= count($g['devices']) ?> device<?= count($g['devices']) === 1 ? '' : 's' ?></span><br>
+                <span>last <?= crash_fmt($g['last']) ?></span>
+            </span>
+        </summary>
+        <div class="crash-detail">
+            <?php if (!empty($sample['message'])): ?>
+                <h4>Message</h4>
+                <div class="msg"><?= htmlspecialchars($sample['message']) ?></div>
+            <?php endif; ?>
+
+            <?php if (!empty($sample['innerException'])): ?>
+                <h4>Inner Exception</h4>
+                <div class="msg"><?= htmlspecialchars($sample['innerException']) ?></div>
+            <?php endif; ?>
+
+            <h4>Where &amp; When (latest)</h4>
+            <div class="msg">
+                Handler: <?= htmlspecialchars($sample['handler'] ?? '-') ?> &middot;
+                <?= htmlspecialchars($sampleMeta['platform'] ?? '-') ?>
+                <?php if (!empty($sample['osVersion'])): ?> (<?= htmlspecialchars($sample['osVersion']) ?>)<?php endif; ?> &middot;
+                v<?= htmlspecialchars($sampleMeta['appVersion'] ?? '-') ?> &middot;
+                <?= crash_fmt($g['last']) ?>
+            </div>
+
+            <?php if (!empty($sample['stackTrace'])): ?>
+                <h4>Stack Trace</h4>
+                <pre><?= htmlspecialchars($sample['stackTrace']) ?></pre>
+            <?php endif; ?>
+
+            <?php if (!empty($sample['breadcrumbs']) && is_array($sample['breadcrumbs'])): ?>
+                <h4>Breadcrumbs (leading up to the crash)</h4>
+                <ul class="breadcrumbs">
+                    <?php foreach ($sample['breadcrumbs'] as $b): ?>
+                        <li><?= htmlspecialchars(is_scalar($b) ? (string) $b : json_encode($b)) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+
+            <h4>Occurrences (<?= $g['count'] ?> total, first <?= crash_fmt($g['first']) ?>)</h4>
+            <table class="occ-table">
+                <thead><tr><th>Time</th><th>Platform</th><th>Version</th><th>Country</th></tr></thead>
+                <tbody>
+                    <?php foreach ($g['occurrences'] as $o): ?>
+                        <tr>
+                            <td><?= crash_fmt($o['ts']) ?></td>
+                            <td><?= htmlspecialchars($o['platform']) ?></td>
+                            <td><?= htmlspecialchars($o['version']) ?></td>
+                            <td><?= htmlspecialchars($o['country'] ?? '-') ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </details>
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/admin/crashes-tab.php
+++ b/admin/crashes-tab.php
@@ -30,7 +30,6 @@ foreach ($crashFiles as $crashFile) {
         'authId'     => $data['authId'] ?? null,
         'receivedAt' => $data['receivedAt'] ?? null,
     ];
-    $crashVersions[$meta['appVersion']] = true;
 
     foreach ($data['crashes'] as $c) {
         if (!is_array($c)) {
@@ -40,6 +39,14 @@ foreach ($crashFiles as $crashFile) {
         if ($meta['authId']) {
             $crashDevices[$meta['authId']] = true;
         }
+
+        // Prefer the version/platform stamped into each crash at capture time,
+        // falling back to the upload's file-level values for older reports. This
+        // avoids attributing a crash to whatever version the app updated to
+        // before the report was uploaded on the next launch.
+        $cVersion = (string) ($c['appVersion'] ?? $meta['appVersion']);
+        $cPlatform = (string) ($c['platform'] ?? $meta['platform']);
+        $crashVersions[$cVersion] = true;
 
         $type = (string) ($c['exceptionType'] ?? 'UnknownException');
         $source = (string) ($c['source'] ?? '');
@@ -59,8 +66,8 @@ foreach ($crashFiles as $crashFile) {
         }
 
         $crashGroups[$sig]['count']++;
-        $crashGroups[$sig]['platforms'][$meta['platform']] = true;
-        $crashGroups[$sig]['versions'][$meta['appVersion']] = true;
+        $crashGroups[$sig]['platforms'][$cPlatform] = true;
+        $crashGroups[$sig]['versions'][$cVersion] = true;
         if ($meta['authId']) {
             $crashGroups[$sig]['devices'][$meta['authId']] = true;
         }
@@ -76,13 +83,13 @@ foreach ($crashFiles as $crashFile) {
         }
         if ($crashGroups[$sig]['sample'] === null || $tsEpoch >= $crashGroups[$sig]['sampleEpoch']) {
             $crashGroups[$sig]['sample'] = $c;
-            $crashGroups[$sig]['sampleMeta'] = $meta;
+            $crashGroups[$sig]['sampleMeta'] = ['platform' => $cPlatform, 'appVersion' => $cVersion, 'country' => $meta['country']];
             $crashGroups[$sig]['sampleEpoch'] = $tsEpoch;
         }
         if (count($crashGroups[$sig]['occurrences']) < 30) {
             $crashGroups[$sig]['occurrences'][] = [
-                'ts' => $ts, 'platform' => $meta['platform'],
-                'version' => $meta['appVersion'], 'country' => $meta['country'],
+                'ts' => $ts, 'platform' => $cPlatform,
+                'version' => $cVersion, 'country' => $meta['country'],
             ];
         }
     }

--- a/admin/crashes-tab.php
+++ b/admin/crashes-tab.php
@@ -45,13 +45,16 @@ foreach ($crashFiles as $crashFile) {
         $source = (string) ($c['source'] ?? '');
         $sig = $type . '|' . $source;
         $ts = $c['timestamp'] ?? $meta['receivedAt'];
+        // Compare on parsed epochs, not raw strings: reports use ISO 8601 while
+        // the receivedAt fallback is "Y-m-d H:i:s", which don't sort together.
+        $tsEpoch = $ts !== null ? (strtotime((string) $ts) ?: 0) : 0;
 
         if (!isset($crashGroups[$sig])) {
             $crashGroups[$sig] = [
                 'type' => $type, 'source' => $source, 'count' => 0,
                 'platforms' => [], 'versions' => [], 'devices' => [],
-                'first' => null, 'last' => null,
-                'sample' => null, 'sampleMeta' => [], 'sampleTs' => '', 'occurrences' => [],
+                'first' => null, 'last' => null, 'firstEpoch' => null, 'lastEpoch' => null,
+                'sample' => null, 'sampleMeta' => [], 'sampleEpoch' => -1, 'occurrences' => [],
             ];
         }
 
@@ -62,17 +65,19 @@ foreach ($crashFiles as $crashFile) {
             $crashGroups[$sig]['devices'][$meta['authId']] = true;
         }
         if ($ts !== null) {
-            if ($crashGroups[$sig]['first'] === null || $ts < $crashGroups[$sig]['first']) {
+            if ($crashGroups[$sig]['firstEpoch'] === null || $tsEpoch < $crashGroups[$sig]['firstEpoch']) {
+                $crashGroups[$sig]['firstEpoch'] = $tsEpoch;
                 $crashGroups[$sig]['first'] = $ts;
             }
-            if ($crashGroups[$sig]['last'] === null || $ts > $crashGroups[$sig]['last']) {
+            if ($crashGroups[$sig]['lastEpoch'] === null || $tsEpoch > $crashGroups[$sig]['lastEpoch']) {
+                $crashGroups[$sig]['lastEpoch'] = $tsEpoch;
                 $crashGroups[$sig]['last'] = $ts;
             }
         }
-        if ($crashGroups[$sig]['sample'] === null || (string) $ts >= $crashGroups[$sig]['sampleTs']) {
+        if ($crashGroups[$sig]['sample'] === null || $tsEpoch >= $crashGroups[$sig]['sampleEpoch']) {
             $crashGroups[$sig]['sample'] = $c;
             $crashGroups[$sig]['sampleMeta'] = $meta;
-            $crashGroups[$sig]['sampleTs'] = (string) $ts;
+            $crashGroups[$sig]['sampleEpoch'] = $tsEpoch;
         }
         if (count($crashGroups[$sig]['occurrences']) < 30) {
             $crashGroups[$sig]['occurrences'][] = [

--- a/api/data/crash.php
+++ b/api/data/crash.php
@@ -1,0 +1,299 @@
+<?php
+session_start();
+
+// Receives crash reports from the desktop app's CrashReporter. Mirrors the
+// security model of upload.php (device/license auth, per-tier rate limit, JSON
+// validation, file storage) but is intentionally self-contained so it can never
+// affect the working telemetry upload endpoint.
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../portal/portal-helper.php';      // authenticate_device_request / authenticate_license_request
+require_once __DIR__ . '/../../track_referral_event.php';   // lookup_country_for_ip()
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->load();
+
+header('X-Content-Type-Options: nosniff');
+header('X-Frame-Options: DENY');
+header('X-XSS-Protection: 1; mode=block');
+header('Content-Type: application/json');
+
+define('CRASH_DIR', __DIR__ . '/../../admin/data-logs/crashes');
+define('CRASH_MAX_SIZE_PREMIUM', 1 * 1024 * 1024);   // 1MB
+define('CRASH_MAX_SIZE_FREE', 256 * 1024);           // 256KB
+define('CRASH_ALLOWED_MIME', ['application/json', 'text/plain']);
+define('CRASH_MAX_PER_HOUR_PREMIUM', 60);
+define('CRASH_MAX_PER_HOUR_FREE', 20);
+// Coarse per-IP cap for free tier so rotating device IDs from one IP can't spam.
+define('CRASH_MAX_PER_HOUR_FREE_PER_IP', 120);
+
+/**
+ * Atomic check-and-bump on a single rate-limit bucket, held under an exclusive
+ * lock so two concurrent requests can't both pass a nearly-full bucket.
+ */
+function crashCheckBucket(string $bucketKey, int $maxPerHour): bool
+{
+    $rate_file = sys_get_temp_dir() . '/crash_rate_' . hash('sha256', $bucketKey);
+    $handle = fopen($rate_file, 'c+');
+    if (!$handle) {
+        return true; // fail open on local I/O trouble
+    }
+    if (!flock($handle, LOCK_EX)) {
+        fclose($handle);
+        return true;
+    }
+    try {
+        $content = stream_get_contents($handle);
+        $hits = json_decode($content ?: '[]', true) ?: [];
+        $now = time();
+        $hits = array_values(array_filter($hits, fn ($t) => ($now - $t) < 3600));
+        if (count($hits) >= $maxPerHour) {
+            return false;
+        }
+        $hits[] = $now;
+        ftruncate($handle, 0);
+        rewind($handle);
+        fwrite($handle, json_encode($hits));
+        fflush($handle);
+        return true;
+    } finally {
+        flock($handle, LOCK_UN);
+        fclose($handle);
+    }
+}
+
+function crashCheckRateLimit(string $authId, int $maxPerHour, ?int $ipMaxPerHour = null): bool
+{
+    $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    if (!crashCheckBucket($authId . '|' . $ip, $maxPerHour)) {
+        return false;
+    }
+    if ($ipMaxPerHour !== null && !crashCheckBucket('ip:' . $ip, $ipMaxPerHour)) {
+        return false;
+    }
+    return true;
+}
+
+/** Authenticate as Premium (license key) or Free (device ID). */
+function crashAuthenticate(): ?array
+{
+    $license = authenticate_license_request();
+    if ($license !== null) {
+        return ['tier' => 'premium', 'authId' => 'subscription:' . ($license['subscription_id'] ?? 'unknown')];
+    }
+    $deviceHash = authenticate_device_request();
+    if ($deviceHash !== null) {
+        return ['tier' => 'free', 'authId' => 'device:' . $deviceHash];
+    }
+    return null;
+}
+
+function crashLog(string $event, string $details = ''): void
+{
+    error_log(json_encode([
+        'timestamp' => date('Y-m-d H:i:s'),
+        'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+        'event' => 'crash_' . $event,
+        'details' => $details,
+    ]));
+}
+
+/** Reject non-JSON or content carrying obvious script-injection markers. */
+function crashValidateJson(string $content): bool
+{
+    json_decode($content);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        return false;
+    }
+    $dangerous = ['/<script[^>]*>/i', '/<iframe[^>]*>/i', '/javascript:/i', '/<\?php/i'];
+    foreach ($dangerous as $pattern) {
+        if (preg_match($pattern, $content)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Keep only the fields we expect on a crash report, with hard length caps so a
+ * malformed or oversized field can't bloat storage. Unknown fields are dropped.
+ */
+function crashSanitizeReport(array $r): array
+{
+    $str = fn ($v, int $max) => is_scalar($v) ? mb_substr((string) $v, 0, $max) : null;
+    $breadcrumbs = [];
+    if (isset($r['breadcrumbs']) && is_array($r['breadcrumbs'])) {
+        foreach (array_slice($r['breadcrumbs'], -25) as $b) {
+            $breadcrumbs[] = is_scalar($b) ? mb_substr((string) $b, 0, 500) : null;
+        }
+        $breadcrumbs = array_values(array_filter($breadcrumbs, fn ($b) => $b !== null));
+    }
+    return array_filter([
+        'dataId'        => $str($r['dataId'] ?? null, 64),
+        'timestamp'     => $str($r['timestamp'] ?? null, 40),
+        'handler'       => $str($r['handler'] ?? null, 40),
+        'exceptionType' => $str($r['exceptionType'] ?? null, 200),
+        'message'       => $str($r['message'] ?? null, 2000),
+        'source'        => $str($r['source'] ?? null, 300),
+        'stackTrace'    => $str($r['stackTrace'] ?? null, 8000),
+        'innerException' => $str($r['innerException'] ?? null, 2000),
+        'osVersion'     => $str($r['osVersion'] ?? null, 120),
+        'breadcrumbs'   => $breadcrumbs ?: null,
+    ], fn ($v) => $v !== null);
+}
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        http_response_code(405);
+        echo json_encode(['error' => 'Only POST method allowed']);
+        crashLog('invalid_method', $_SERVER['REQUEST_METHOD']);
+        exit;
+    }
+
+    $auth = crashAuthenticate();
+    if ($auth === null) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized']);
+        crashLog('invalid_auth');
+        exit;
+    }
+
+    $tier = $auth['tier'];
+    $authId = $auth['authId'];
+    $maxSize = $tier === 'premium' ? CRASH_MAX_SIZE_PREMIUM : CRASH_MAX_SIZE_FREE;
+    $maxPerHour = $tier === 'premium' ? CRASH_MAX_PER_HOUR_PREMIUM : CRASH_MAX_PER_HOUR_FREE;
+    $ipMaxPerHour = $tier === 'free' ? CRASH_MAX_PER_HOUR_FREE_PER_IP : null;
+
+    if (!crashCheckRateLimit($authId, $maxPerHour, $ipMaxPerHour)) {
+        http_response_code(429);
+        echo json_encode(['error' => 'Rate limit exceeded']);
+        crashLog('rate_limit_exceeded', $tier);
+        exit;
+    }
+
+    if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Upload error', 'code' => $_FILES['file']['error'] ?? 'no_file']);
+        crashLog('upload_error');
+        exit;
+    }
+
+    $uploaded = $_FILES['file'];
+    if ($uploaded['size'] === 0 || $uploaded['size'] > $maxSize) {
+        http_response_code(413);
+        echo json_encode(['error' => 'Invalid file size', 'max_size' => $maxSize]);
+        crashLog('bad_size', $uploaded['size'] . ' tier=' . $tier);
+        exit;
+    }
+
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    $mime = finfo_file($finfo, $uploaded['tmp_name']);
+    finfo_close($finfo);
+    if (!in_array($mime, CRASH_ALLOWED_MIME, true)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid file type', 'detected' => $mime]);
+        crashLog('invalid_mime', (string) $mime);
+        exit;
+    }
+
+    $content = file_get_contents($uploaded['tmp_name']);
+    if ($content === false || !crashValidateJson($content)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid or malicious content']);
+        crashLog('invalid_content');
+        exit;
+    }
+
+    $payload = json_decode($content, true);
+    if (!is_array($payload) || !isset($payload['crashes']) || !is_array($payload['crashes'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid payload structure']);
+        crashLog('invalid_structure');
+        exit;
+    }
+
+    // Rebuild from an explicit allowlist so nothing unexpected reaches disk.
+    $reports = [];
+    foreach (array_slice($payload['crashes'], 0, 50) as $report) {
+        if (is_array($report)) {
+            $reports[] = crashSanitizeReport($report);
+        }
+    }
+    if (count($reports) === 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'No valid crash reports']);
+        crashLog('no_reports');
+        exit;
+    }
+
+    $appVersion = isset($payload['appVersion']) && is_scalar($payload['appVersion'])
+        ? mb_substr((string) $payload['appVersion'], 0, 40) : null;
+    $platform = isset($payload['platform']) && is_scalar($payload['platform'])
+        ? mb_substr((string) $payload['platform'], 0, 40) : null;
+
+    // Best-effort country from the request IP (same source the funnel/telemetry use).
+    $country = null;
+    if (function_exists('lookup_country_for_ip')) {
+        try {
+            $country = lookup_country_for_ip($_SERVER['REMOTE_ADDR'] ?? '');
+        } catch (Throwable $e) {
+            $country = null;
+        }
+    }
+
+    $stored = [
+        'tier' => $tier,
+        'authId' => $authId,
+        'appVersion' => $appVersion,
+        'platform' => $platform,
+        'countryCode' => $country,
+        'receivedAt' => date('Y-m-d H:i:s'),
+        'crashes' => $reports,
+    ];
+
+    if (!is_dir(CRASH_DIR)) {
+        if (!mkdir(CRASH_DIR, 0755, true) && !is_dir(CRASH_DIR)) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to create crash directory']);
+            crashLog('mkdir_failure');
+            exit;
+        }
+        file_put_contents(CRASH_DIR . '/.htaccess', "Order deny,allow\nDeny from all\n");
+    }
+
+    $timestamp = date('Ymd_His');
+    $suffix = bin2hex(random_bytes(4));
+    $filename = CRASH_DIR . "/argo_crash_{$tier}_{$timestamp}_{$suffix}.json";
+    $counter = 1;
+    $base = $filename;
+    while (file_exists($filename)) {
+        $filename = str_replace('.json', "_{$counter}.json", $base);
+        if (++$counter > 1000) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Unable to generate unique filename']);
+            crashLog('filename_failure');
+            exit;
+        }
+    }
+
+    $json = json_encode($stored);
+    if ($json === false || file_put_contents($filename, $json, LOCK_EX) === false) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to save crash report']);
+        crashLog('write_failure');
+        exit;
+    }
+    chmod($filename, 0644);
+
+    echo json_encode([
+        'status' => 'success',
+        'file' => basename($filename),
+        'received' => count($reports),
+        'timestamp' => date('Y-m-d H:i:s'),
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Internal server error']);
+    crashLog('exception', $e->getMessage());
+    error_log('Crash endpoint error: ' . $e->getMessage());
+}

--- a/api/data/crash.php
+++ b/api/data/crash.php
@@ -64,7 +64,7 @@ function crashCheckBucket(string $bucketKey, int $maxPerHour): bool
 
 function crashCheckRateLimit(string $authId, int $maxPerHour, ?int $ipMaxPerHour = null): bool
 {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    $ip = get_client_ip();
     if (!crashCheckBucket($authId . '|' . $ip, $maxPerHour)) {
         return false;
     }
@@ -92,7 +92,7 @@ function crashLog(string $event, string $details = ''): void
 {
     error_log(json_encode([
         'timestamp' => date('Y-m-d H:i:s'),
-        'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+        'ip' => get_client_ip(),
         'event' => 'crash_' . $event,
         'details' => $details,
     ]));
@@ -186,14 +186,19 @@ try {
         exit;
     }
 
+    // Sniff the MIME type when fileinfo is available. If the extension is
+    // missing, finfo_open() returns false; skip the sniff in that case and rely
+    // on the JSON content validation below, rather than emit warnings.
     $finfo = finfo_open(FILEINFO_MIME_TYPE);
-    $mime = finfo_file($finfo, $uploaded['tmp_name']);
-    finfo_close($finfo);
-    if (!in_array($mime, CRASH_ALLOWED_MIME, true)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Invalid file type', 'detected' => $mime]);
-        crashLog('invalid_mime', (string) $mime);
-        exit;
+    if ($finfo !== false) {
+        $mime = finfo_file($finfo, $uploaded['tmp_name']);
+        finfo_close($finfo);
+        if (!in_array($mime, CRASH_ALLOWED_MIME, true)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid file type', 'detected' => $mime]);
+            crashLog('invalid_mime', (string) $mime);
+            exit;
+        }
     }
 
     $content = file_get_contents($uploaded['tmp_name']);
@@ -235,7 +240,7 @@ try {
     $country = null;
     if (function_exists('lookup_country_for_ip')) {
         try {
-            $country = lookup_country_for_ip($_SERVER['REMOTE_ADDR'] ?? '');
+            $country = lookup_country_for_ip(get_client_ip());
         } catch (Throwable $e) {
             $country = null;
         }

--- a/api/data/crash.php
+++ b/api/data/crash.php
@@ -138,6 +138,8 @@ function crashSanitizeReport(array $r): array
         'stackTrace'    => $str($r['stackTrace'] ?? null, 8000),
         'innerException' => $str($r['innerException'] ?? null, 2000),
         'osVersion'     => $str($r['osVersion'] ?? null, 120),
+        'appVersion'    => $str($r['appVersion'] ?? null, 40),
+        'platform'      => $str($r['platform'] ?? null, 40),
         'breadcrumbs'   => $breadcrumbs ?: null,
     ], fn ($v) => $v !== null);
 }

--- a/api/data/upload.php
+++ b/api/data/upload.php
@@ -21,7 +21,7 @@ header('Content-Type: application/json');
 define('MAX_FILE_SIZE_PREMIUM', 10 * 1024 * 1024); // 10MB max for Premium uploads
 define('MAX_FILE_SIZE_FREE', 256 * 1024);          // 256KB max for free-tier uploads
 define('ALLOWED_MIME_TYPES', ['application/json', 'text/plain']);
-define('DATA_DIR', __DIR__ . '/../../admin/data-logs');
+define('DATA_DIR', __DIR__ . '/../../admin/data-logs/telemetry');
 define('MAX_UPLOADS_PER_HOUR_PREMIUM', 100);
 define('MAX_UPLOADS_PER_HOUR_FREE', 6);
 // Coarse per-IP cap for free tier so rotating X-Device-Id values from a single IP


### PR DESCRIPTION
## What this adds
- **Crash reporting endpoint** (`api/data/crash.php`): receives unhandled-exception reports from the desktop app, reusing the existing device/license auth, rate limiting, and JSON validation, with a strict field allowlist. Stores to `admin/data-logs/crashes/`.
- **Crashes tab in App Stats**: groups reports by exception signature (type + `file:line`), showing count, affected devices/versions, stack trace, breadcrumbs, and an occurrences table. Replaces the standalone page; auto-wired by `section-tabs.js`.
- **data-logs reorg**: telemetry moves to `admin/data-logs/telemetry/`. App Stats reads both the new folder and the legacy root during the transition (de-duped by filename), so nothing disappears before/after the one-time file move.

## Security fix
- Adds an `.htaccess` rule blocking direct web access to `admin/data-logs/`. Those stored telemetry/crash files were previously **publicly downloadable** by direct URL; they are read only by the authenticated admin pages over the filesystem, so this is safe and closes the exposure.

## Companion
Pairs with the desktop-app crash-capture PR (targets `V.2.0.8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)