### PR TITLE
Add Free Tools hub: estimate, purchase order, tax, and craft pricing tools

### DIFF
--- a/api/invoice-generator/track.php
+++ b/api/invoice-generator/track.php
@@ -25,7 +25,12 @@ $event_data = is_array($body) ? ($body['event_data'] ?? '') : '';
 
 // Allowlist of event types the tool is allowed to emit. Keep this list in
 // sync with invoice-generator/scripts/tracker.js + its callers.
+//
+// The same engine powers two tools, distinguished by an event prefix
+// (window.DOC_CONFIG.eventPrefix): the invoice generator emits 'invgen_*' and
+// the estimate generator emits 'estgen_*'. Both post to this one endpoint.
 $allowed = [
+    // --- Invoice generator (invgen_*) ---
     'invgen_pdf_downloaded',
     'invgen_docx_downloaded',
     'invgen_cta_clicked',
@@ -39,6 +44,26 @@ $allowed = [
     'invgen_template_download',     // Excel direct download / Google Docs or Sheets copy click
     // Phase E: share-link copy
     'invgen_share_link_copied',     // User clicked the toolbar "Copy share link" button
+    // --- Estimate generator (estgen_*) ---
+    'estgen_pdf_downloaded',
+    'estgen_docx_downloaded',
+    'estgen_cta_clicked',
+    'estgen_template_changed',
+    'estgen_country_changed',
+    'estgen_currency_changed',
+    'estgen_niche_default_used',
+    'estgen_logo_uploaded',
+    'estgen_share_link_copied',
+    // --- Purchase order generator (pogen_*) ---
+    'pogen_pdf_downloaded',
+    'pogen_docx_downloaded',
+    'pogen_cta_clicked',
+    'pogen_template_changed',
+    'pogen_country_changed',
+    'pogen_currency_changed',
+    'pogen_niche_default_used',
+    'pogen_logo_uploaded',
+    'pogen_share_link_copied',
 ];
 if (!in_array($event_type, $allowed, true)) {
     http_response_code(400);

--- a/compare/argo-books-vs-quickbooks/index.php
+++ b/compare/argo-books-vs-quickbooks/index.php
@@ -167,7 +167,7 @@ $qb_advanced  = competitor_price('quickbooks', 'advanced');
                         <?= svg_icon('dollar', 30, '', 1.5) ?>
                     </div>
                     <h3>No price creep</h3>
-                    <p>QuickBooks has raised their prices twice since we launched this comparison page, and we've had to update these numbers each time. Their cheapest plan is now $<?= $qb_easystart ?> CAD/month. Argo Books has a free version with core features, and Premium is $<?= $argo_monthly ?> CAD/month.</p>
+                    <p>QuickBooks has raised their prices twice since we launched this comparison page, and we've had to update these numbers each time. They increased their prices by 70% in the last 5 years. How much will they increase it in the next 5 years?</p>
                 </div>
                 <div class="diff-card animate-on-scroll">
                     <div class="diff-icon purple">
@@ -301,7 +301,7 @@ $qb_advanced  = competitor_price('quickbooks', 'advanced');
             <div class="section-header animate-on-scroll">
                 <span class="section-label">Pricing</span>
                 <h2>Save hundreds every year</h2>
-                <p class="section-desc">QuickBooks charges $<?= $qb_easystart ?> to $<?= $qb_advanced ?> CAD/month depending on the plan, and those prices keep climbing every year (we've had to update this page twice already to keep up). Argo Books keeps it simple with predictable, affordable pricing.</p>
+                <p class="section-desc">QuickBooks charges $<?= $qb_easystart ?> to $<?= $qb_advanced ?> CAD/month depending on the plan, and those prices keep climbing every year (70% in the last 5 years!). We've had to update this page twice already to keep up. Argo Books keeps it simple with predictable, affordable pricing.</p>
             </div>
             <div class="pricing-grid">
                 <div class="pricing-col animate-on-scroll">

--- a/craft-pricing-calculator/index.php
+++ b/craft-pricing-calculator/index.php
@@ -1,0 +1,287 @@
+<?php
+// craft-pricing-calculator/index.php
+// Free craft / handmade-product pricing calculator with the full SEO content
+// layer (quick answer, how-to, formula, markup-by-channel table, mistakes,
+// worked example, FAQ). Reuses the shared tool shell (invoice-generator/
+// layout.php): header, "All tools" breadcrumb, OG/Twitter/canonical, schema.
+// Calculation is client-side (scripts/main.js + calc.js).
+
+require_once __DIR__ . '/../invoice-generator/_base.php';
+
+if (PHP_SAPI !== 'cli') {
+    require_once __DIR__ . '/../statistics.php';
+    track_page_view('craftcalc_tool');
+}
+
+$page_title = 'Free Craft Pricing Calculator: Price Your Handmade Products | Argo Books';
+$page_description = 'Free craft pricing calculator for handmade sellers. Add your material cost, labour, and markup to find a selling price that actually pays you, with profit and margin worked out. Works for soap, candles, jewellery, and more.';
+$canonical_url = 'https://argorobots.com/craft-pricing-calculator/';
+
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
+$ref_qs = '?source=craftcalc-tool&amp;utm_source=craft-pricing-calculator&amp;utm_medium=tool&amp;utm_campaign=phase1';
+
+// Markup / margin guidance by sales channel. Drives the on-page table and the
+// quick-fill buttons in the calculator (preset = a sensible mid-range markup).
+$channels = [
+    ['name' => 'Online shop / Etsy', 'markup' => '100–200%', 'margin' => '50–67%', 'preset' => 150],
+    ['name' => 'Craft fairs / markets', 'markup' => '150–250%', 'margin' => '60–71%', 'preset' => 200],
+    ['name' => 'Wholesale to shops', 'markup' => '50–100%', 'margin' => '33–50%', 'preset' => 75],
+    ['name' => 'Boutique / consignment', 'markup' => '200–300%', 'margin' => '67–75%', 'preset' => 250],
+];
+
+// FAQ defined once, rendered into both the visible section AND the FAQPage
+// JSON-LD below, so the two can never drift apart.
+$faqs = [
+    [
+        'q' => 'How do I price a handmade product?',
+        'a' => 'Add up what one item costs you to make: your materials plus the value of your own time (labour). Then add a markup on top to create your profit. A common starting point for handmade sellers is a markup of 100% to 200%, which leaves you a healthy profit margin of 50% to 67%.',
+    ],
+    [
+        'q' => 'What is the formula for pricing crafts?',
+        'a' => 'Selling price = (material cost + labour cost) × (1 + markup %). For example, if an item costs you $10 in materials and time and you apply a 150% markup, your price is $10 × 2.5 = $25. The $15 above your cost is your profit.',
+    ],
+    [
+        'q' => 'Should I include my own labour when pricing?',
+        'a' => 'Yes. This is the single most common pricing mistake. Your time is a real cost even though no money leaves your pocket. Decide on an hourly rate you would be happy to earn, multiply it by how long one item takes to make, and include that as labour. If you skip it, you are effectively working for free.',
+    ],
+    [
+        'q' => 'What is a good profit margin for handmade goods?',
+        'a' => 'For direct sales (your own shop, Etsy, or markets), aim for a profit margin around 50% to 67%. When you sell wholesale to other shops, a margin of 33% to 50% is normal because the retailer needs room to mark the item up again for their own customers.',
+    ],
+    [
+        'q' => 'How do I work out my material cost per item?',
+        'a' => 'Use the per-item cost, not the price of the whole pack. If a $20 bag of supplies makes 8 items, your material cost is $20 ÷ 8 = $2.50 per item. Do this for every ingredient and add them together, including small things like packaging and labels, which add up.',
+    ],
+    [
+        'q' => 'What is the difference between wholesale and retail price?',
+        'a' => 'Retail is the price you charge the end customer. Wholesale is the lower price you charge a shop that resells your product. A common rule is "keystone" pricing, where the shop pays roughly half your retail price so they can double it and still make a profit. Use a smaller markup for wholesale than for direct sales.',
+    ],
+];
+
+// Schema: SoftwareApplication (the calculator) + FAQPage, as a @graph.
+$faq_schema_items = array_map(function ($f) {
+    return [
+        '@type' => 'Question',
+        'name' => $f['q'],
+        'acceptedAnswer' => ['@type' => 'Answer', 'text' => $f['a']],
+    ];
+}, $faqs);
+
+$page_schema_json = json_encode([
+    '@context' => 'https://schema.org',
+    '@graph' => [
+        [
+            '@type' => 'SoftwareApplication',
+            'name' => 'Free Craft Pricing Calculator',
+            'applicationCategory' => 'BusinessApplication',
+            'operatingSystem' => 'Web',
+            'offers' => ['@type' => 'Offer', 'price' => '0', 'priceCurrency' => 'USD'],
+            'creator' => ['@id' => 'https://argorobots.com/#organization'],
+            'url' => $canonical_url,
+        ],
+        [
+            '@type' => 'FAQPage',
+            'mainEntity' => $faq_schema_items,
+        ],
+    ],
+], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+
+$breadcrumb_schema_json = json_encode([
+    '@context' => 'https://schema.org',
+    '@type' => 'BreadcrumbList',
+    'itemListElement' => [
+        ['@type' => 'ListItem', 'position' => 1, 'name' => 'Home', 'item' => 'https://argorobots.com/'],
+        ['@type' => 'ListItem', 'position' => 2, 'name' => 'Free Tools', 'item' => 'https://argorobots.com/tools/'],
+        ['@type' => 'ListItem', 'position' => 3, 'name' => 'Craft Pricing Calculator', 'item' => $canonical_url],
+    ],
+], JSON_UNESCAPED_SLASHES);
+
+$extra_head = '<link rel="stylesheet" href="' . INVGEN_BASE . '/craft-pricing-calculator/styles/craft-calculator.css">';
+$extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/craft-pricing-calculator/scripts/main.js"></script>';
+
+ob_start();
+?>
+<div class="craft-app">
+
+  <section class="site-hero">
+    <h1 class="site-hero-title">Free Craft Pricing Calculator</h1>
+    <p class="site-hero-tagline">Stop guessing what to charge. Enter your costs and a markup to find a handmade price that actually pays you back, with your profit and margin worked out for you.</p>
+  </section>
+
+  <aside class="page-banner" role="complementary">
+    <span class="page-banner-text">Selling regularly? Track your real costs and profit with Argo Books.</span>
+    <a class="page-banner-link" data-pitch-placement="banner" href="<?= INVGEN_BASE ?>/features/expense-revenue-tracking/<?= $ref_qs ?>&amp;placement=banner">See how <span aria-hidden="true">&rarr;</span></a>
+  </aside>
+
+  <div class="craft-grid">
+    <form class="craft-form" autocomplete="off" aria-label="Craft pricing inputs">
+      <div class="craft-field">
+        <label for="cc-material">Material cost (per item)</label>
+        <div class="craft-money">
+          <span class="craft-money-affix">$</span>
+          <input id="cc-material" data-cc="material" type="number" inputmode="decimal" min="0" step="0.01" placeholder="0.00">
+        </div>
+        <p class="craft-hint">Supplies for one item. Made in batches? Divide the batch cost by how many it makes.</p>
+      </div>
+
+      <div class="craft-field">
+        <label for="cc-labor">Labour cost (per item)</label>
+        <div class="craft-money">
+          <span class="craft-money-affix">$</span>
+          <input id="cc-labor" data-cc="labor" type="number" inputmode="decimal" min="0" step="0.01" placeholder="0.00">
+        </div>
+        <p class="craft-hint">Your time for one item. For batches, divide the batch's time across all of them.</p>
+      </div>
+
+      <div class="craft-field">
+        <label for="cc-markup">Markup</label>
+        <div class="craft-money craft-money-percent">
+          <input id="cc-markup" data-cc="markup" type="number" inputmode="decimal" min="0" step="1" placeholder="150">
+          <span class="craft-money-affix craft-money-affix-right">%</span>
+        </div>
+        <div class="craft-channels" role="group" aria-label="Quick markup presets by sales channel">
+          <?php foreach ($channels as $c): ?>
+            <button type="button" class="craft-channel-btn" data-cc-preset="<?= (int)$c['preset'] ?>"><?= htmlspecialchars(strtok($c['name'], ' /')) ?> <span class="craft-channel-pct"><?= (int)$c['preset'] ?>%</span></button>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </form>
+
+    <div class="craft-results" data-cc-results aria-live="polite">
+      <div class="craft-headline">
+        <span class="craft-headline-label">Suggested selling price</span>
+        <span class="craft-headline-amount" data-cc="price">$0.00</span>
+      </div>
+      <dl class="craft-breakdown">
+        <div class="craft-breakdown-row">
+          <dt>Materials &amp; labour</dt>
+          <dd data-cc="cost">$0.00</dd>
+        </div>
+        <div class="craft-breakdown-row craft-breakdown-profit">
+          <dt>Your profit</dt>
+          <dd data-cc="profit">$0.00</dd>
+        </div>
+        <div class="craft-breakdown-row craft-breakdown-rate">
+          <dt>Profit margin</dt>
+          <dd data-cc="margin">0%</dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+
+  <article class="craft-content">
+
+    <section>
+      <h2>How to price your handmade products (quick answer)</h2>
+      <p>Add your <strong>material cost</strong> and <strong>labour cost</strong> together to get what one item really costs you to make. Then apply a <strong>markup</strong> to set your selling price. The standard handmade formula is:</p>
+      <p class="craft-formula">Selling price = (material cost + labour cost) &times; (1 + markup %)</p>
+      <p>Most handmade sellers use a markup of <strong>100% to 200%</strong>, which leaves a profit margin of about <strong>50% to 67%</strong>. The calculator above does the maths for you and shows your profit and margin as you type.</p>
+    </section>
+
+    <section>
+      <h2>How to use the calculator</h2>
+      <h3>The three inputs</h3>
+      <ul>
+        <li><strong>Material cost</strong>: everything you use to make one item, including packaging and labels. Use the cost <em>per item</em>, not the price of the whole pack.</li>
+        <li><strong>Labour cost</strong>: your time. Pick an hourly rate you would be happy to earn, then multiply by how long one item takes to make.</li>
+        <li><strong>Markup</strong>: the percentage you add on top of your cost. Tap a preset for your sales channel, or type your own.</li>
+      </ul>
+      <h3>Reading the results</h3>
+      <ul>
+        <li><strong>Suggested selling price</strong>: what to charge per item at that markup.</li>
+        <li><strong>Materials &amp; labour</strong>: your total cost to make one item.</li>
+        <li><strong>Your profit</strong>: what you keep per item after costs.</li>
+        <li><strong>Profit margin</strong>: your profit as a share of the selling price.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Markup and margin by sales channel</h2>
+      <p>Where you sell changes how much to mark up. Selling direct lets you keep more; selling wholesale means leaving room for the shop to mark the item up again.</p>
+      <table class="craft-table">
+        <thead>
+          <tr><th scope="col">Where you sell</th><th scope="col">Typical markup</th><th scope="col">Profit margin</th></tr>
+        </thead>
+        <tbody>
+          <?php foreach ($channels as $c): ?>
+            <tr>
+              <td><?= htmlspecialchars($c['name']) ?></td>
+              <td><?= htmlspecialchars($c['markup']) ?></td>
+              <td><?= htmlspecialchars($c['margin']) ?></td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>The formula explained</h2>
+      <p>Two quick calculations sit behind the result:</p>
+      <p class="craft-formula">Selling price = (material cost + labour cost) &times; (1 + markup %)</p>
+      <p class="craft-formula">Profit margin = (selling price &minus; total cost) &divide; selling price</p>
+      <p>Markup and margin are not the same number. A 100% markup (doubling your cost) is a 50% margin. That difference trips up a lot of sellers, so the calculator shows both.</p>
+    </section>
+
+    <section>
+      <h2>A worked example</h2>
+      <div class="craft-example">
+        <p>Say you make soap in batches. A batch of <strong>20 bars</strong> uses <strong>$40</strong> of oils, lye, fragrance, and packaging, so materials are $40 &divide; 20 = <strong>$2.00 per bar</strong>. The batch takes about an hour and you value your time at $20/hour, so labour is $20 &divide; 20 = <strong>$1.00 per bar</strong>. Dividing the batch cost across every bar gives your true per-item cost. You sell on Etsy, so you pick a <strong>150% markup</strong>.</p>
+        <ul>
+          <li>Total cost: $2.00 + $1.00 = <strong>$3.00 per bar</strong></li>
+          <li>Selling price: $3.00 &times; 2.5 = <strong>$7.50</strong></li>
+          <li>Your profit: <strong>$4.50</strong> per bar</li>
+          <li>Profit margin: <strong>60%</strong></li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Common pricing mistakes</h2>
+      <ol class="craft-mistakes">
+        <li><strong>Not paying yourself for labour.</strong> Your time is a real cost. Leave it out and your "profit" is really just unpaid wages.</li>
+        <li><strong>Using the pack price instead of the per-item cost.</strong> Divide the cost of a pack by how many items it makes.</li>
+        <li><strong>Copying a competitor's price.</strong> You do not know their costs. Price from your own numbers, then sanity-check against the market.</li>
+        <li><strong>Forgetting overhead.</strong> Stall fees, online listing fees, and equipment add up. Build a little extra into your markup to cover them.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Who is this calculator for?</h2>
+      <p>Anyone selling something they make by hand: soap and candle makers, jewellers, bakers, potters, woodworkers, and crafters selling on Etsy, at markets, or wholesale to shops. If you make it and sell it, this gets you to a price that pays you fairly.</p>
+    </section>
+
+    <section>
+      <h2>When to move beyond a calculator</h2>
+      <p>A calculator prices one product at a time. Once you are selling regularly, the bigger question is whether the whole business is profitable across every sale, every supply run, and every fee. That is where <a class="craft-link" href="<?= INVGEN_BASE ?>/features/expense-revenue-tracking/<?= $ref_qs ?>&amp;placement=content">Argo Books</a> comes in: it tracks your income and expenses, shows your real profit month to month, and helps you send invoices and stay ready for tax time. It is free to start.</p>
+    </section>
+
+  </article>
+
+  <section class="craft-faqs">
+    <h2>Frequently asked questions</h2>
+    <div class="faq-grid">
+      <?php foreach ($faqs as $f): ?>
+        <div class="faq-item">
+          <button type="button" class="faq-question" aria-expanded="false">
+            <h3><?= htmlspecialchars($f['q']) ?></h3>
+            <span class="faq-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6,9 12,15 18,9"/>
+              </svg>
+            </span>
+          </button>
+          <div class="faq-answer">
+            <div class="faq-answer-content">
+              <p><?= htmlspecialchars($f['a']) ?></p>
+            </div>
+          </div>
+        </div>
+      <?php endforeach; ?>
+    </div>
+  </section>
+
+</div>
+<?php
+$body_content = ob_get_clean();
+
+include __DIR__ . '/../invoice-generator/layout.php';

--- a/craft-pricing-calculator/scripts/calc.js
+++ b/craft-pricing-calculator/scripts/calc.js
@@ -1,0 +1,22 @@
+// craft-pricing-calculator/scripts/calc.js
+// Pure pricing math for the craft pricing calculator. No DOM, no globals, so
+// calc.test.js can verify it directly.
+//
+// Model (the standard handmade-pricing formula):
+//   total cost    = material cost + labor cost
+//   selling price = total cost * (1 + markup%)
+//   profit        = selling price - total cost
+//   margin        = profit / selling price
+
+export function computeCraftPrice({ materialCost, laborCost, markupPercent }) {
+  const material = Math.max(0, Number(materialCost) || 0);
+  const labor = Math.max(0, Number(laborCost) || 0);
+  const markup = Math.max(0, Number(markupPercent) || 0);
+
+  const totalCost = material + labor;
+  const sellingPrice = totalCost * (1 + markup / 100);
+  const profit = sellingPrice - totalCost;
+  const margin = sellingPrice > 0 ? profit / sellingPrice : 0;
+
+  return { material, labor, markup, totalCost, sellingPrice, profit, margin };
+}

--- a/craft-pricing-calculator/scripts/calc.test.js
+++ b/craft-pricing-calculator/scripts/calc.test.js
@@ -1,0 +1,43 @@
+// craft-pricing-calculator/scripts/calc.test.js
+// Run with: node --test craft-pricing-calculator/scripts/*.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { computeCraftPrice } from './calc.js';
+
+const near = (a, b, tol = 0.001, msg = '') =>
+  assert.ok(Math.abs(a - b) <= tol, `${msg} expected ~${b}, got ${a}`);
+
+test('materials + labor, 150% markup', () => {
+  const r = computeCraftPrice({ materialCost: 5, laborCost: 10, markupPercent: 150 });
+  near(r.totalCost, 15, 0.001, 'total cost');
+  near(r.sellingPrice, 37.5, 0.001, 'selling price'); // 15 * 2.5
+  near(r.profit, 22.5, 0.001, 'profit');
+  near(r.margin, 0.6, 0.0001, 'margin'); // 22.5 / 37.5
+});
+
+test('100% markup doubles cost and gives 50% margin', () => {
+  const r = computeCraftPrice({ materialCost: 8, laborCost: 12, markupPercent: 100 });
+  near(r.sellingPrice, 40, 0.001);
+  near(r.margin, 0.5, 0.0001);
+});
+
+test('zero markup means price equals cost, zero profit', () => {
+  const r = computeCraftPrice({ materialCost: 3, laborCost: 7, markupPercent: 0 });
+  near(r.sellingPrice, 10, 0.001);
+  near(r.profit, 0, 0.001);
+  near(r.margin, 0, 0.001);
+});
+
+test('empty / invalid inputs are treated as zero', () => {
+  const r = computeCraftPrice({ materialCost: '', laborCost: undefined, markupPercent: 'abc' });
+  assert.strictEqual(r.totalCost, 0);
+  assert.strictEqual(r.sellingPrice, 0);
+  assert.strictEqual(r.margin, 0);
+});
+
+test('negative inputs are floored at zero', () => {
+  const r = computeCraftPrice({ materialCost: -5, laborCost: -10, markupPercent: -50 });
+  assert.strictEqual(r.totalCost, 0);
+  assert.strictEqual(r.sellingPrice, 0);
+});

--- a/craft-pricing-calculator/scripts/main.js
+++ b/craft-pricing-calculator/scripts/main.js
@@ -1,0 +1,87 @@
+// craft-pricing-calculator/scripts/main.js
+// Wires the pricing form to the pure calc and renders live. Vanilla ES module.
+//
+// Note: unlike the invoice/tax tools, this calculator is currency-agnostic, so
+// it shows a plain "$" with no ISO code (reusing formatMoney would append
+// "USD", implying a US-only tool, which this isn't).
+
+import { computeCraftPrice } from './calc.js';
+
+const $ = (sel) => document.querySelector(sel);
+const el = {
+  material: $('[data-cc="material"]'),
+  labor: $('[data-cc="labor"]'),
+  markup: $('[data-cc="markup"]'),
+  price: $('[data-cc="price"]'),
+  cost: $('[data-cc="cost"]'),
+  profit: $('[data-cc="profit"]'),
+  margin: $('[data-cc="margin"]'),
+};
+
+const moneyFmt = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+const money = (n) => moneyFmt.format(Number.isFinite(n) ? n : 0);
+const pct = (rate) => `${Math.round(rate * 100)}%`;
+
+function render() {
+  const r = computeCraftPrice({
+    materialCost: el.material.value,
+    laborCost: el.labor.value,
+    markupPercent: el.markup.value,
+  });
+  el.price.textContent = money(r.sellingPrice);
+  el.cost.textContent = money(r.totalCost);
+  el.profit.textContent = money(r.profit);
+  el.margin.textContent = pct(r.margin);
+}
+
+function wirePresets() {
+  const buttons = document.querySelectorAll('[data-cc-preset]');
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      el.markup.value = btn.getAttribute('data-cc-preset');
+      buttons.forEach((b) => b.classList.toggle('is-active', b === btn));
+      render();
+    });
+  });
+  // Typing a custom markup clears the active preset highlight.
+  if (el.markup) {
+    el.markup.addEventListener('input', () => {
+      buttons.forEach((b) => {
+        if (b.getAttribute('data-cc-preset') !== el.markup.value) b.classList.remove('is-active');
+      });
+    });
+  }
+}
+
+// Collapsible FAQ accordion, matching the invoice-template pages. Reuses the
+// shared .faq-item / .faq-question / .faq-answer styling from tool.css.
+function wireFaq() {
+  const items = document.querySelectorAll('.craft-faqs .faq-item');
+  items.forEach((item) => {
+    const question = item.querySelector('.faq-question');
+    if (!question) return;
+    question.addEventListener('click', () => {
+      const wasActive = item.classList.contains('active');
+      items.forEach((other) => {
+        other.classList.remove('active');
+        const btn = other.querySelector('.faq-question');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      });
+      if (!wasActive) {
+        item.classList.add('active');
+        question.setAttribute('aria-expanded', 'true');
+      }
+    });
+  });
+}
+
+function init() {
+  wireFaq();
+  if (!el.material) return;
+  const form = el.material.closest('form') || document;
+  form.addEventListener('input', render);
+  wirePresets();
+  render();
+}
+
+init();

--- a/craft-pricing-calculator/styles/craft-calculator.css
+++ b/craft-pricing-calculator/styles/craft-calculator.css
@@ -1,0 +1,317 @@
+/* craft-pricing-calculator/styles/craft-calculator.css
+   Loads on top of invoice-generator/styles/tool.css (via layout.php), so it
+   reuses the shared chrome (site-header, breadcrumb, .site-hero, .page-banner)
+   and the brand CSS variables from custom-colors.css. Only the calculator and
+   the article/SEO content are styled here. */
+
+.craft-app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 20px 96px;
+}
+
+/* ---------- Calculator ---------- */
+.craft-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: stretch;
+  margin-bottom: 16px;
+}
+
+.craft-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 4px 20px var(--shadow-sm);
+}
+
+.craft-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.craft-field label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--tool-text);
+}
+
+.craft-money {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.craft-money input {
+  width: 100%;
+  font: inherit;
+  color: var(--tool-text);
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 8px;
+  padding: 10px 12px 10px 26px;
+  min-height: 44px;
+}
+
+.craft-money-percent input {
+  padding: 10px 34px 10px 12px;
+}
+
+.craft-money input:focus {
+  outline: none;
+  border-color: var(--tool-primary);
+  box-shadow: 0 0 0 3px var(--blue-100);
+}
+
+.craft-money-affix {
+  position: absolute;
+  left: 12px;
+  color: var(--tool-muted);
+  pointer-events: none;
+  font-weight: 600;
+}
+
+.craft-money-affix-right {
+  left: auto;
+  right: 12px;
+}
+
+.craft-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--tool-muted);
+}
+
+/* Channel markup presets */
+.craft-channels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.craft-channel-btn {
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--tool-border);
+  background: var(--tool-surface);
+  color: var(--tool-text);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.craft-channel-btn:hover {
+  border-color: var(--tool-primary);
+}
+
+.craft-channel-btn.is-active {
+  border-color: var(--tool-primary);
+  background: var(--blue-50);
+  color: var(--blue-700);
+}
+
+.craft-channel-pct {
+  font-weight: 700;
+  margin-left: 4px;
+}
+
+/* Results */
+.craft-results {
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 14px;
+  padding: 28px;
+  box-shadow: 0 4px 20px var(--shadow-sm);
+}
+
+.craft-headline {
+  text-align: center;
+  padding: 8px 0 22px;
+  border-bottom: 1px solid var(--tool-border);
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.craft-headline-label {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--tool-primary);
+}
+
+.craft-headline-amount {
+  font-size: 44px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--tool-text);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.craft-breakdown {
+  margin: 0;
+}
+
+.craft-breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding: 9px 0;
+}
+
+.craft-breakdown-row dt {
+  color: var(--invoice-text);
+}
+
+.craft-breakdown-row dd {
+  margin: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--tool-text);
+}
+
+.craft-breakdown-profit dt,
+.craft-breakdown-profit dd {
+  color: var(--emerald-600);
+  font-weight: 700;
+}
+
+.craft-breakdown-rate dt,
+.craft-breakdown-rate dd {
+  color: var(--tool-muted);
+  font-weight: 500;
+}
+
+/* ---------- Article / SEO content ---------- */
+.craft-content {
+  max-width: 760px;
+  margin: 40px auto 0;
+  color: var(--tool-text);
+}
+
+.craft-content section {
+  margin-bottom: 36px;
+}
+
+.craft-content h2 {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 12px;
+}
+
+.craft-content h3 {
+  font-size: 17px;
+  font-weight: 600;
+  margin: 20px 0 8px;
+}
+
+.craft-content p {
+  margin: 0 0 12px;
+  line-height: 1.65;
+}
+
+.craft-content ul,
+.craft-content ol {
+  margin: 0 0 12px;
+  padding-left: 22px;
+  line-height: 1.65;
+}
+
+.craft-content li {
+  margin-bottom: 8px;
+}
+
+.craft-formula {
+  background: var(--tool-secondary);
+  border: 1px solid var(--tool-border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.craft-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 8px 0 12px;
+  font-size: 15px;
+}
+
+.craft-table th,
+.craft-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--tool-border);
+}
+
+.craft-table thead th {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--tool-muted);
+}
+
+.craft-example {
+  background: var(--blue-50);
+  border: 1px solid var(--blue-100);
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+
+.craft-example p {
+  margin-bottom: 10px;
+}
+
+.craft-example ul {
+  margin-bottom: 0;
+}
+
+.craft-link {
+  color: var(--tool-primary);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* FAQ uses the shared accordion component (.faq-grid / .faq-item) from
+   tool.css; this just sets the section width and heading to match the article. */
+.craft-faqs {
+  max-width: 820px;
+  margin: 8px auto 0;
+}
+
+.craft-faqs h2 {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-align: center;
+  margin: 0 0 20px;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 760px) {
+  .craft-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .craft-headline-amount {
+    font-size: 36px;
+  }
+
+  .craft-content h2 {
+    font-size: 21px;
+  }
+}

--- a/documentation/pages/features/spreadsheet-import.php
+++ b/documentation/pages/features/spreadsheet-import.php
@@ -14,7 +14,7 @@ include __DIR__ . '/../../docs-header.php';
             <h2>How AI Import Works</h2>
             <p>The AI importer analyzes your spreadsheet and figures out the rest. Here's what happens when you import a file:</p>
             <ol class="steps-list">
-                <li>Click <strong>File &gt; Import...</strong>, select "Excel or CSV", then choose your file</li>
+                <li>Click <strong>File &gt; Import &gt; Spreadsheet</strong>, then choose your file</li>
                 <li>AI analyzes each sheet, detects the data type (customers, products, expenses, etc.), and maps your columns to Argo Books fields</li>
                 <li>Review the mapping. You'll see confidence scores for each match, and can adjust anything that doesn't look right</li>
                 <li>Click <strong>Import</strong> to bring everything in</li>

--- a/estimate-generator/index.php
+++ b/estimate-generator/index.php
@@ -55,5 +55,6 @@ include __DIR__ . '/../invoice-generator/_fragment.php';
 $body_content = ob_get_clean();
 
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
 include __DIR__ . '/../invoice-generator/layout.php';

--- a/estimate-generator/index.php
+++ b/estimate-generator/index.php
@@ -1,0 +1,59 @@
+<?php
+// estimate-generator/index.php
+// Standalone free estimate generator tool page.
+//
+// Thin shell over the SHARED generator engine that lives in /invoice-generator/.
+// It picks the 'estimate' document-type config, embeds the same editor surface
+// (_fragment.php), mirrors the JS-relevant config to window.DOC_CONFIG, and
+// defers to the same layout.php + main.js. See invoice-generator/doc-config.php
+// for the full config and the consolidation rationale.
+
+require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../invoice-generator/doc-config.php';
+
+$doc_type = 'estimate';
+$dc = invgen_doc_config($doc_type);
+
+// Server-side page view. track_page_view() filters admins, bots, and duplicates
+// itself, so calling it unconditionally is safe. Skip during PHP CLI smoke
+// tests (no $_SERVER['REMOTE_ADDR'], no real visitor).
+if (PHP_SAPI !== 'cli') {
+    require_once __DIR__ . '/../statistics.php';
+    track_page_view('estgen_tool');
+}
+
+$page_title = $dc['page_title'];
+$page_description = $dc['page_description'];
+$canonical_url = $dc['canonical_url'];
+
+// Referral source baked into every conversion-pitch CTA inside _fragment.php.
+$invgen_ref = $dc['default_ref'];
+
+// Show the hero (H1 + tagline) only on the standalone tool page.
+$show_tool_hero = true;
+
+$page_schema_json = json_encode([
+  '@context' => 'https://schema.org',
+  '@type' => 'SoftwareApplication',
+  'name' => $dc['schema_name'],
+  'applicationCategory' => 'BusinessApplication',
+  'operatingSystem' => 'Web',
+  'offers' => ['@type' => 'Offer', 'price' => '0', 'priceCurrency' => 'USD'],
+  'creator' => ['@id' => 'https://argorobots.com/#organization'],
+  'url' => $dc['canonical_url'],
+], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+
+// Mirror the JS-relevant config to window.DOC_CONFIG so the shared engine
+// modules (state/pdf/docx/main) know this is an estimate. Emitted into the
+// <head> via $extra_head, ahead of main.js which loads at end of <body>.
+$extra_head = '<script>window.DOC_CONFIG = '
+    . json_encode(invgen_doc_config_js($dc), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT)
+    . ';</script>';
+
+ob_start();
+include __DIR__ . '/../invoice-generator/_fragment.php';
+$body_content = ob_get_clean();
+
+$extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
+
+include __DIR__ . '/../invoice-generator/layout.php';

--- a/invoice-generator/_fragment.php
+++ b/invoice-generator/_fragment.php
@@ -15,9 +15,14 @@
 //   That value goes into the ?source= query param, which track_referral.php
 //   reads on the destination (argorobots.com/) to attribute the visit.
 //   Falls back to 'invgen-tool' when callers forget to set it.
-$invgen_ref = $invgen_ref ?? 'invgen-tool';
 require_once __DIR__ . '/_base.php';
-$ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-generator&amp;utm_medium=tool&amp;utm_campaign=phase1';
+require_once __DIR__ . '/doc-config.php';
+// Document-type config drives copy, accessibility labels, conversion-CTA
+// attribution, and which invoice-only fields render. Defaults to 'invoice'
+// so niche pages (which embed this fragment without a $doc_type) are unchanged.
+$dc = invgen_doc_config($doc_type ?? 'invoice');
+$invgen_ref = $invgen_ref ?? $dc['default_ref'];
+$ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=' . htmlspecialchars($dc['utm_source']) . '&amp;utm_medium=tool&amp;utm_campaign=phase1';
 // The site-header (logo bar) is rendered once for every tool page by layout.php,
 // so this fragment no longer emits its own.
 ?>
@@ -25,21 +30,21 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
 
   <?php if (!empty($show_tool_hero)): ?>
   <section class="site-hero">
-    <h1 class="site-hero-title">Free Invoice Generator</h1>
-    <p class="site-hero-tagline">Create professional invoices with one click. No signup required. Download as PDF or Word.</p>
+    <h1 class="site-hero-title"><?= htmlspecialchars($dc['hero_title']) ?></h1>
+    <p class="site-hero-tagline"><?= htmlspecialchars($dc['hero_tagline']) ?></p>
   </section>
   <?php endif; ?>
 
   <aside class="page-banner" role="complementary">
-    <span class="page-banner-text">Want to handle payments, refunds, and track everything?</span>
-    <a class="page-banner-link" data-pitch-placement="banner" href="<?= INVGEN_BASE ?>/features/invoicing/<?= $ref_qs ?>&amp;placement=banner">Try Argo Books <span aria-hidden="true">&rarr;</span></a>
+    <span class="page-banner-text"><?= htmlspecialchars($dc['banner_text']) ?></span>
+    <a class="page-banner-link" data-pitch-placement="banner" href="<?= INVGEN_BASE ?><?= htmlspecialchars($dc['cta_href']) ?><?= $ref_qs ?>&amp;placement=banner">Try Argo Books <span aria-hidden="true">&rarr;</span></a>
   </aside>
 
-  <header class="toolbar" role="toolbar" aria-label="Invoice tools">
+  <header class="toolbar" role="toolbar" aria-label="<?= htmlspecialchars($dc['toolbar_aria']) ?>">
     <div class="toolbar-controls">
       <label class="toolbar-field">
         <span class="toolbar-label">Template</span>
-        <select data-field="template" aria-label="Invoice template">
+        <select data-field="template" aria-label="<?= htmlspecialchars($dc['template_aria']) ?>">
           <option value="classic">Classic</option>
           <option value="modern">Modern</option>
           <option value="formal">Formal</option>
@@ -98,7 +103,7 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
     </div>
   </header>
 
-  <main class="invoice" aria-label="Invoice editor">
+  <main class="invoice" aria-label="<?= htmlspecialchars($dc['editor_aria']) ?>">
 
     <!-- Watercolor wave decoration: visible only for [data-template="ribbon"].
          Three overlapping wave paths, each filled with a vertical gradient at
@@ -147,7 +152,7 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
         <input type="text" class="editable-text editable-document-title" data-label="documentTitle" aria-label="Document title">
         <label class="invoice-number-field">
           <span class="invoice-number-prefix">#</span>
-          <input type="text" data-field="invoiceNumber" placeholder="1" aria-label="Invoice number">
+          <input type="text" data-field="invoiceNumber" placeholder="1" aria-label="<?= htmlspecialchars($dc['number_aria']) ?>">
         </label>
       </div>
     </section>
@@ -162,7 +167,7 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
         <div class="meta-bill-ship">
           <div class="meta-block meta-billto">
             <input type="text" class="editable-text editable-label" data-label="billTo" aria-label="Bill To label">
-            <textarea id="field-billTo" data-field="billTo" rows="3" placeholder="Client name&#10;Address&#10;City, State ZIP"></textarea>
+            <textarea id="field-billTo" data-field="billTo" rows="3" placeholder="<?= $dc['recipient_placeholder'] ?>"></textarea>
           </div>
 
           <div class="meta-block meta-shipto-col">
@@ -183,10 +188,12 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
           <input type="text" class="editable-text editable-label" data-label="date" aria-label="Date label">
           <input type="date" id="field-date" data-field="date">
         </div>
+        <?php if ($dc['show_payment_terms']): ?>
         <div class="meta-field-row">
           <input type="text" class="editable-text editable-label" data-label="paymentTerms" aria-label="Payment Terms label">
           <input type="text" id="field-paymentTerms" data-field="paymentTerms" placeholder="Net 30">
         </div>
+        <?php endif; ?>
         <div class="meta-field-row">
           <input type="text" class="editable-text editable-label" data-label="dueDate" aria-label="Due Date label">
           <input type="date" id="field-dueDate" data-field="dueDate">
@@ -251,7 +258,7 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
         </div>
       </div>
 
-      <div class="invoice-totals" role="group" aria-label="Invoice totals">
+      <div class="invoice-totals" role="group" aria-label="<?= htmlspecialchars($dc['totals_aria']) ?>">
         <div class="totals-row totals-subtotal">
           <input type="text" class="editable-text editable-totals-label" data-label="subtotal" aria-label="Subtotal label">
           <output data-field="subtotal" class="totals-value">$0.00</output>
@@ -298,6 +305,7 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
           <output data-field="total" class="totals-value">$0.00</output>
         </div>
 
+        <?php if ($dc['show_payment_fields']): ?>
         <div class="totals-row totals-paid">
           <input type="text" class="editable-text editable-totals-label" data-label="amountPaid" aria-label="Amount Paid label">
           <span class="totals-input-group">
@@ -311,16 +319,38 @@ $ref_qs = '?source=' . htmlspecialchars($invgen_ref) . '&amp;utm_source=invoice-
           <input type="text" class="editable-text editable-totals-label" data-label="balanceDue" aria-label="Balance Due label">
           <output data-field="balance-due" class="totals-value">$0.00</output>
         </div>
+        <?php endif; ?>
       </div>
     </section>
+
+    <?php if (!empty($dc['show_signature'])): ?>
+    <section class="invoice-signature">
+      <div id="signature-block" class="signature-block" hidden>
+        <input type="text" class="editable-text editable-label signature-heading" data-label="signatureLabel" aria-label="Signature section label">
+        <div class="signature-row">
+          <div class="signature-field">
+            <span class="signature-line" aria-hidden="true"></span>
+            <input type="text" class="editable-text editable-label signature-caption" data-label="signatureName" aria-label="Signature line label">
+          </div>
+          <div class="signature-field signature-field-date">
+            <span class="signature-line" aria-hidden="true"></span>
+            <input type="text" class="editable-text editable-label signature-caption" data-label="signatureDate" aria-label="Signature date label">
+          </div>
+        </div>
+      </div>
+      <div class="signature-toggle-row">
+        <button type="button" class="btn btn-add" data-action="toggle-signature" aria-controls="signature-block">+ Signature</button>
+      </div>
+    </section>
+    <?php endif; ?>
 
   </main>
 
   <dialog id="invgen-post-download" class="invgen-modal" aria-labelledby="invgen-modal-title">
-    <h2 id="invgen-modal-title">Your invoice is downloading</h2>
+    <h2 id="invgen-modal-title"><?= htmlspecialchars($dc['modal_heading']) ?></h2>
     <p>If you want to handle payments, refunds, and track everything, use Argo Books.</p>
     <div class="invgen-modal-actions">
-      <a href="https://argorobots.com/pricing/?source=<?= htmlspecialchars($invgen_ref) ?>&amp;utm_source=invoice-generator&amp;utm_medium=tool&amp;utm_campaign=phase1&amp;placement=modal" data-pitch-placement="modal" class="btn btn-primary">Get Argo Books</a>
+      <a href="https://argorobots.com/pricing/?source=<?= htmlspecialchars($invgen_ref) ?>&amp;utm_source=<?= htmlspecialchars($dc['utm_source']) ?>&amp;utm_medium=tool&amp;utm_campaign=phase1&amp;placement=modal" data-pitch-placement="modal" class="btn btn-primary">Get Argo Books</a>
       <button type="button" class="btn btn-secondary" data-action="close-modal">Close</button>
     </div>
   </dialog>

--- a/invoice-generator/doc-config.php
+++ b/invoice-generator/doc-config.php
@@ -1,0 +1,171 @@
+<?php
+// invoice-generator/doc-config.php
+//
+// Single source of truth for the document-type configuration that drives the
+// shared generator engine. The same editor surface (_fragment.php), scripts
+// (scripts/*), and styles (tool.css) power two tools:
+//   - the free invoice generator  (/invoice-generator/)
+//   - the free estimate generator (/estimate-generator/)
+//
+// Each tool's index.php picks a config via invgen_doc_config($type) and:
+//   - reads it in PHP to swap page copy / aria labels and to conditionally
+//     render the invoice-only money fields (Payment Terms, Amount Paid,
+//     Balance Due), and
+//   - mirrors the JS-relevant subset to window.DOC_CONFIG (see
+//     invgen_doc_config_js()) so the client modules know the document type.
+//
+// The 'invoice' entry MUST reproduce the engine's historical hardcoded values
+// exactly (page copy, the 'argobooks.invoiceGenerator.draft' storage key, the
+// 'invgen' event prefix, the 'INVOICE' document title). When window.DOC_CONFIG
+// is absent (the invoice standalone page relies on JS fallbacks, and every
+// niche page embeds _fragment.php without a $doc_type), behavior is unchanged.
+
+if (!function_exists('invgen_doc_config')) {
+
+    /**
+     * Return the configuration for a document type. Unknown types fall back to
+     * 'invoice' so a misconfigured caller degrades to the original tool.
+     */
+    function invgen_doc_config(string $type): array
+    {
+        $configs = [
+            'invoice' => [
+                'type'                => 'invoice',
+                // Page metadata (used by the standalone index.php)
+                'page_title'          => 'Free Invoice Generator | Argo Books',
+                'page_description'    => 'Free online invoice generator. No signup required. Download PDF or Word.',
+                'schema_name'         => 'Free Invoice Generator',
+                'canonical_url'       => 'https://argorobots.com/invoice-generator/',
+                // Editor surface copy + accessibility labels
+                'hero_title'          => 'Free Invoice Generator',
+                'hero_tagline'        => 'Create professional invoices with one click. No signup required. Download as PDF or Word.',
+                'banner_text'         => 'Want to handle payments, refunds, and track everything?',
+                'toolbar_aria'        => 'Invoice tools',
+                'template_aria'       => 'Invoice template',
+                'editor_aria'         => 'Invoice editor',
+                'number_aria'         => 'Invoice number',
+                'totals_aria'         => 'Invoice totals',
+                'modal_heading'       => 'Your invoice is downloading',
+                // Default editable labels (mirrored to JS)
+                'document_title'      => 'INVOICE',
+                'due_date_label'      => 'Due Date',
+                // Placeholder for the recipient (Bill To) address box. Echoed
+                // raw so the &#10; line breaks survive; values are developer-
+                // defined, never user input.
+                'recipient_placeholder' => 'Client name&#10;Address&#10;City, State ZIP',
+                // Extra default-label overrides merged over the engine defaults
+                // (keyed by data-label name). Empty for the invoice baseline.
+                'label_overrides'     => [],
+                // Field visibility
+                'show_payment_terms'  => true,   // "Payment Terms" meta row
+                'show_payment_fields' => true,   // "Amount Paid" + "Balance Due" totals rows
+                'show_signature'      => false,  // optional acceptance/signature block
+                // Export + analytics + persistence (mirrored to JS)
+                'filename_prefix'     => 'invoice',
+                'storage_key'         => 'argobooks.invoiceGenerator.draft',
+                'event_prefix'        => 'invgen',
+                'tool_path'           => '/invoice-generator/',
+                // Conversion CTA attribution
+                'utm_source'          => 'invoice-generator',
+                'default_ref'         => 'invgen-tool',
+                'cta_href'            => '/features/invoicing/',
+            ],
+            'estimate' => [
+                'type'                => 'estimate',
+                'page_title'          => 'Free Estimate Generator | Argo Books',
+                'page_description'    => 'Free online estimate generator. No signup required. Download PDF or Word.',
+                'schema_name'         => 'Free Estimate Generator',
+                'canonical_url'       => 'https://argorobots.com/estimate-generator/',
+                'hero_title'          => 'Free Estimate Generator',
+                'hero_tagline'        => 'Create professional estimates with one click. No signup required. Download as PDF or Word.',
+                'banner_text'         => 'Want to turn estimates into invoices and get paid faster?',
+                'toolbar_aria'        => 'Estimate tools',
+                'template_aria'       => 'Estimate template',
+                'editor_aria'         => 'Estimate editor',
+                'number_aria'         => 'Estimate number',
+                'totals_aria'         => 'Estimate totals',
+                'modal_heading'       => 'Your estimate is downloading',
+                'document_title'      => 'ESTIMATE',
+                'due_date_label'      => 'Valid Until',
+                'recipient_placeholder' => 'Client name&#10;Address&#10;City, State ZIP',
+                'label_overrides'     => [],
+                'show_payment_terms'  => false,
+                'show_payment_fields' => false,
+                'show_signature'      => true,
+                'filename_prefix'     => 'estimate',
+                'storage_key'         => 'argobooks.estimateGenerator.draft',
+                'event_prefix'        => 'estgen',
+                'tool_path'           => '/estimate-generator/',
+                'utm_source'          => 'estimate-generator',
+                'default_ref'         => 'estgen-tool',
+                'cta_href'            => '/features/invoicing/',
+            ],
+            'purchase-order' => [
+                'type'                => 'purchase-order',
+                'page_title'          => 'Free Purchase Order Generator | Argo Books',
+                'page_description'    => 'Free online purchase order generator. No signup required. Download PDF or Word.',
+                'schema_name'         => 'Free Purchase Order Generator',
+                'canonical_url'       => 'https://argorobots.com/purchase-order-generator/',
+                'hero_title'          => 'Free Purchase Order Generator',
+                'hero_tagline'        => 'Create professional purchase orders with one click. No signup required. Download as PDF or Word.',
+                'banner_text'         => 'Want to track expenses, bills, and orders in one place?',
+                'toolbar_aria'        => 'Purchase order tools',
+                'template_aria'       => 'Purchase order template',
+                'editor_aria'         => 'Purchase order editor',
+                'number_aria'         => 'Purchase order number',
+                'totals_aria'         => 'Purchase order totals',
+                'modal_heading'       => 'Your purchase order is downloading',
+                'document_title'      => 'PURCHASE ORDER',
+                'due_date_label'      => 'Delivery Date',
+                // The recipient of a PO is the supplier you're ordering from.
+                'recipient_placeholder' => 'Vendor name&#10;Address&#10;City, State ZIP',
+                // "Bill To" -> "Vendor"; the separate "PO Number" meta field
+                // would be redundant on a PO (the document's own # is the PO
+                // number), so it becomes a free "Reference" field.
+                'label_overrides'     => [
+                    'billTo'         => 'Vendor',
+                    'poNumber'       => 'Reference',
+                    'signatureLabel' => 'Authorized by',
+                ],
+                // POs commonly state payment terms; they are not a payment
+                // record, so Amount Paid / Balance Due are dropped.
+                'show_payment_terms'  => true,
+                'show_payment_fields' => false,
+                'show_signature'      => true,
+                'filename_prefix'     => 'purchase-order',
+                'storage_key'         => 'argobooks.purchaseOrderGenerator.draft',
+                'event_prefix'        => 'pogen',
+                'tool_path'           => '/purchase-order-generator/',
+                'utm_source'          => 'purchase-order-generator',
+                'default_ref'         => 'pogen-tool',
+                // A PO is about buying, so the pitch points at expense tracking.
+                'cta_href'            => '/features/expense-revenue-tracking/',
+            ],
+        ];
+
+        return $configs[$type] ?? $configs['invoice'];
+    }
+
+    /**
+     * The JS-relevant subset of a config, ready to inject as window.DOC_CONFIG.
+     * Keys are camelCased to match how the client modules read them.
+     * showPaymentTerms / showPaymentFields gate, respectively, the Payment
+     * Terms meta line and the Amount Paid + Balance Due totals rows in the Word
+     * output (kept separate because a PO keeps terms but drops paid/balance).
+     */
+    function invgen_doc_config_js(array $dc): array
+    {
+        return [
+            'type'              => $dc['type'],
+            'documentTitle'     => $dc['document_title'],
+            'dueDateLabel'      => $dc['due_date_label'],
+            'filenamePrefix'    => $dc['filename_prefix'],
+            'storageKey'        => $dc['storage_key'],
+            'eventPrefix'       => $dc['event_prefix'],
+            'toolPath'          => $dc['tool_path'],
+            'showPaymentTerms'  => (bool) $dc['show_payment_terms'],
+            'showPaymentFields' => (bool) $dc['show_payment_fields'],
+            'labelOverrides'    => $dc['label_overrides'] ?? [],
+        ];
+    }
+}

--- a/invoice-generator/index.php
+++ b/invoice-generator/index.php
@@ -41,5 +41,6 @@ $body_content = ob_get_clean();
 
 require_once __DIR__ . '/_base.php';
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
 include __DIR__ . '/layout.php';

--- a/invoice-generator/layout.php
+++ b/invoice-generator/layout.php
@@ -16,6 +16,9 @@ $og_image = $og_image ?? 'https://argorobots.com/resources/images/og-default.png
 $body_content = $body_content ?? '';
 $extra_head = $extra_head ?? '';
 $extra_scripts = $extra_scripts ?? '';
+// Optional back-link to the /tools/ hub, shown top-left of the header. Opt-in:
+// set by the tool pages only, so guides / articles / niche pages are unaffected.
+$tools_back = $tools_back ?? null; // ['href' => ..., 'label' => ...]
 
 // Sitewide Organization + WebSite schema. Baked in for E-E-A-T.
 // Update logo path and sameAs URLs to match the project's real assets / social profiles.
@@ -95,6 +98,13 @@ $site_schema = [
     </a>
   </div>
 </header>
+<?php if ($tools_back): ?>
+<nav class="tool-breadcrumb" aria-label="Breadcrumb">
+  <a class="site-back" href="<?= htmlspecialchars($tools_back['href']) ?>">
+    <span class="site-back-arrow" aria-hidden="true">&larr;</span> <?= htmlspecialchars($tools_back['label']) ?>
+  </a>
+</nav>
+<?php endif; ?>
 <?= $body_content ?>
 <?= $extra_scripts ?>
 </body>

--- a/invoice-generator/scripts/docx.js
+++ b/invoice-generator/scripts/docx.js
@@ -18,6 +18,18 @@ const BASE = (typeof window !== 'undefined' && window.INVGEN_BASE) || '';
 const DOCX_SRC = `${BASE}/invoice-generator/vendor/docx.umd.js`;
 const COUNTRIES_URL = `${BASE}/invoice-generator/data/countries.json`;
 
+// Document-type config (shared engine; invoice defaults when absent).
+const DOC = (typeof window !== 'undefined' && window.DOC_CONFIG) || {};
+const FILENAME_PREFIX = DOC.filenamePrefix || 'invoice';
+const EVENT_PREFIX = DOC.eventPrefix || 'invgen';
+// Gate the invoice-only money fields. Default true preserves invoice output.
+// A purchase order keeps Payment Terms but drops Amount Paid / Balance Due,
+// so the two are tracked independently.
+const SHOW_PAYMENT_TERMS = DOC.showPaymentTerms !== false;
+const SHOW_PAYMENT_FIELDS = DOC.showPaymentFields !== false;
+// Title-cased document noun for the Word document's <title> metadata.
+const DOC_NOUN = FILENAME_PREFIX.charAt(0).toUpperCase() + FILENAME_PREFIX.slice(1);
+
 // Letter (8.5") at default 1" margins = 6.5" content = 9360 twentieths-of-a-
 // point (DXA). We use DXA for every table and cell width because the docx
 // library's PERCENTAGE width writes OOXML pct values that Google Docs reads
@@ -183,17 +195,20 @@ function buildHeader(state, d) {
     }
   }
   leftChildren.push(new Paragraph({
-    children: [new TextRun({ text: 'From', bold: true, size: 18, color: '666666' })],
+    children: [new TextRun({ text: (state.labels && state.labels.from) || 'From', bold: true, size: 18, color: '666666' })],
     spacing: { after: 40 },
   }));
   paragraphsFromMultiline(state.from || '', { size: 20 }, d).forEach((p) => leftChildren.push(p));
 
-  // Right cell: "INVOICE" heading and number, right-aligned.
+  // Right cell: document-title heading (e.g. "INVOICE" / "ESTIMATE") and
+  // number, right-aligned. The heading follows the editable documentTitle
+  // label so a renamed title flows through to the Word output.
+  const headingText = (state.labels && state.labels.documentTitle) || DOC.documentTitle || 'INVOICE';
   const invoiceNumberText = state.invoiceNumber ? `# ${state.invoiceNumber}` : '';
   const rightChildren = [
     new Paragraph({
       children: [new TextRun({
-        text: 'INVOICE',
+        text: headingText,
         bold: true,
         size: 44,
         font: style.headingFont,
@@ -263,8 +278,12 @@ function buildPartiesAndMeta(state, d) {
     return children;
   }
 
+  // Word labels follow the editable on-screen labels so a renamed field
+  // (e.g. "Bill To" -> "Vendor" on a purchase order) carries into the export.
+  const L = state.labels || {};
+
   const partyCells = [
-    new TableCell({ width: { size: dxa(33), type: WidthType.DXA }, borders: cellBorders, children: partyStack('Bill To', state.billTo) }),
+    new TableCell({ width: { size: dxa(33), type: WidthType.DXA }, borders: cellBorders, children: partyStack(L.billTo || 'Bill To', state.billTo) }),
   ];
   // Ship To: include only when the textbox actually has content. A toggled-on
   // but empty Ship To should not print a stray label.
@@ -273,7 +292,7 @@ function buildPartiesAndMeta(state, d) {
     partyCells.push(new TableCell({
       width: { size: dxa(33), type: WidthType.DXA },
       borders: cellBorders,
-      children: partyStack('Ship To', shipToText),
+      children: partyStack(L.shipTo || 'Ship To', shipToText),
     }));
   }
 
@@ -290,10 +309,10 @@ function buildPartiesAndMeta(state, d) {
       spacing: { after: 40 },
     }));
   };
-  pushMeta('Date', state.date);
-  pushMeta('Payment Terms', state.paymentTerms);
-  pushMeta('Due Date', state.dueDate);
-  pushMeta('PO Number', state.poNumber);
+  pushMeta(L.date || 'Date', state.date);
+  if (SHOW_PAYMENT_TERMS) pushMeta(L.paymentTerms || 'Payment Terms', state.paymentTerms);
+  pushMeta(L.dueDate || DOC.dueDateLabel || 'Due Date', state.dueDate);
+  pushMeta(L.poNumber || 'PO Number', state.poNumber);
 
   const metaCellWidth = shipToText ? 34 : 67;
   partyCells.push(new TableCell({
@@ -343,13 +362,15 @@ function buildLineItemsTable(state, d) {
     });
   }
 
+  // Column headers follow the editable on-screen labels.
+  const L = state.labels || {};
   const headerRow = new TableRow({
     tableHeader: true,
     children: [
-      headerCell('Description'),
-      headerCell('Quantity', AlignmentType.RIGHT),
-      headerCell('Rate', AlignmentType.RIGHT),
-      headerCell('Amount', AlignmentType.RIGHT),
+      headerCell(L.description || 'Description'),
+      headerCell(L.quantity || 'Quantity', AlignmentType.RIGHT),
+      headerCell(L.rate || 'Rate', AlignmentType.RIGHT),
+      headerCell(L.amount || 'Amount', AlignmentType.RIGHT),
     ],
   });
 
@@ -414,20 +435,22 @@ function buildTotals(state, totals, taxLabel, d) {
     }));
   };
 
-  pushRow('Subtotal', fmt(totals.subtotal));
+  // Totals labels follow the editable on-screen labels.
+  const L = state.labels || {};
+  pushRow(L.subtotal || 'Subtotal', fmt(totals.subtotal));
   if (state.discount !== null && state.discount !== undefined) {
-    pushRow('Discount', fmt(-totals.discount));
+    pushRow(L.discount || 'Discount', fmt(-totals.discount));
   }
   if (state.shipping !== null && state.shipping !== undefined) {
-    pushRow('Shipping', fmt(totals.shipping));
+    pushRow(L.shipping || 'Shipping', fmt(totals.shipping));
   }
   pushRow(taxLabel, fmt(totals.tax));
-  pushRow('Total', fmt(totals.total), { bold: true });
+  pushRow(L.total || 'Total', fmt(totals.total), { bold: true });
 
   const amountPaid = Number(state.amountPaid) || 0;
-  if (amountPaid !== 0) {
-    pushRow('Amount Paid', fmt(amountPaid));
-    pushRow('Balance Due', fmt(totals.balanceDue), { bold: true });
+  if (SHOW_PAYMENT_FIELDS && amountPaid !== 0) {
+    pushRow(L.amountPaid || 'Amount Paid', fmt(amountPaid));
+    pushRow(L.balanceDue || 'Balance Due', fmt(totals.balanceDue), { bold: true });
   }
 
   return new Table({
@@ -491,6 +514,54 @@ function buildBottomRow(state, totals, taxLabel, d) {
   });
 }
 
+// Optional acceptance / signature block: a heading plus two ruled lines (to
+// sign and to date) with captions beneath. Returns [] when not toggled on.
+function buildSignature(state, d) {
+  if (state.signature == null) return [];
+  const { Paragraph, TextRun, Table, TableRow, TableCell, WidthType, BorderStyle } = d;
+  const L = state.labels || {};
+
+  const noBorder = { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' };
+  const cellBorders = { top: noBorder, bottom: noBorder, left: noBorder, right: noBorder };
+  const ruleBorder = { style: BorderStyle.SINGLE, size: 4, color: '000000' };
+
+  // A signing cell: an empty paragraph carrying a bottom border (the line to
+  // sign on), then a small caption beneath it.
+  function signCell(caption, widthPct) {
+    return new TableCell({
+      width: { size: dxa(widthPct), type: WidthType.DXA },
+      borders: cellBorders,
+      children: [
+        new Paragraph({ border: { bottom: ruleBorder }, spacing: { before: 260, after: 40 }, children: [new TextRun({ text: '' })] }),
+        new Paragraph({ children: [new TextRun({ text: caption, size: 16, color: '666666' })] }),
+      ],
+    });
+  }
+
+  const heading = new Paragraph({
+    children: [new TextRun({ text: L.signatureLabel || 'Accepted by', bold: true, size: 20 })],
+    spacing: { after: 80 },
+  });
+
+  const table = new Table({
+    width: { size: DXA_FULL, type: WidthType.DXA },
+    columnWidths: [dxa(55), dxa(10), dxa(35)],
+    borders: {
+      top: noBorder, bottom: noBorder, left: noBorder, right: noBorder,
+      insideHorizontal: noBorder, insideVertical: noBorder,
+    },
+    rows: [new TableRow({
+      children: [
+        signCell(L.signatureName || 'Signature', 55),
+        new TableCell({ width: { size: dxa(10), type: WidthType.DXA }, borders: cellBorders, children: [new Paragraph('')] }),
+        signCell(L.signatureDate || 'Date', 35),
+      ],
+    })],
+  });
+
+  return [heading, table];
+}
+
 function buildDocument(state, totals, taxLabel, d) {
   const { Document, Paragraph, TextRun, Footer, AlignmentType } = d;
 
@@ -506,9 +577,15 @@ function buildDocument(state, totals, taxLabel, d) {
     buildBottomRow(state, totals, taxLabel, d),
   ];
 
+  const signatureEls = buildSignature(state, d);
+  if (signatureEls.length) {
+    children.push(spacer(320));
+    signatureEls.forEach((el) => children.push(el));
+  }
+
   return new Document({
     creator: 'Argo Books',
-    title: state.invoiceNumber ? `Invoice ${state.invoiceNumber}` : 'Invoice',
+    title: state.invoiceNumber ? `${DOC_NOUN} ${state.invoiceNumber}` : DOC_NOUN,
     sections: [{
       properties: {},
       footers: {
@@ -531,13 +608,17 @@ export async function downloadDocx(state) {
   const countriesData = await countriesPromiseLocal;
 
   const totals = computeTotals(state);
-  const taxLabel = taxLabelForCountry(countriesData, state.country);
+  // Prefer the editable on-screen tax label (what the user sees and the PDF
+  // shows) so Word matches; fall back to the country-derived label.
+  const taxLabel = (state.labels && state.labels.tax)
+    ? state.labels.tax
+    : taxLabelForCountry(countriesData, state.country);
   const doc = buildDocument(state, totals, taxLabel, d);
 
   const blob = await d.Packer.toBlob(doc);
 
   const safeNumber = (state.invoiceNumber && String(state.invoiceNumber).trim()) || 'draft';
-  const filename = `invoice-${safeNumber}.docx`;
+  const filename = `${FILENAME_PREFIX}-${safeNumber}.docx`;
 
   const url = URL.createObjectURL(blob);
   try {
@@ -551,5 +632,5 @@ export async function downloadDocx(state) {
     // Allow the browser to start the download before revoking.
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-  trackEvent('invgen_docx_downloaded', state.template || '');
+  trackEvent(`${EVENT_PREFIX}_docx_downloaded`, state.template || '');
 }

--- a/invoice-generator/scripts/main.js
+++ b/invoice-generator/scripts/main.js
@@ -11,6 +11,13 @@ import { trackEvent } from './tracker.js';
 
 const BASE = (typeof window !== 'undefined' && window.INVGEN_BASE) || '';
 
+// Document-type config (shared engine; invoice defaults when absent). EVP
+// prefixes the analytics event names so the estimate tool reports under
+// estgen_*; TOOL_PATH is the canonical path for the "Copy share link" URL.
+const DOC = (typeof window !== 'undefined' && window.DOC_CONFIG) || {};
+const EVP = DOC.eventPrefix || 'invgen';
+const TOOL_PATH = DOC.toolPath || '/invoice-generator/';
+
 // ---------- tiny DOM helpers ----------
 
 const $ = (sel, root = document) => root.querySelector(sel);
@@ -122,6 +129,20 @@ function hydrateFromState() {
       shippingRow.hidden = false;
       if (shippingToggleBtn) shippingToggleBtn.hidden = true;
       setFieldValue($('[data-field="shipping-value"]'), state.shipping.value);
+    }
+  }
+
+  // Signature: shown only when state.signature is not null. The block only
+  // exists on doc types that opt in (estimate, purchase order).
+  const signatureBlock = $('#signature-block');
+  const signatureToggleBtn = $('[data-action="toggle-signature"]');
+  if (signatureBlock) {
+    if (state.signature == null) {
+      signatureBlock.hidden = true;
+      if (signatureToggleBtn) signatureToggleBtn.hidden = false;
+    } else {
+      signatureBlock.hidden = false;
+      if (signatureToggleBtn) signatureToggleBtn.hidden = true;
     }
   }
 
@@ -313,13 +334,13 @@ function onAnyInput(ev) {
     state.template = value;
     applyTemplate(state.template);
     handleSaveResult(saveDraft(state));
-    trackEvent('invgen_template_changed', value);
+    trackEvent(`${EVP}_template_changed`, value);
     return;
   }
 
   if (field === 'currency') {
     applyCurrency(value);
-    trackEvent('invgen_currency_changed', value);
+    trackEvent(`${EVP}_currency_changed`, value);
     return;
   }
 
@@ -415,7 +436,7 @@ async function handleLogoFileChange(ev) {
     } else {
       handleSaveResult(result);
     }
-    trackEvent('invgen_logo_uploaded', '');
+    trackEvent(`${EVP}_logo_uploaded`, '');
   } catch (_e) {
     showToast('Could not read that image. Try a different file.');
   }
@@ -539,6 +560,17 @@ function wireToggles() {
     if (valueInput) valueInput.focus();
     rerenderAndSave();
   });
+
+  // Signature/acceptance block: present only on opt-in doc types.
+  const signatureBtn = $('[data-action="toggle-signature"]');
+  if (signatureBtn) signatureBtn.addEventListener('click', () => {
+    if (state.signature != null) return;
+    state.signature = {};
+    const block = $('#signature-block');
+    if (block) block.hidden = false;
+    signatureBtn.hidden = true;
+    handleSaveResult(saveDraft(state));
+  });
 }
 
 // "Remove" controls live inside the toggle rows themselves; we install them
@@ -584,6 +616,22 @@ function ensureSectionRemoveButtons() {
       const wrap = $('#field-shipTo-wrap');
       if (wrap) wrap.hidden = true;
       const btn = $('[data-action="toggle-shipTo"]');
+      if (btn) {
+        btn.hidden = false;
+        btn.focus();
+      }
+      handleSaveResult(saveDraft(state));
+    },
+  });
+
+  installRemoveButton({
+    rowSelector: '#signature-block',
+    label: 'Remove signature',
+    onRemove: () => {
+      state.signature = null;
+      const block = $('#signature-block');
+      if (block) block.hidden = true;
+      const btn = $('[data-action="toggle-signature"]');
       if (btn) {
         btn.hidden = false;
         btn.focus();
@@ -690,7 +738,7 @@ function wirePitchTracking() {
   document.querySelectorAll('[data-pitch-placement]').forEach((el) => {
     el.addEventListener('click', () => {
       const placement = el.getAttribute('data-pitch-placement') || '';
-      trackEvent('invgen_cta_clicked', placement);
+      trackEvent(`${EVP}_cta_clicked`, placement);
     });
   });
 }
@@ -764,7 +812,7 @@ function wireCopyShareLink() {
     button.textContent = 'Copying...';
     try {
       const { serializeShareLink } = await import(`${BASE}/invoice-generator/scripts/url-params.js`);
-      const shareUrl = serializeShareLink(`${window.location.origin}${BASE}/invoice-generator/`, state);
+      const shareUrl = serializeShareLink(`${window.location.origin}${BASE}${TOOL_PATH}`, state);
       let copied = false;
       if (navigator.clipboard && window.isSecureContext) {
         try {
@@ -785,7 +833,7 @@ function wireCopyShareLink() {
       }
       showToast(copied ? 'Share link copied to clipboard.' : 'Could not copy. The link is in your address bar.');
       if (copied) {
-        try { trackEvent('invgen_share_link_copied', ''); } catch (_e) { /* tracking is best-effort */ }
+        try { trackEvent(`${EVP}_share_link_copied`, ''); } catch (_e) { /* tracking is best-effort */ }
       }
     } catch (err) {
       console.error('Share link copy failed:', err);
@@ -820,7 +868,7 @@ async function init() {
     const slug = (typeof window !== 'undefined' && window.INVOICE_NICHE_SLUG)
       ? String(window.INVOICE_NICHE_SLUG)
       : '';
-    trackEvent('invgen_niche_default_used', slug);
+    trackEvent(`${EVP}_niche_default_used`, slug);
   }
 
   // Share-link URL parameters override the persisted draft for THIS session

--- a/invoice-generator/scripts/pdf.js
+++ b/invoice-generator/scripts/pdf.js
@@ -34,6 +34,11 @@ const BASE = (typeof window !== 'undefined' && window.INVGEN_BASE) || '';
 const HTML2CANVAS_SRC = `${BASE}/invoice-generator/vendor/html2canvas.min.js`;
 const JSPDF_SRC = `${BASE}/invoice-generator/vendor/jspdf.umd.min.js`;
 
+// Document-type config (shared engine; invoice defaults when absent).
+const DOC = (typeof window !== 'undefined' && window.DOC_CONFIG) || {};
+const FILENAME_PREFIX = DOC.filenamePrefix || 'invoice';
+const EVENT_PREFIX = DOC.eventPrefix || 'invgen';
+
 let libsPromise = null;
 
 function loadScript(src) {
@@ -198,9 +203,9 @@ export async function downloadPdf(state) {
     pdf.text('Made with argorobots.com', pageWidthMm / 2, pageHeightMm - 5, { align: 'center' });
 
     const number = (state.invoiceNumber || '').toString().trim() || 'draft';
-    pdf.save(`invoice-${number}.pdf`);
+    pdf.save(`${FILENAME_PREFIX}-${number}.pdf`);
 
-    trackEvent('invgen_pdf_downloaded', state.template);
+    trackEvent(`${EVENT_PREFIX}_pdf_downloaded`, state.template);
   } finally {
     invoice.classList.remove('invgen-capturing');
   }

--- a/invoice-generator/scripts/state.js
+++ b/invoice-generator/scripts/state.js
@@ -1,10 +1,17 @@
 // invoice-generator/scripts/state.js
 // Invoice state model + localStorage persistence.
+//
+// The engine is shared by the invoice, estimate, and purchase-order generators.
+// window.DOC_CONFIG (injected by the page) carries the document-type overrides;
+// when it is absent (the invoice standalone page and every niche page) the
+// invoice defaults apply, so behavior is unchanged.
 
-const STORAGE_KEY = 'argobooks.invoiceGenerator.draft';
+const DOC = (typeof window !== 'undefined' && window.DOC_CONFIG) || {};
+
+const STORAGE_KEY = DOC.storageKey || 'argobooks.invoiceGenerator.draft';
 
 export function emptyState() {
-  return {
+  const state = {
     template: 'classic',
     country: 'US',
     currency: 'USD',
@@ -28,18 +35,19 @@ export function emptyState() {
     notes: '',
     terms: '',
     amountPaid: 0,
+    signature: null, // null means the acceptance/signature block is hidden; {} when shown
     // Every visible piece of text on the invoice surface is user-editable.
     // The default values are the standard invoice labels; the user can
     // rename any of them (e.g. "Bill To" -> "Client", "Tax" -> "GST").
     labels: {
       businessTitle: '',
-      documentTitle: 'INVOICE',
+      documentTitle: DOC.documentTitle || 'INVOICE',
       from: 'From',
       billTo: 'Bill To',
       shipTo: 'Ship To',
       date: 'Date',
       paymentTerms: 'Payment Terms',
-      dueDate: 'Due Date',
+      dueDate: DOC.dueDateLabel || 'Due Date',
       poNumber: 'PO Number',
       description: 'Description',
       quantity: 'Quantity',
@@ -54,8 +62,20 @@ export function emptyState() {
       total: 'Total',
       amountPaid: 'Amount Paid',
       balanceDue: 'Balance Due',
+      signatureLabel: 'Accepted by',
+      signatureName: 'Signature',
+      signatureDate: 'Date',
     },
   };
+
+  // Per-document-type label overrides (e.g. "Bill To" -> "Vendor" for a PO),
+  // merged over the defaults above. Only known label keys are applied.
+  const overrides = DOC.labelOverrides || {};
+  for (const key of Object.keys(overrides)) {
+    if (key in state.labels) state.labels[key] = overrides[key];
+  }
+
+  return state;
 }
 
 function todayISO() {
@@ -70,17 +90,32 @@ function addDaysISO(iso, days) {
 
 // Priority: localStorage draft > nicheDefaults > empty state.
 // (A.18 introduces nicheDefaults; A.7 ships the parameter as a no-op-friendly default.)
+//
+// `labels` is merged one level deep, not shallow-replaced: a draft saved before
+// a new label existed (e.g. the signature captions) would otherwise clobber the
+// whole labels object and blank out the new defaults. Deep-merging backfills
+// any new default labels while preserving the user's own renames.
+function mergeOver(base, overlay) {
+  if (!overlay || typeof overlay !== 'object') return base;
+  return {
+    ...base,
+    ...overlay,
+    labels: { ...base.labels, ...(overlay.labels || {}) },
+  };
+}
+
 export function loadDraft(nicheDefaults) {
+  const base = emptyState();
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) return { ...emptyState(), ...JSON.parse(raw) };
+    if (raw) return mergeOver(base, JSON.parse(raw));
   } catch (_e) {
     // fall through to defaults
   }
   if (nicheDefaults && typeof nicheDefaults === 'object') {
-    return { ...emptyState(), ...nicheDefaults };
+    return mergeOver(base, nicheDefaults);
   }
-  return emptyState();
+  return base;
 }
 
 export function saveDraft(state) {

--- a/invoice-generator/styles/tool.css
+++ b/invoice-generator/styles/tool.css
@@ -1462,6 +1462,67 @@ body {
   width: 100%;
 }
 
+/* Optional acceptance / signature block. Toggled on like Ship To; the user
+   prints the document and signs above each line. Lines are plain ruled
+   borders so they print cleanly and capture into the PDF. */
+.invoice-signature {
+  margin-top: 28px;
+}
+
+.signature-block {
+  position: relative;
+}
+
+.signature-heading {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--invoice-text);
+  margin-bottom: 24px;
+}
+
+.signature-row {
+  display: flex;
+  gap: 40px;
+  flex-wrap: wrap;
+}
+
+.signature-field {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.signature-field-date {
+  flex: 0 1 200px;
+}
+
+.signature-line {
+  display: block;
+  height: 28px;
+  border-bottom: 1px solid var(--invoice-text);
+}
+
+.signature-caption {
+  margin-top: 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--invoice-muted);
+  font-weight: 600;
+}
+
+.signature-toggle-row {
+  margin-top: 12px;
+}
+
+.signature-block > .invgen-section-remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
 .invoice-totals {
   display: flex;
   flex-direction: column;
@@ -2171,6 +2232,7 @@ input.editable-document-title {
 .invgen-capturing .col-delete,
 .invgen-capturing .meta-label-spacer,
 .invgen-capturing .line-items-actions,
+.invgen-capturing .signature-toggle-row,
 .invgen-capturing #logo-slot {
   display: none !important;
 }

--- a/invoice-generator/styles/tool.css
+++ b/invoice-generator/styles/tool.css
@@ -956,6 +956,35 @@ body {
   flex: 0 0 auto;
 }
 
+/* Back-link to the /tools/ hub, in its own row below the header, aligned to
+   the content's max-width. */
+.tool-breadcrumb {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 12px 20px 0;
+}
+
+.site-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+  color: var(--tool-muted);
+  font-size: 14px;
+  font-weight: 500;
+  flex: 0 0 auto;
+}
+
+.site-back:hover,
+.site-back:focus {
+  color: var(--tool-primary);
+}
+
+.site-back-arrow {
+  font-size: 16px;
+  line-height: 1;
+}
+
 .site-brand img {
   display: block;
   height: 28px;
@@ -966,6 +995,11 @@ body {
 @media (max-width: 540px) {
   .site-header-inner {
     padding: 12px 16px;
+  }
+
+  .tool-breadcrumb {
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }
 

--- a/invoice-template/index.php
+++ b/invoice-template/index.php
@@ -99,5 +99,6 @@ ob_start();
 </article>
 <?php
 $body_content = ob_get_clean();
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
 include __DIR__ . '/../invoice-generator/layout.php';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test invoice-generator/scripts/*.test.js self-employed-tax-calculator/scripts/*.test.js",
+    "test": "node --test invoice-generator/scripts/*.test.js self-employed-tax-calculator/scripts/*.test.js craft-pricing-calculator/scripts/*.test.js",
     "build:templates": "node invoice-generator/scripts/build-templates.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test invoice-generator/scripts/*.test.js",
+    "test": "node --test invoice-generator/scripts/*.test.js self-employed-tax-calculator/scripts/*.test.js",
     "build:templates": "node invoice-generator/scripts/build-templates.js"
   },
   "devDependencies": {

--- a/purchase-order-generator/index.php
+++ b/purchase-order-generator/index.php
@@ -55,5 +55,6 @@ include __DIR__ . '/../invoice-generator/_fragment.php';
 $body_content = ob_get_clean();
 
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
 include __DIR__ . '/../invoice-generator/layout.php';

--- a/purchase-order-generator/index.php
+++ b/purchase-order-generator/index.php
@@ -1,0 +1,59 @@
+<?php
+// purchase-order-generator/index.php
+// Standalone free purchase order generator tool page.
+//
+// Thin shell over the SHARED generator engine that lives in /invoice-generator/.
+// It picks the 'purchase-order' document-type config, embeds the same editor
+// surface (_fragment.php), mirrors the JS-relevant config to window.DOC_CONFIG,
+// and defers to the same layout.php + main.js. See invoice-generator/doc-config.php
+// for the full config and the consolidation rationale.
+
+require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../invoice-generator/doc-config.php';
+
+$doc_type = 'purchase-order';
+$dc = invgen_doc_config($doc_type);
+
+// Server-side page view. track_page_view() filters admins, bots, and duplicates
+// itself, so calling it unconditionally is safe. Skip during PHP CLI smoke
+// tests (no $_SERVER['REMOTE_ADDR'], no real visitor).
+if (PHP_SAPI !== 'cli') {
+    require_once __DIR__ . '/../statistics.php';
+    track_page_view('pogen_tool');
+}
+
+$page_title = $dc['page_title'];
+$page_description = $dc['page_description'];
+$canonical_url = $dc['canonical_url'];
+
+// Referral source baked into every conversion-pitch CTA inside _fragment.php.
+$invgen_ref = $dc['default_ref'];
+
+// Show the hero (H1 + tagline) only on the standalone tool page.
+$show_tool_hero = true;
+
+$page_schema_json = json_encode([
+  '@context' => 'https://schema.org',
+  '@type' => 'SoftwareApplication',
+  'name' => $dc['schema_name'],
+  'applicationCategory' => 'BusinessApplication',
+  'operatingSystem' => 'Web',
+  'offers' => ['@type' => 'Offer', 'price' => '0', 'priceCurrency' => 'USD'],
+  'creator' => ['@id' => 'https://argorobots.com/#organization'],
+  'url' => $dc['canonical_url'],
+], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+
+// Mirror the JS-relevant config to window.DOC_CONFIG so the shared engine
+// modules (state/pdf/docx/main) know this is a purchase order. Emitted into the
+// <head> via $extra_head, ahead of main.js which loads at end of <body>.
+$extra_head = '<script>window.DOC_CONFIG = '
+    . json_encode(invgen_doc_config_js($dc), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT)
+    . ';</script>';
+
+ob_start();
+include __DIR__ . '/../invoice-generator/_fragment.php';
+$body_content = ob_get_clean();
+
+$extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
+
+include __DIR__ . '/../invoice-generator/layout.php';

--- a/resources/footer/footer.php
+++ b/resources/footer/footer.php
@@ -54,6 +54,7 @@
       <li><a href="<?= $base ?>about-us/">About Us</a></li>
       <li><a href="<?= $base ?>contact-us/">Contact Us</a></li>
       <li><a href="<?= $base ?>guides/">Guides</a></li>
+      <li><a href="<?= $base ?>tools/">Tools</a></li>
       <li><a href="<?= $base ?>review/">Leave a Review</a></li>
     </ul>
   </div>

--- a/self-employed-tax-calculator/data/tax-rates-2026.js
+++ b/self-employed-tax-calculator/data/tax-rates-2026.js
@@ -1,0 +1,257 @@
+// self-employed-tax-calculator/data/tax-rates-2026.js
+//
+// Single source of truth for the 2026 tax-year rates used by the self-employed
+// tax calculator. To update for a future year, copy this file, edit the
+// numbers, bump TAX_META, and point calc.js at the new file.
+//
+// TAX YEAR: 2026
+// LAST VERIFIED: 2026-06-07
+//
+// SOURCES (all figures are 2026 tax year):
+//  - US federal brackets + standard deduction: Tax Foundation 2026
+//    https://taxfoundation.org/data/all/federal/2026-tax-brackets/
+//  - US Social Security wage base ($184,500) + SE tax (15.3%, 92.35% factor):
+//    SSA 2026 COLA fact sheet; IRS self-employment tax guidance.
+//  - Canada federal brackets + basic personal amount: taxtips.ca/taxrates/canada.htm
+//  - CPP / QPP 2026 (rates, YMPE $74,600, YAMPE $85,000, $3,500 exemption):
+//    taxtips.ca/cpp-qpp-and-ei/cpp-qpp-contribution-rates.htm
+//  - Each province/territory: taxtips.ca/taxrates/<prov>.htm
+//
+// IMPORTANT — this is a deliberately SIMPLE ("set aside roughly this much")
+// estimate. It assumes a single / basic filer with no dependants and only the
+// standard deduction (US) or basic personal amount (Canada). It errs slightly
+// HIGH (the safe direction for a set-aside tool) by omitting:
+//   US: the QBI (199A) deduction, state income tax, the extra 0.9% Medicare
+//       surtax over $200k, and non-single filing statuses.
+//   CA: the CPP/QPP deduction & credit, EI/QPIP, the Ontario low-income
+//       reduction, and dependant/spousal credits. Uses the maximum federal
+//       basic personal amount (exact below $181,440; minor at higher incomes).
+// It is NOT tax advice. See the disclaimer on the page.
+
+export const TAX_META = {
+  taxYear: 2026,
+  lastVerified: '2026-06-07',
+};
+
+// Brackets are marginal: each entry taxes income between the previous entry's
+// `upTo` and this entry's `upTo` at `rate`. The final entry uses Infinity.
+export const US = {
+  standardDeduction: 16100, // single filer, 2026
+  brackets: [
+    { upTo: 12400, rate: 0.10 },
+    { upTo: 50400, rate: 0.12 },
+    { upTo: 105700, rate: 0.22 },
+    { upTo: 201775, rate: 0.24 },
+    { upTo: 256225, rate: 0.32 },
+    { upTo: 640600, rate: 0.35 },
+    { upTo: Infinity, rate: 0.37 },
+  ],
+  se: {
+    netFactor: 0.9235,      // net earnings from self-employment = profit * 92.35%
+    socialSecurityRate: 0.124,
+    medicareRate: 0.029,
+    socialSecurityWageBase: 184500, // 2026 SS taxable maximum
+    minNetEarnings: 400,    // below this, no SE tax is owed
+  },
+};
+
+// Canada Pension Plan (rest of Canada) and Quebec Pension Plan (QC).
+// Self-employed pay both the employee and employer portions.
+export const CANADA_PENSION = {
+  basicExemption: 3500,
+  ympe: 74600,  // Year's Maximum Pensionable Earnings (first ceiling)
+  yampe: 85000, // Year's Additional Maximum Pensionable Earnings (second ceiling)
+  cpp: { baseSelfRate: 0.119, secondSelfRate: 0.08 }, // CPP + CPP2
+  qpp: { baseSelfRate: 0.126, secondSelfRate: 0.08 }, // QPP + QPP2 (Quebec)
+};
+
+export const CANADA_FEDERAL = {
+  brackets: [
+    { upTo: 58523, rate: 0.14 },
+    { upTo: 117045, rate: 0.205 },
+    { upTo: 181440, rate: 0.26 },
+    { upTo: 258482, rate: 0.29 },
+    { upTo: Infinity, rate: 0.33 },
+  ],
+  lowestRate: 0.14, // rate at which the basic personal amount credit is given
+  // Basic personal amount phases from max down to min between these incomes.
+  bpaMax: 16452,
+  bpaMin: 14829,
+  bpaPhaseStart: 181440,
+  bpaPhaseEnd: 258482,
+  quebecAbatement: 0.165, // QC residents' federal tax is reduced by 16.5%
+};
+
+// Provinces / territories. `bpa` is the provincial basic personal amount,
+// credited at `lowestRate` (the first bracket's rate). `surtax` (Ontario only)
+// applies to provincial tax after the BPA credit.
+export const PROVINCES = {
+  AB: {
+    name: 'Alberta',
+    lowestRate: 0.08,
+    bpa: 22769,
+    brackets: [
+      { upTo: 61200, rate: 0.08 },
+      { upTo: 154259, rate: 0.10 },
+      { upTo: 185111, rate: 0.12 },
+      { upTo: 246813, rate: 0.13 },
+      { upTo: 370220, rate: 0.14 },
+      { upTo: Infinity, rate: 0.15 },
+    ],
+  },
+  BC: {
+    name: 'British Columbia',
+    lowestRate: 0.0506,
+    bpa: 13216,
+    brackets: [
+      { upTo: 50363, rate: 0.0506 },
+      { upTo: 100728, rate: 0.077 },
+      { upTo: 115648, rate: 0.105 },
+      { upTo: 140430, rate: 0.1229 },
+      { upTo: 190405, rate: 0.147 },
+      { upTo: 265545, rate: 0.168 },
+      { upTo: Infinity, rate: 0.205 },
+    ],
+  },
+  MB: {
+    name: 'Manitoba',
+    lowestRate: 0.108,
+    bpa: 15780,
+    brackets: [
+      { upTo: 47000, rate: 0.108 },
+      { upTo: 100000, rate: 0.1275 },
+      { upTo: Infinity, rate: 0.174 },
+    ],
+  },
+  NB: {
+    name: 'New Brunswick',
+    lowestRate: 0.094,
+    bpa: 13664,
+    brackets: [
+      { upTo: 52333, rate: 0.094 },
+      { upTo: 104666, rate: 0.14 },
+      { upTo: 193861, rate: 0.16 },
+      { upTo: Infinity, rate: 0.195 },
+    ],
+  },
+  NL: {
+    name: 'Newfoundland and Labrador',
+    lowestRate: 0.087,
+    bpa: 13094,
+    brackets: [
+      { upTo: 44678, rate: 0.087 },
+      { upTo: 89354, rate: 0.145 },
+      { upTo: 159528, rate: 0.158 },
+      { upTo: 223340, rate: 0.178 },
+      { upTo: 285319, rate: 0.198 },
+      { upTo: 570638, rate: 0.208 },
+      { upTo: 1141275, rate: 0.213 },
+      { upTo: Infinity, rate: 0.218 },
+    ],
+  },
+  NS: {
+    name: 'Nova Scotia',
+    lowestRate: 0.0879,
+    bpa: 11932,
+    brackets: [
+      { upTo: 30995, rate: 0.0879 },
+      { upTo: 61991, rate: 0.1495 },
+      { upTo: 97417, rate: 0.1667 },
+      { upTo: 157124, rate: 0.175 },
+      { upTo: Infinity, rate: 0.21 },
+    ],
+  },
+  NT: {
+    name: 'Northwest Territories',
+    lowestRate: 0.059,
+    bpa: 18198,
+    brackets: [
+      { upTo: 53003, rate: 0.059 },
+      { upTo: 106009, rate: 0.086 },
+      { upTo: 172346, rate: 0.122 },
+      { upTo: Infinity, rate: 0.1405 },
+    ],
+  },
+  NU: {
+    name: 'Nunavut',
+    lowestRate: 0.04,
+    bpa: 19659,
+    brackets: [
+      { upTo: 55801, rate: 0.04 },
+      { upTo: 111602, rate: 0.07 },
+      { upTo: 181439, rate: 0.09 },
+      { upTo: Infinity, rate: 0.115 },
+    ],
+  },
+  ON: {
+    name: 'Ontario',
+    lowestRate: 0.0505,
+    bpa: 12989,
+    brackets: [
+      { upTo: 53891, rate: 0.0505 },
+      { upTo: 107785, rate: 0.0915 },
+      { upTo: 150000, rate: 0.1116 },
+      { upTo: 220000, rate: 0.1216 },
+      { upTo: Infinity, rate: 0.1316 },
+    ],
+    // Ontario surtax, applied to basic Ontario tax (after the BPA credit):
+    // 20% of tax over t1, plus an additional 36% of tax over t2.
+    surtax: { t1: 5818, r1: 0.20, t2: 7446, r2: 0.36 },
+  },
+  PE: {
+    name: 'Prince Edward Island',
+    lowestRate: 0.095,
+    bpa: 15000,
+    brackets: [
+      { upTo: 33928, rate: 0.095 },
+      { upTo: 65820, rate: 0.1347 },
+      { upTo: 106890, rate: 0.166 },
+      { upTo: 142250, rate: 0.1762 },
+      { upTo: 200000, rate: 0.19 },
+      { upTo: Infinity, rate: 0.20 },
+    ],
+  },
+  QC: {
+    name: 'Quebec',
+    lowestRate: 0.14,
+    bpa: 18952,
+    usesQpp: true, // Quebec uses QPP, and federal tax gets the 16.5% abatement
+    brackets: [
+      { upTo: 54345, rate: 0.14 },
+      { upTo: 108680, rate: 0.19 },
+      { upTo: 132245, rate: 0.24 },
+      { upTo: Infinity, rate: 0.2575 },
+    ],
+  },
+  SK: {
+    name: 'Saskatchewan',
+    lowestRate: 0.105,
+    bpa: 20381,
+    brackets: [
+      { upTo: 54532, rate: 0.105 },
+      { upTo: 155805, rate: 0.125 },
+      { upTo: Infinity, rate: 0.145 },
+    ],
+  },
+  YT: {
+    name: 'Yukon',
+    lowestRate: 0.064,
+    bpa: 16452, // Yukon mirrors the federal basic personal amount
+    // Statutory rates: 6.4 / 9 / 10.9 / 12.8 / 15. (Some tables show 12.93%
+    // in the $181,440-$258,482 band; that is the *effective* rate once
+    // Yukon's BPA-supplement clawback is folded in, not the statutory rate.
+    // We model BPA as a flat credit, so we use the statutory 12.8% here.)
+    brackets: [
+      { upTo: 58523, rate: 0.064 },
+      { upTo: 117045, rate: 0.09 },
+      { upTo: 181440, rate: 0.109 },
+      { upTo: 500000, rate: 0.128 },
+      { upTo: Infinity, rate: 0.15 },
+    ],
+  },
+};
+
+// Display order for the province dropdown (alphabetical by full name).
+export const PROVINCE_ORDER = [
+  'AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT',
+];

--- a/self-employed-tax-calculator/index.php
+++ b/self-employed-tax-calculator/index.php
@@ -1,0 +1,129 @@
+<?php
+// self-employed-tax-calculator/index.php
+// Standalone free self-employed tax calculator (US + Canada, 2026).
+//
+// Reuses the shared tool shell (invoice-generator/layout.php): same header,
+// "All tools" breadcrumb, SEO/OG/schema, and tool.css chrome. The calculation
+// is client-side (scripts/main.js + calc.js + data/tax-rates-2026.js).
+
+require_once __DIR__ . '/../invoice-generator/_base.php';
+
+if (PHP_SAPI !== 'cli') {
+    require_once __DIR__ . '/../statistics.php';
+    track_page_view('taxcalc_tool');
+}
+
+$page_title = 'Free Self-Employed Tax Calculator (US & Canada) | Argo Books';
+$page_description = 'Free self-employed tax calculator for the US and Canada. Estimate your self-employment/CPP tax and income tax for 2026, and see how much to set aside each quarter. No signup.';
+$canonical_url = 'https://argorobots.com/self-employed-tax-calculator/';
+
+$page_schema_json = json_encode([
+  '@context' => 'https://schema.org',
+  '@type' => 'SoftwareApplication',
+  'name' => 'Free Self-Employed Tax Calculator',
+  'applicationCategory' => 'FinanceApplication',
+  'operatingSystem' => 'Web',
+  'offers' => ['@type' => 'Offer', 'price' => '0', 'priceCurrency' => 'USD'],
+  'creator' => ['@id' => 'https://argorobots.com/#organization'],
+  'url' => $canonical_url,
+], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+
+$tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
+
+$extra_head = '<link rel="stylesheet" href="' . INVGEN_BASE . '/self-employed-tax-calculator/styles/calculator.css">';
+$extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/self-employed-tax-calculator/scripts/main.js"></script>';
+
+// Conversion-pitch CTA target: a self-employed tax tool funnels naturally into
+// year-round expense tracking.
+$cta_qs = '?source=taxcalc-tool&amp;utm_source=tax-calculator&amp;utm_medium=tool&amp;utm_campaign=phase1';
+
+ob_start();
+?>
+<div class="taxcalc-app">
+
+  <section class="site-hero">
+    <h1 class="site-hero-title">Free Self-Employed Tax Calculator</h1>
+    <p class="site-hero-tagline">Estimate your self-employment taxes and how much to set aside. United States &amp; Canada, 2026 tax year. No signup.</p>
+  </section>
+
+  <aside class="page-banner" role="complementary">
+    <span class="page-banner-text">Want this worked out automatically all year?</span>
+    <a class="page-banner-link" data-pitch-placement="banner" href="<?= INVGEN_BASE ?>/features/expense-revenue-tracking/<?= $cta_qs ?>&amp;placement=banner">Track income &amp; expenses with Argo Books <span aria-hidden="true">&rarr;</span></a>
+  </aside>
+
+  <div class="taxcalc-grid">
+    <form class="taxcalc-form" autocomplete="off" aria-label="Tax calculator inputs">
+      <div class="taxcalc-field">
+        <label for="tc-country">Country</label>
+        <select id="tc-country" data-tc="country">
+          <option value="US">United States</option>
+          <option value="CA">Canada</option>
+        </select>
+      </div>
+
+      <div class="taxcalc-field" data-tc-province-field hidden>
+        <label for="tc-province">Province or territory</label>
+        <select id="tc-province" data-tc="province"></select>
+      </div>
+
+      <div class="taxcalc-field">
+        <label for="tc-income">Self-employed income (for the year)</label>
+        <div class="taxcalc-money">
+          <span class="taxcalc-money-affix">$</span>
+          <input id="tc-income" data-tc="income" type="number" inputmode="decimal" min="0" step="100" placeholder="0">
+        </div>
+      </div>
+
+      <div class="taxcalc-field">
+        <label for="tc-expenses">Business expenses (for the year)</label>
+        <div class="taxcalc-money">
+          <span class="taxcalc-money-affix">$</span>
+          <input id="tc-expenses" data-tc="expenses" type="number" inputmode="decimal" min="0" step="100" placeholder="0">
+        </div>
+        <p class="taxcalc-hint">Income minus expenses is your taxable profit.</p>
+      </div>
+
+      <p class="taxcalc-note" data-tc="region-note"></p>
+    </form>
+
+    <div class="taxcalc-results" data-tc-results aria-live="polite">
+      <div class="taxcalc-headline">
+        <span class="taxcalc-headline-label">Set aside about</span>
+        <span class="taxcalc-headline-amount" data-tc="setaside">$0</span>
+        <span class="taxcalc-headline-sub"><span data-tc="setaside-pct">0%</span> of your income &middot; roughly <span data-tc="quarterly">$0</span> per quarter</span>
+      </div>
+
+      <dl class="taxcalc-breakdown">
+        <div class="taxcalc-breakdown-row">
+          <dt>Taxable profit</dt>
+          <dd data-tc="netprofit">$0</dd>
+        </div>
+        <div class="taxcalc-breakdown-row">
+          <dt data-tc="contribution-label">Self-employment tax</dt>
+          <dd data-tc="contribution">$0</dd>
+        </div>
+        <div class="taxcalc-breakdown-row">
+          <dt>Income tax</dt>
+          <dd data-tc="incometax">$0</dd>
+        </div>
+        <div class="taxcalc-breakdown-row taxcalc-breakdown-total">
+          <dt>Total estimated tax</dt>
+          <dd data-tc="total">$0</dd>
+        </div>
+        <div class="taxcalc-breakdown-row taxcalc-breakdown-rate">
+          <dt>Effective tax rate</dt>
+          <dd data-tc="effrate">0%</dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+
+  <p class="taxcalc-disclaimer">
+    <strong>Estimate only &mdash; not tax advice.</strong> This is a simplified 2026 estimate for a single, basic filer using the standard deduction (US) or basic personal amount (Canada). It leaves out credits, other deductions, and (for the US) state income tax, so your actual tax will differ. Check with a tax professional before making decisions.
+  </p>
+
+</div>
+<?php
+$body_content = ob_get_clean();
+
+include __DIR__ . '/../invoice-generator/layout.php';

--- a/self-employed-tax-calculator/scripts/calc.js
+++ b/self-employed-tax-calculator/scripts/calc.js
@@ -1,0 +1,119 @@
+// self-employed-tax-calculator/scripts/calc.js
+//
+// Pure tax-estimate functions. No DOM, no globals: take net profit (and a
+// province for Canada) and return a structured breakdown. All rates live in
+// data/tax-rates-2026.js. Kept side-effect-free so calc.test.js can verify the
+// numbers against hand-worked examples.
+//
+// See the data file's header for the simplifying assumptions (single/basic
+// filer, standard deduction / basic personal amount only, estimate errs high).
+
+import { US, CANADA_FEDERAL, CANADA_PENSION, PROVINCES } from '../data/tax-rates-2026.js';
+
+// Progressive tax over marginal brackets. Each bracket taxes the income slice
+// between the previous bracket's `upTo` and its own `upTo` at `rate`.
+export function bracketTax(income, brackets) {
+  let tax = 0;
+  let lower = 0;
+  for (const b of brackets) {
+    if (income <= lower) break;
+    const slice = Math.min(income, b.upTo) - lower;
+    if (slice > 0) tax += slice * b.rate;
+    lower = b.upTo;
+  }
+  return tax;
+}
+
+// --- United States (federal only) ---
+export function computeUS(profit) {
+  const netProfit = Math.max(0, Number(profit) || 0);
+
+  // Self-employment tax: 15.3% on 92.35% of net profit, Social Security
+  // portion capped at the wage base, Medicare uncapped.
+  const seBase = netProfit * US.se.netFactor;
+  let selfEmploymentTax = 0;
+  if (seBase >= US.se.minNetEarnings) {
+    const ss = Math.min(seBase, US.se.socialSecurityWageBase) * US.se.socialSecurityRate;
+    const medicare = seBase * US.se.medicareRate;
+    selfEmploymentTax = ss + medicare;
+  }
+
+  // Income tax on profit minus half the SE tax minus the standard deduction.
+  const taxableIncome = Math.max(0, netProfit - selfEmploymentTax / 2 - US.standardDeduction);
+  const incomeTax = bracketTax(taxableIncome, US.brackets);
+
+  const total = selfEmploymentTax + incomeTax;
+  return {
+    country: 'US',
+    currency: 'USD',
+    netProfit,
+    contributionLabel: 'Self-employment tax',
+    contribution: selfEmploymentTax,
+    incomeTax,
+    taxableIncome,
+    total,
+    effectiveRate: netProfit > 0 ? total / netProfit : 0,
+    quarterly: total / 4,
+  };
+}
+
+// Federal basic personal amount, phasing from max down to min across the
+// top-bracket income range.
+function federalBpa(income) {
+  const f = CANADA_FEDERAL;
+  if (income <= f.bpaPhaseStart) return f.bpaMax;
+  if (income >= f.bpaPhaseEnd) return f.bpaMin;
+  const frac = (income - f.bpaPhaseStart) / (f.bpaPhaseEnd - f.bpaPhaseStart);
+  return f.bpaMax - (f.bpaMax - f.bpaMin) * frac;
+}
+
+// --- Canada (federal + provincial + CPP/QPP) ---
+export function computeCanada(profit, provinceCode) {
+  const netProfit = Math.max(0, Number(profit) || 0);
+  const prov = PROVINCES[provinceCode] || PROVINCES.ON;
+  const cp = CANADA_PENSION;
+  const rates = prov.usesQpp ? cp.qpp : cp.cpp;
+
+  // CPP / QPP. Self-employed pay both the employee and employer portions.
+  const baseEarnings = Math.max(0, Math.min(netProfit, cp.ympe) - cp.basicExemption);
+  const secondEarnings = Math.max(0, Math.min(netProfit, cp.yampe) - cp.ympe);
+  const contribution = baseEarnings * rates.baseSelfRate + secondEarnings * rates.secondSelfRate;
+
+  // Federal income tax: bracket tax minus the basic-personal-amount credit
+  // (given at the lowest rate). Quebec residents get the 16.5% abatement.
+  let federalTax = bracketTax(netProfit, CANADA_FEDERAL.brackets)
+    - federalBpa(netProfit) * CANADA_FEDERAL.lowestRate;
+  federalTax = Math.max(0, federalTax);
+  if (prov.usesQpp) federalTax *= (1 - CANADA_FEDERAL.quebecAbatement);
+
+  // Provincial income tax: bracket tax minus the provincial BPA credit, then
+  // the Ontario surtax (the only province with one) on the result.
+  let provincialTax = bracketTax(netProfit, prov.brackets) - prov.bpa * prov.lowestRate;
+  provincialTax = Math.max(0, provincialTax);
+  if (prov.surtax) {
+    const s = prov.surtax;
+    provincialTax += Math.max(0, provincialTax - s.t1) * s.r1
+      + Math.max(0, provincialTax - s.t2) * s.r2;
+  }
+
+  const incomeTax = federalTax + provincialTax;
+  const total = contribution + incomeTax;
+  return {
+    country: 'CA',
+    currency: 'CAD',
+    netProfit,
+    contributionLabel: prov.usesQpp ? 'QPP contributions' : 'CPP contributions',
+    contribution,
+    federalTax,
+    provincialTax,
+    incomeTax,
+    total,
+    effectiveRate: netProfit > 0 ? total / netProfit : 0,
+    quarterly: total / 4,
+  };
+}
+
+// Dispatch helper used by the UI.
+export function computeTax({ country, profit, province }) {
+  return country === 'CA' ? computeCanada(profit, province) : computeUS(profit);
+}

--- a/self-employed-tax-calculator/scripts/calc.test.js
+++ b/self-employed-tax-calculator/scripts/calc.test.js
@@ -1,0 +1,85 @@
+// self-employed-tax-calculator/scripts/calc.test.js
+// Verifies the tax math against hand-worked 2026 examples. Run with:
+//   node --test self-employed-tax-calculator/scripts/*.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { computeUS, computeCanada, bracketTax } from './calc.js';
+
+const near = (actual, expected, tol = 1, msg = '') =>
+  assert.ok(Math.abs(actual - expected) <= tol, `${msg} expected ~${expected}, got ${actual}`);
+
+test('bracketTax sums marginal slices', () => {
+  const brackets = [{ upTo: 100, rate: 0.10 }, { upTo: 200, rate: 0.20 }, { upTo: Infinity, rate: 0.30 }];
+  assert.strictEqual(bracketTax(0, brackets), 0);
+  near(bracketTax(50, brackets), 5);          // 50 * 10%
+  near(bracketTax(150, brackets), 10 + 10);   // 100*10% + 50*20%
+  near(bracketTax(250, brackets), 10 + 20 + 15); // + 50*30%
+});
+
+// US: $60k profit. SE tax = 60000*0.9235*0.153 = 8477.73; half = 4238.865.
+// Taxable = 60000 - 4238.865 - 16100 = 39661.135.
+// Income tax = 12400*0.10 + 27261.135*0.12 = 1240 + 3271.34 = 4511.34.
+// Total = 12989.07.
+test('US $60k self-employed', () => {
+  const r = computeUS(60000);
+  near(r.contribution, 8477.73, 0.5, 'SE tax');
+  near(r.incomeTax, 4511.34, 0.5, 'income tax');
+  near(r.total, 12989.07, 1, 'total');
+  near(r.quarterly, 3247.27, 0.5, 'quarterly');
+  near(r.effectiveRate, 0.2165, 0.001, 'effective rate');
+});
+
+// US high income exercises the Social Security wage-base cap ($184,500).
+// $250k: seBase=230875; SS=184500*0.124=22878; Medicare=230875*0.029=6695.375;
+// SE=29573.375. Taxable=250000-14786.6875-16100=219113.3125. Income tax=46572.26.
+// Total=76145.64.
+test('US $250k caps Social Security portion', () => {
+  const r = computeUS(250000);
+  near(r.contribution, 29573.38, 1, 'SE tax with SS cap');
+  near(r.total, 76145.64, 2, 'total');
+});
+
+test('US zero and tiny profit owe nothing', () => {
+  assert.strictEqual(computeUS(0).total, 0);
+  assert.strictEqual(computeUS(300).contribution, 0); // below $400 net-earnings floor
+});
+
+// Canada ON: $60k profit.
+// CPP = (60000-3500)*0.119 = 6723.50.
+// Federal = (58523*0.14 + 1477*0.205) - 16452*0.14 = 8496.005 - 2303.28 = 6192.73.
+// ON = (53891*0.0505 + 6109*0.0915) - 12989*0.0505 = 3280.47 - 655.94 = 2624.52 (no surtax).
+// Income tax = 8817.25; total = 15540.75.
+test('Canada Ontario $60k self-employed', () => {
+  const r = computeCanada(60000, 'ON');
+  near(r.contribution, 6723.50, 0.5, 'CPP');
+  near(r.federalTax, 6192.73, 0.5, 'federal');
+  near(r.provincialTax, 2624.52, 0.5, 'Ontario');
+  near(r.total, 15540.75, 1, 'total');
+});
+
+// Quebec exercises QPP (12.6%) + the 16.5% federal abatement.
+// QPP = 56500*0.126 = 7119. Federal = 6192.725 * 0.835 = 5170.93.
+// QC prov = (54345*0.14 + 5655*0.19) - 18952*0.14 = 8682.75 - 2653.28 = 6029.47.
+// Total = 7119 + 5170.93 + 6029.47 = 18319.40.
+test('Canada Quebec $60k uses QPP and abatement', () => {
+  const r = computeCanada(60000, 'QC');
+  near(r.contribution, 7119.00, 0.5, 'QPP');
+  near(r.total, 18319.40, 1.5, 'total');
+});
+
+// CPP2 kicks in above the first ceiling (YMPE $74,600).
+// $90k Ontario: base CPP = (74600-3500)*0.119 = 8460.90; CPP2 = (85000-74600)*0.08 = 832.
+test('Canada $90k adds the CPP2 second contribution', () => {
+  const r = computeCanada(90000, 'ON');
+  near(r.contribution, 8460.90 + 832, 1, 'CPP base + CPP2');
+});
+
+test('every province computes a positive total at $80k', () => {
+  const codes = ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'];
+  for (const code of codes) {
+    const r = computeCanada(80000, code);
+    assert.ok(r.total > 0 && r.total < 80000, `${code} total out of range: ${r.total}`);
+    assert.ok(r.effectiveRate > 0.1 && r.effectiveRate < 0.45, `${code} effective rate odd: ${r.effectiveRate}`);
+  }
+});

--- a/self-employed-tax-calculator/scripts/main.js
+++ b/self-employed-tax-calculator/scripts/main.js
@@ -1,0 +1,108 @@
+// self-employed-tax-calculator/scripts/main.js
+// Wires the calculator form to the pure calc functions and renders a live
+// estimate. Vanilla ES module, no build step. Reuses formatMoney from the
+// invoice generator so currency formatting stays consistent across tools.
+
+import { computeTax } from './calc.js';
+import { PROVINCES, PROVINCE_ORDER } from '../data/tax-rates-2026.js';
+import { formatMoney } from '../../invoice-generator/scripts/currency.js';
+
+const $ = (sel) => document.querySelector(sel);
+const el = {
+  country: $('[data-tc="country"]'),
+  provinceField: $('[data-tc-province-field]'),
+  province: $('[data-tc="province"]'),
+  income: $('[data-tc="income"]'),
+  expenses: $('[data-tc="expenses"]'),
+  regionNote: $('[data-tc="region-note"]'),
+  setaside: $('[data-tc="setaside"]'),
+  setasidePct: $('[data-tc="setaside-pct"]'),
+  quarterly: $('[data-tc="quarterly"]'),
+  netProfit: $('[data-tc="netprofit"]'),
+  contributionLabel: $('[data-tc="contribution-label"]'),
+  contribution: $('[data-tc="contribution"]'),
+  incomeTax: $('[data-tc="incometax"]'),
+  total: $('[data-tc="total"]'),
+  effRate: $('[data-tc="effrate"]'),
+};
+
+const num = (v) => {
+  const n = parseFloat(v);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+};
+
+const pct = (rate) => `${(rate * 100).toFixed(1)}%`;
+
+// Whole-dollar formatting for the headline (a "set aside roughly this much"
+// number reads better without cents). The detailed breakdown keeps cents via
+// the shared formatMoney.
+function formatWhole(amount, currency, locale) {
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency', currency, maximumFractionDigits: 0,
+    }).format(Math.round(amount));
+  } catch (_e) {
+    return `$${Math.round(amount)}`;
+  }
+}
+
+function populateProvinces() {
+  if (!el.province) return;
+  el.province.innerHTML = '';
+  for (const code of PROVINCE_ORDER) {
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = PROVINCES[code].name;
+    el.province.appendChild(opt);
+  }
+  el.province.value = 'ON'; // sensible default
+}
+
+function syncCountry() {
+  const isCA = el.country.value === 'CA';
+  if (el.provinceField) el.provinceField.hidden = !isCA;
+  if (el.regionNote) {
+    el.regionNote.textContent = isCA
+      ? 'Includes federal and provincial income tax plus CPP/QPP. Tax year 2026.'
+      : 'Federal estimate only — does not include state income tax. Tax year 2026.';
+  }
+}
+
+function render() {
+  const country = el.country.value;
+  const profit = Math.max(0, num(el.income.value) - num(el.expenses.value));
+  const province = el.province ? el.province.value : 'ON';
+
+  const r = computeTax({ country, profit, province });
+  const currency = r.currency;
+  const locale = country === 'CA' ? 'en-CA' : 'en-US';
+  const money = (n) => formatMoney(n, currency, locale);
+
+  el.setaside.textContent = formatWhole(r.total, currency, locale);
+  el.setasidePct.textContent = pct(r.effectiveRate);
+  el.quarterly.textContent = formatWhole(r.quarterly, currency, locale);
+
+  el.netProfit.textContent = money(r.netProfit);
+  el.contributionLabel.textContent = r.contributionLabel;
+  el.contribution.textContent = money(r.contribution);
+  el.incomeTax.textContent = money(r.incomeTax);
+  el.total.textContent = money(r.total);
+  el.effRate.textContent = pct(r.effectiveRate);
+}
+
+function handle(ev) {
+  if (ev.target === el.country) syncCountry();
+  render();
+}
+
+function init() {
+  if (!el.country) return;
+  populateProvinces();
+  syncCountry();
+  render();
+  const form = el.country.closest('form') || document;
+  form.addEventListener('input', handle);
+  form.addEventListener('change', handle);
+}
+
+init();

--- a/self-employed-tax-calculator/styles/calculator.css
+++ b/self-employed-tax-calculator/styles/calculator.css
@@ -1,0 +1,203 @@
+/* self-employed-tax-calculator/styles/calculator.css
+   Calculator-specific styling. Loads on top of invoice-generator/styles/tool.css
+   (pulled in by layout.php), so it reuses the shared chrome — site-header, the
+   "All tools" breadcrumb, .site-hero, .page-banner — and the brand CSS variables
+   from custom-colors.css. Only the calculator's form + results UI lives here. */
+
+.taxcalc-app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 20px 96px;
+}
+
+/* Two columns on desktop: inputs on the left, the live result on the right. */
+.taxcalc-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 28px;
+  align-items: start;
+}
+
+/* ---------- Inputs ---------- */
+.taxcalc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 4px 20px var(--shadow-sm);
+}
+
+.taxcalc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.taxcalc-field label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--tool-text);
+}
+
+.taxcalc-field select,
+.taxcalc-money input {
+  width: 100%;
+  font: inherit;
+  color: var(--tool-text);
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-height: 44px;
+}
+
+.taxcalc-field select:focus,
+.taxcalc-money input:focus {
+  outline: none;
+  border-color: var(--tool-primary);
+  box-shadow: 0 0 0 3px var(--blue-100);
+}
+
+/* Money input with a leading $ affix. */
+.taxcalc-money {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.taxcalc-money-affix {
+  position: absolute;
+  left: 12px;
+  color: var(--tool-muted);
+  pointer-events: none;
+  font-weight: 600;
+}
+
+.taxcalc-money input {
+  padding-left: 26px;
+}
+
+.taxcalc-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--tool-muted);
+}
+
+.taxcalc-note {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--tool-muted);
+}
+
+/* ---------- Results ---------- */
+.taxcalc-results {
+  background: var(--tool-surface);
+  border: 1px solid var(--tool-border);
+  border-radius: 14px;
+  padding: 28px;
+  box-shadow: 0 4px 20px var(--shadow-sm);
+}
+
+.taxcalc-headline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: center;
+  padding: 8px 0 22px;
+  border-bottom: 1px solid var(--tool-border);
+  margin-bottom: 20px;
+}
+
+.taxcalc-headline-label {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--tool-primary);
+}
+
+.taxcalc-headline-amount {
+  font-size: 44px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--tool-text);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.taxcalc-headline-sub {
+  font-size: 14px;
+  color: var(--tool-muted);
+}
+
+.taxcalc-breakdown {
+  margin: 0;
+}
+
+.taxcalc-breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding: 9px 0;
+}
+
+.taxcalc-breakdown-row dt {
+  color: var(--invoice-text);
+}
+
+.taxcalc-breakdown-row dd {
+  margin: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--tool-text);
+}
+
+.taxcalc-breakdown-total {
+  border-top: 1px solid var(--tool-border);
+  margin-top: 6px;
+  padding-top: 14px;
+  font-size: 18px;
+}
+
+.taxcalc-breakdown-total dt {
+  font-weight: 700;
+  color: var(--tool-text);
+}
+
+.taxcalc-breakdown-total dd {
+  font-weight: 700;
+}
+
+.taxcalc-breakdown-rate dt,
+.taxcalc-breakdown-rate dd {
+  color: var(--tool-muted);
+  font-weight: 500;
+}
+
+/* ---------- Disclaimer ---------- */
+.taxcalc-disclaimer {
+  margin: 28px auto 0;
+  max-width: 760px;
+  padding: 14px 18px;
+  background: var(--amber-50);
+  border: 1px solid var(--amber-300);
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--amber-900);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 760px) {
+  .taxcalc-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .taxcalc-headline-amount {
+    font-size: 36px;
+  }
+}

--- a/self-employed-tax-calculator/styles/calculator.css
+++ b/self-employed-tax-calculator/styles/calculator.css
@@ -15,7 +15,9 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
   gap: 28px;
-  align-items: start;
+  /* stretch: both columns grow to the height of the taller one so the form
+     and results cards are always the same size. */
+  align-items: stretch;
 }
 
 /* ---------- Inputs ---------- */
@@ -28,6 +30,9 @@
   border-radius: 14px;
   padding: 24px;
   box-shadow: 0 4px 20px var(--shadow-sm);
+  /* Fixed height that already fits the taller Canada layout (which adds the
+     province field) so the cards don't grow/shrink when the country changes. */
+  min-height: 460px;
 }
 
 .taxcalc-field {
@@ -99,6 +104,7 @@
   border-radius: 14px;
   padding: 28px;
   box-shadow: 0 4px 20px var(--shadow-sm);
+  min-height: 460px; /* match the form so both cards stay the same fixed size */
 }
 
 .taxcalc-headline {
@@ -195,6 +201,13 @@
 @media (max-width: 760px) {
   .taxcalc-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Stacked on mobile, so the fixed height just wastes space — let them size
+     to content. */
+  .taxcalc-form,
+  .taxcalc-results {
+    min-height: 0;
   }
 
   .taxcalc-headline-amount {

--- a/tools/index.php
+++ b/tools/index.php
@@ -44,6 +44,14 @@ $tools = [
         'icon_class'  => 'amber',
     ],
     [
+        'name'        => 'Free Self-Employed Tax Calculator',
+        'description' => 'Estimate your self-employment taxes and how much to set aside each quarter. United States and Canada, 2026.',
+        'href'        => '../self-employed-tax-calculator/',
+        'cta'         => 'Open the calculator',
+        'icon'        => 'pie-chart',
+        'icon_class'  => 'indigo',
+    ],
+    [
         'name'        => 'Free Invoice Templates',
         'description' => 'Ready-made invoice templates in PDF, Word, Excel, Google Docs, and Google Sheets. Pick a style and start billing.',
         'href'        => '../invoice-template/',

--- a/tools/index.php
+++ b/tools/index.php
@@ -52,6 +52,14 @@ $tools = [
         'icon_class'  => 'indigo',
     ],
     [
+        'name'        => 'Free Craft Pricing Calculator',
+        'description' => 'Price your handmade products to actually pay you. Add materials, labour, and markup to get a selling price, profit, and margin.',
+        'href'        => '../craft-pricing-calculator/',
+        'cta'         => 'Open the calculator',
+        'icon'        => 'shopping-bag',
+        'icon_class'  => 'cyan',
+    ],
+    [
         'name'        => 'Free Invoice Templates',
         'description' => 'Ready-made invoice templates in PDF, Word, Excel, Google Docs, and Google Sheets. Pick a style and start billing.',
         'href'        => '../invoice-template/',

--- a/tools/index.php
+++ b/tools/index.php
@@ -1,0 +1,197 @@
+<?php
+// tools/index.php
+//
+// Free tools hub. A simple directory page that links out to the free,
+// standalone tools we offer (invoice generator, invoice templates).
+// Served at argorobots.com/tools/ via Apache DirectoryIndex.
+//
+// Unlike the tool pages themselves (which use the isolated invoice-generator
+// layout), this hub is a normal marketing page: real site header + footer so
+// visitors can navigate the rest of the site from here.
+
+require_once __DIR__ . '/../resources/icons.php';
+
+if (PHP_SAPI !== 'cli') {
+    require_once __DIR__ . '/../statistics.php';
+    track_page_view('tools_hub');
+}
+
+// Each entry renders one card. `icon` / `icon_class` reuse the shared
+// svg_icon() set and the about-us feature-icon color variants.
+$tools = [
+    [
+        'name'        => 'Free Invoice Generator',
+        'description' => 'Create and download a professional invoice in seconds. No signup, no watermark. Export to PDF or Word.',
+        'href'        => '../invoice-generator/',
+        'cta'         => 'Open the generator',
+        'icon'        => 'document',
+        'icon_class'  => '',
+    ],
+    [
+        'name'        => 'Free Estimate Generator',
+        'description' => 'Build a professional estimate or quote in seconds. No signup, no watermark. Export to PDF or Word.',
+        'href'        => '../estimate-generator/',
+        'cta'         => 'Open the generator',
+        'icon'        => 'document',
+        'icon_class'  => 'green',
+    ],
+    [
+        'name'        => 'Free Purchase Order Generator',
+        'description' => 'Send vendors a clean purchase order in seconds. No signup, no watermark. Export to PDF or Word.',
+        'href'        => '../purchase-order-generator/',
+        'cta'         => 'Open the generator',
+        'icon'        => 'package',
+        'icon_class'  => 'amber',
+    ],
+    [
+        'name'        => 'Free Invoice Templates',
+        'description' => 'Ready-made invoice templates in PDF, Word, Excel, Google Docs, and Google Sheets. Pick a style and start billing.',
+        'href'        => '../invoice-template/',
+        'cta'         => 'Browse templates',
+        'icon'        => 'grid',
+        'icon_class'  => 'purple',
+    ],
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="author" content="Argo">
+
+    <!-- SEO Meta Tags -->
+    <meta name="description"
+        content="Free tools for small businesses from Argo Books. Generate invoices, grab invoice templates, and more. No signup required.">
+    <meta name="keywords"
+        content="free business tools, free invoice generator, free invoice templates, small business tools, argo books tools">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="Free Tools - Argo Books">
+    <meta property="og:description"
+        content="Free tools for small businesses from Argo Books. Generate invoices, grab invoice templates, and more. No signup required.">
+    <meta property="og:url" content="https://argorobots.com/tools/">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Argo Books">
+    <meta property="og:locale" content="en_CA">
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Free Tools - Argo Books">
+    <meta name="twitter:description"
+        content="Free tools for small businesses from Argo Books. Generate invoices, grab invoice templates, and more. No signup required.">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://argorobots.com/tools/">
+
+    <!-- CollectionPage Schema -->
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            "name": "Free Tools",
+            "url": "https://argorobots.com/tools/",
+            "description": "Free tools for small businesses from Argo Books."
+        }
+    </script>
+
+    <link rel="shortcut icon" type="image/x-icon" href="../resources/images/argo-logo/argo-icon.ico">
+    <title>Free Tools - Argo Books</title>
+
+    <script src="../resources/scripts/main.js"></script>
+
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../resources/styles/custom-colors.css">
+    <link rel="stylesheet" href="../resources/styles/button.css">
+    <link rel="stylesheet" href="../resources/header/style.css">
+    <link rel="stylesheet" href="../resources/footer/style.css">
+</head>
+
+<body>
+    <header>
+        <?php include __DIR__ . '/../resources/header/header.php'; ?>
+    </header>
+    <main>
+
+    <!-- Hero Section -->
+    <section class="hero">
+        <div class="hero-bg">
+            <div class="hero-gradient-orb hero-orb-1"></div>
+            <div class="hero-gradient-orb hero-orb-2"></div>
+        </div>
+        <div class="container">
+            <h1 class="animate-fade-in">Free Tools</h1>
+            <p class="hero-subtitle animate-fade-in">Handy tools for small businesses. Free to use, no signup required.</p>
+        </div>
+    </section>
+
+    <!-- Tools Grid -->
+    <section class="tools-section">
+        <div class="container">
+            <div class="tools-grid">
+                <?php foreach ($tools as $tool): ?>
+                    <a class="tool-card animate-on-scroll" href="<?= htmlspecialchars($tool['href']) ?>">
+                        <div class="feature-icon <?= htmlspecialchars($tool['icon_class']) ?>">
+                            <?= svg_icon($tool['icon'], null, '', 1.5) ?>
+                        </div>
+                        <h2><?= htmlspecialchars($tool['name']) ?></h2>
+                        <p><?= htmlspecialchars($tool['description']) ?></p>
+                        <span class="tool-card-cta">
+                            <span><?= htmlspecialchars($tool['cta']) ?></span>
+                            <?= svg_icon('arrow-right', 18) ?>
+                        </span>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    </main>
+
+    <!-- Contact + Footer Wrapper -->
+    <div class="dark-section-wrapper">
+        <!-- Contact Section -->
+        <section class="contact-section">
+            <div class="container">
+                <div class="contact-card animate-on-scroll">
+                    <h2>Want the full toolkit?</h2>
+                    <p>Argo Books is free accounting software that does all of this and more: invoicing, payments, receipt scanning, and reporting.</p>
+                    <a href="../downloads/" class="btn btn-primary">
+                        <span>Download Argo Books</span>
+                        <?= svg_icon('arrow-right', 18) ?>
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <footer class="footer">
+            <?php include __DIR__ . '/../resources/footer/footer.php'; ?>
+        </footer>
+    </div>
+
+    <script>
+        // Scroll animations
+        document.addEventListener('DOMContentLoaded', function() {
+            const observerOptions = {
+                threshold: 0.1,
+                rootMargin: '0px 0px -50px 0px'
+            };
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('animate-visible');
+                    }
+                });
+            }, observerOptions);
+
+            document.querySelectorAll('.animate-on-scroll').forEach(el => {
+                observer.observe(el);
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/tools/style.css
+++ b/tools/style.css
@@ -238,6 +238,14 @@ body {
   color: var(--indigo-500);
 }
 
+.feature-icon.cyan {
+  background: linear-gradient(135deg, var(--cyan-50), var(--cyan-100));
+}
+
+.feature-icon.cyan svg {
+  color: var(--cyan-500);
+}
+
 /* ========================================
    Dark Section Wrapper (Contact + Footer)
    ======================================== */

--- a/tools/style.css
+++ b/tools/style.css
@@ -1,0 +1,327 @@
+/* tools/index.php styles.
+   Shares the visual language of the about-us marketing page: gradient hero
+   with floating orbs, white cards on a light grid, dark footer wrapper. */
+
+body {
+  line-height: 1.6;
+  color: var(--hero-gradient-end);
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ========================================
+   Animations
+   ======================================== */
+.animate-fade-in {
+  animation: fadeIn 0.6s ease-out forwards;
+}
+
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.animate-on-scroll.animate-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ========================================
+   Hero Section
+   ======================================== */
+.hero {
+  position: relative;
+  padding: 140px 0 80px;
+  text-align: center;
+  background: linear-gradient(135deg, var(--hero-gradient-start) 0%, var(--hero-gradient-end) 100%);
+  color: var(--white);
+  overflow: hidden;
+}
+
+.hero .hero-bg {
+  position: absolute;
+  inset: 0;
+}
+
+.hero .hero-gradient-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0;
+  mix-blend-mode: screen;
+  animation: heroOrbFadeIn 2s ease-out forwards;
+}
+
+.hero .hero-orb-1 {
+  width: 400px;
+  height: 400px;
+  background: linear-gradient(135deg, var(--primary-blue), var(--purple-500));
+  top: -100px;
+  right: -100px;
+  animation: heroOrbFadeIn 2s ease-out forwards, heroOrbPulse 4s ease-in-out infinite 2s, heroOrbFloat1 15s ease-in-out infinite;
+}
+
+.hero .hero-orb-2 {
+  width: 300px;
+  height: 300px;
+  background: linear-gradient(135deg, var(--cyan-500), var(--primary-blue));
+  bottom: -50px;
+  left: -50px;
+  animation: heroOrbFadeIn 2s ease-out 0.3s forwards, heroOrbPulse 5s ease-in-out infinite 2.3s, heroOrbFloat2 18s ease-in-out infinite;
+}
+
+@keyframes heroOrbFadeIn {
+  from { opacity: 0; transform: scale(0.6); }
+  to { opacity: 0.7; transform: scale(1); }
+}
+
+@keyframes heroOrbPulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 0.95; }
+}
+
+@keyframes heroOrbFloat1 {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  25% { transform: translate(-60px, 40px) rotate(3deg); }
+  50% { transform: translate(30px, -30px) rotate(-2deg); }
+  75% { transform: translate(70px, 50px) rotate(1deg); }
+}
+
+@keyframes heroOrbFloat2 {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(50px, -40px); }
+  50% { transform: translate(-30px, 50px); }
+  75% { transform: translate(40px, 20px); }
+}
+
+.hero .container {
+  position: relative;
+  z-index: 2;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+
+.hero .hero-subtitle {
+  font-size: 1.25rem;
+  color: var(--white);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* ========================================
+   Tools Grid
+   ======================================== */
+.tools-section {
+  padding: 100px 0;
+}
+
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 28px;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.tool-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background: var(--white);
+  padding: 36px;
+  border-radius: 16px;
+  text-decoration: none;
+  box-shadow: 0 4px 20px var(--shadow-sm);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tool-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px var(--shadow-default);
+}
+
+.tool-card h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin: 4px 0 10px;
+  letter-spacing: -0.01em;
+}
+
+.tool-card p {
+  font-size: 1rem;
+  color: var(--black);
+  margin: 0 0 20px;
+  line-height: 1.6;
+}
+
+.tool-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--primary-blue);
+}
+
+.tool-card-cta svg {
+  transition: transform 0.2s ease;
+}
+
+.tool-card:hover .tool-card-cta svg {
+  transform: translateX(4px);
+}
+
+/* Tool icon (reuses about-us .feature-icon color variants) */
+.feature-icon {
+  width: 56px;
+  height: 56px;
+  background: linear-gradient(135deg, var(--blue-50), var(--blue-100));
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 0 20px;
+}
+
+.feature-icon svg {
+  width: 28px;
+  height: 28px;
+  color: var(--primary-blue);
+}
+
+.feature-icon.purple {
+  background: linear-gradient(135deg, var(--purple-50), var(--purple-100));
+}
+
+.feature-icon.purple svg {
+  color: var(--purple-500);
+}
+
+.feature-icon.green {
+  background: linear-gradient(135deg, var(--green-50), var(--green-100));
+}
+
+.feature-icon.green svg {
+  color: var(--emerald-500);
+}
+
+.feature-icon.amber {
+  background: linear-gradient(135deg, var(--amber-50), var(--amber-100));
+}
+
+.feature-icon.amber svg {
+  color: var(--amber-600);
+}
+
+/* ========================================
+   Dark Section Wrapper (Contact + Footer)
+   ======================================== */
+.dark-section-wrapper {
+  position: relative;
+  background: linear-gradient(135deg, var(--hero-gradient-start) 0%, var(--hero-gradient-end) 100%);
+  overflow: hidden;
+}
+
+.dark-section-wrapper .footer {
+  background: transparent;
+}
+
+.contact-section {
+  padding: 100px 0;
+  background: transparent;
+}
+
+.contact-card {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-card h2 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--white);
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+
+.contact-card p {
+  font-size: 1.1rem;
+  color: var(--white);
+  margin-bottom: 32px;
+  line-height: 1.7;
+}
+
+.contact-card .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-primary {
+  padding: 14px 28px;
+  background: linear-gradient(135deg, var(--primary-blue), var(--blue-700));
+  color: var(--white);
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px var(--blue-alpha-30);
+}
+
+/* ========================================
+   Responsive
+   ======================================== */
+@media (max-width: 800px) {
+  .tools-grid {
+    grid-template-columns: 1fr;
+    max-width: 420px;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 120px 0 60px;
+  }
+
+  .hero h1 {
+    font-size: 2.25rem;
+  }
+
+  .hero .hero-subtitle {
+    font-size: 1.1rem;
+  }
+
+  .tools-section,
+  .contact-section {
+    padding: 60px 0;
+  }
+
+  .contact-card h2 {
+    font-size: 1.75rem;
+  }
+}

--- a/tools/style.css
+++ b/tools/style.css
@@ -230,6 +230,14 @@ body {
   color: var(--amber-600);
 }
 
+.feature-icon.indigo {
+  background: linear-gradient(135deg, var(--indigo-50), var(--indigo-100));
+}
+
+.feature-icon.indigo svg {
+  color: var(--indigo-500);
+}
+
 /* ========================================
    Dark Section Wrapper (Contact + Footer)
    ======================================== */

--- a/tools/style.css
+++ b/tools/style.css
@@ -285,10 +285,18 @@ body {
   line-height: 1.7;
 }
 
+/* Override the site-wide .btn (button.css loads after this file and forces
+   width:180px / padding:10px 0, which squeezes a longer label onto two lines).
+   This selector is more specific than .btn, so these win. */
 .contact-card .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
+  width: auto;
+  padding: 14px 28px;
+  border-radius: 12px;
+  white-space: nowrap;
 }
 
 .btn-primary {


### PR DESCRIPTION
## Summary

Adds a **Free Tools** hub (`/tools/`, linked from the footer) and five free, SEO-oriented tools, built on a shared engine to keep things consolidated:

- **Invoice generator** refactored into a shared document engine (`invoice-generator/doc-config.php`) that also powers:
  - **Estimate generator** (`/estimate-generator/`)
  - **Purchase order generator** (`/purchase-order-generator/`)
- **Self-employed tax calculator** (`/self-employed-tax-calculator/`) — US (federal) + Canada (federal + 13 provinces/territories), 2026 rates, verified against IRS/SSA/CRA, with documented assumptions and unit tests.
- **Craft pricing calculator** (`/craft-pricing-calculator/`) — handmade-product pricing with a full SEO content layer (FAQ accordion, markup-by-channel table, worked example) and `SoftwareApplication` + `FAQPage` + `BreadcrumbList` schema.

Also: an optional acceptance/signature block on the estimate and PO; Word-export labels now follow the on-screen editable labels (fixes a tax-label mismatch); a draft deep-merge fix; an "All tools" back-link under the header on tool pages; and equal-height tax-calculator cards.

## Reuse / consolidation

All tools share `invoice-generator/layout.php` (header, breadcrumb, OG/canonical/schema, `tool.css` chrome). The generators share one engine via a document-type config; backward-compatible, so the invoice generator and its niche pages are unchanged. Calculators reuse the shared currency formatting where appropriate.

## Verification

- JS unit suites pass (`npm test`, 40 tests) — including hand-checked tax math (SS wage cap, CPP2, Quebec QPP + abatement, Ontario surtax) and a structural validator over all bracket tables.
- `php -l` clean on changed/new PHP; CLI renders verified for each tool; schema/SEO markers present.
- **Not yet done:** live in-browser checks (PDF/Word downloads, interactive recalculation, FAQ accordion) — the local server was unavailable during development. Worth a pass before/after merge.

## Note on accuracy

The tax calculator publishes real 2026 tax figures under the brand. Rates live in one data file with citations and a "last verified" date for easy yearly updates. Two source transcription errors were caught and corrected during the build (Canada federal 4th rate 29%, BC bottom rate 5.06%, Yukon 12.8%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
